### PR TITLE
create generate_keypair and create_child binaries; move function create_child() to a new module ipc_lib

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -121,6 +121,7 @@ dependencies = [
  "clap",
  "dotenv",
  "serde",
+ "thiserror",
 ]
 
 [[package]]
@@ -438,6 +439,26 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "thiserror"
+version = "1.0.61"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c546c80d6be4bc6a00c0f01730c08df82eaa7a7a61f11d656526506112cc1709"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.61"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46c3384250002a6d5af4d114f2845d37b57521033f30d5c3f46c4d70e1197533"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,55 @@
 version = 3
 
 [[package]]
+name = "anstream"
+version = "0.6.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "418c75fa768af9c03be99d17643f93f79bbba589895012a80e3452a19ddda15b"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is_terminal_polyfill",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "038dfcf04a5feb68e9c60b21c9625a54c2c0616e79b72b0fd87075a056ae1d1b"
+
+[[package]]
+name = "anstyle-parse"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c03a11a9034d92058ceb6ee011ce58af4a9bf61491aa7e1e59ecd24bd40d22d4"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad186efb764318d35165f1758e7dcef3b10628e26d41a44bc5550652e6804391"
+dependencies = [
+ "windows-sys",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "3.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61a38449feb7068f52bb06c12759005cf459ee52bb4adc1d5a7c4322d716fb19"
+dependencies = [
+ "anstyle",
+ "windows-sys",
+]
+
+[[package]]
 name = "arrayvec"
 version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -69,6 +118,7 @@ version = "0.1.0"
 dependencies = [
  "bitcoin",
  "bitcoincore-rpc",
+ "clap",
  "dotenv",
  "serde",
 ]
@@ -131,6 +181,52 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
+name = "clap"
+version = "4.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "84b3edb18336f4df585bc9aa31dd99c036dfa5dc5e9a2939a722a188f3a8970d"
+dependencies = [
+ "clap_builder",
+ "clap_derive",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1c09dd5ada6c6c78075d6fd0da3f90d8080651e2d6cc8eb2f1aaa4034ced708"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "clap_lex",
+ "strsim",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2bac35c6dafb060fd4d275d9a4ffae97917c13a6327903a8be2153cd964f7085"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "clap_lex"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b82cf0babdbd58558212896d1a4272303a57bdb245c2bf1147185fb45640e70"
+
+[[package]]
+name = "colorchoice"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b6a852b24ab71dffc585bcb46eaf7959d175cb865a7152e35b348d1b2960422"
+
+[[package]]
 name = "dotenv"
 version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -148,6 +244,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "heck"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
 name = "hex-conservative"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -161,6 +263,12 @@ name = "hex_lit"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3011d1213f159867b13cfd6ac92d2cd5f1345762c63be3554e84092d85a50bbd"
+
+[[package]]
+name = "is_terminal_polyfill"
+version = "1.70.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8478577c03552c21db0e2724ffb8986a5ce7af88107e6be5d2ee6e158c12800"
 
 [[package]]
 name = "itoa"
@@ -316,6 +424,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "strsim"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
 name = "syn"
 version = "2.0.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -333,7 +447,86 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
 
 [[package]]
+name = "utf8parse"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
 name = "wasi"
 version = "0.11.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
+
+[[package]]
+name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
+dependencies = [
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,4 +10,5 @@ bitcoincore-rpc = "0.19.0"
 dotenv = "0.15.0"
 serde = "1.0.203"
 clap = { version = "4.5.8", features = ["derive"] }
+thiserror = "1.0.61"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,4 +9,5 @@ bitcoin = "0.32.2"
 bitcoincore-rpc = "0.19.0"
 dotenv = "0.15.0"
 serde = "1.0.203"
+clap = { version = "4.5.8", features = ["derive"] }
 

--- a/README.md
+++ b/README.md
@@ -117,12 +117,40 @@ This guide will walk you through the necessary steps needed to setup the environ
     The output should be 101.
     </details>
 
-4. **Run the code**
 
-4.1. Run the listener by executing
+## Running the code
+
+1. Run the listener by executing
 
 ```sh
 cargo run --bin btc_monitor
 ```
 
+You can leave the listener running on the background or separate shell.
 
+2. Generate a bitcoin private/public keypair
+
+```sh
+cargo run --bin generate_keypair
+```
+
+The output will look like this:
+
+```
+private_key:
+tprv8ZgxMBicQKsPeMg7q6BrYrcJBvVcQ6tR6R5PUWGrgx3fyGg9R6N9MEhhHrpeSZ65FzHVL95LCEU8r4nu6nEHAeELd632W3mGHM1ZFsPVGYU
+public_key:
+028cc08dacd6717da80a79f552197b23c61a2348c0aec6651d0150cf1512e53b21
+```
+
+3. Create a new IPC subnet
+```sh
+cargo run --bin create_child -- --name <name> --pk <subnetPK>
+```
+where `<name>` is the desired name for the new subnet and `<subnetPK>` is a valid bitcoin public key, such as the one in the output of `generate_keypair`.
+This binary will create the necessary bitcoin transactions and submit them to the local bitcoin node.
+
+When the transactions get finalized on the bitcoin network (the local testnet), the `btc_monitor` binary should detect them as IPC-related. You should see an output such as
+```
+transaction 8fd7027b33cbdaeeefd88b03effe8288a539c376240e167fe572551f785ff07f at block height 117 contains the keyword 'IPC:CREATE'
+```

--- a/src/bin/btc_monitor.rs
+++ b/src/bin/btc_monitor.rs
@@ -1,7 +1,8 @@
+use std::{thread, time::Duration};
+
 use bitcoin_ipc::utils;
 
 use bitcoincore_rpc::{Auth, Client, RpcApi};
-use std::{thread, time::Duration};
 
 pub fn main() -> Result<(), Box<dyn std::error::Error>> {
     let (rpc_user, rpc_pass, rpc_url, wallet_name) = utils::load_env();
@@ -36,9 +37,9 @@ pub fn main() -> Result<(), Box<dyn std::error::Error>> {
                             let witness_slice: Vec<u8> = witness.iter().map(|&x| x as u8).collect();
 
                             if let Ok(witness_str) = std::str::from_utf8(&witness_slice) {
-                                if witness_str.contains("IPC:CREATE") {
+                                if witness_str.contains(bitcoin_ipc::IPC_CREATE_SUBNET_TAG) {
                                     // Try to parse the rest of the command.
-                                    println!("Transaction {} at block height {} contains the keyword 'IPC:CREATE'", tx.compute_txid(), block_height);
+                                    println!("Transaction {} at block height {} contains the keyword '{:?}'", tx.compute_txid(), block_height, bitcoin_ipc::IPC_CREATE_SUBNET_TAG);
                                 }
                             }
                         }

--- a/src/bin/btc_monitor.rs
+++ b/src/bin/btc_monitor.rs
@@ -5,7 +5,7 @@ use bitcoin_ipc::utils;
 use bitcoincore_rpc::{Auth, Client, RpcApi};
 
 pub fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let (rpc_user, rpc_pass, rpc_url, wallet_name) = utils::load_env();
+    let (rpc_user, rpc_pass, rpc_url, wallet_name) = utils::load_env()?;
 
     let rpc = Client::new(
         &rpc_url,
@@ -40,6 +40,10 @@ pub fn main() -> Result<(), Box<dyn std::error::Error>> {
                                 if witness_str.contains(bitcoin_ipc::IPC_CREATE_SUBNET_TAG) {
                                     // Try to parse the rest of the command.
                                     println!("Transaction {} at block height {} contains the keyword '{:?}'", tx.compute_txid(), block_height, bitcoin_ipc::IPC_CREATE_SUBNET_TAG);
+                                }
+                                if witness_str.contains(bitcoin_ipc::IPC_JOIN_SUBNET_TAG) {
+                                    // Try to parse the rest of the command.
+                                    println!("Transaction {} at block height {} contains the keyword '{:?}'", tx.compute_txid(), block_height, bitcoin_ipc::IPC_JOIN_SUBNET_TAG);
                                 }
                             }
                         }

--- a/src/bin/create_child.rs
+++ b/src/bin/create_child.rs
@@ -1,0 +1,32 @@
+use clap::Parser;
+use std::str::FromStr;
+
+use bitcoin::address::Address;
+use bitcoin_ipc::ipc_lib::create_child;
+
+#[derive(Parser, Debug)]
+#[command(version, about, long_about = None)]
+struct Args {
+    /// Subnet name
+    #[arg(short, long)]
+    name: String,
+
+    /// Subnet public key
+    #[arg(short, long)]
+    pk: String,
+}
+
+pub fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let args = Args::parse();
+
+    let mut subnet_data = String::new();
+    subnet_data.push_str(bitcoin_ipc::IPC_CREATE_SUBNET_TAG);
+    subnet_data.push_str(&format!("name={}", args.name));
+
+    let pubkey = bitcoin::secp256k1::PublicKey::from_str(&args.pk)?;
+    let btc_pubkey = bitcoin::PublicKey::new(pubkey);
+    let subnet_address = Address::p2pkh(btc_pubkey, bitcoin_ipc::NETWORK);
+
+    create_child(subnet_address, subnet_data.as_bytes())?;
+    Ok(())
+}

--- a/src/bin/create_child.rs
+++ b/src/bin/create_child.rs
@@ -27,6 +27,6 @@ pub fn main() -> Result<(), Box<dyn std::error::Error>> {
     let btc_pubkey = bitcoin::PublicKey::new(pubkey);
     let subnet_address = Address::p2pkh(btc_pubkey, bitcoin_ipc::NETWORK);
 
-    create_child(subnet_address, subnet_data.as_bytes())?;
+    create_child(&subnet_address, subnet_data.as_bytes())?;
     Ok(())
 }

--- a/src/bin/generate_keypair.rs
+++ b/src/bin/generate_keypair.rs
@@ -1,0 +1,18 @@
+use bitcoin::key::Secp256k1;
+use bitcoin_ipc::bitcoin_utils::get_private_key;
+
+pub fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let secp = &Secp256k1::new();
+
+    let private_key = get_private_key(1, bitcoin_ipc::NETWORK);
+    let public_key: bitcoin::secp256k1::PublicKey = private_key.to_keypair(secp).public_key();
+
+    let keypair_string = format!(
+        "private_key:\n{}\npublic_key:\n{}\n",
+        private_key.to_string(),
+        public_key.to_string()
+    );
+    print!("{}", keypair_string);
+
+    Ok(())
+}

--- a/src/bitcoin_utils.rs
+++ b/src/bitcoin_utils.rs
@@ -168,7 +168,6 @@ pub fn commit_arbitrary_data(
     change: TxOut,
     data: &[u8],
     secp: &Secp256k1<All>,
-    x_only_pubkey: XOnlyPublicKey,
 ) -> (Transaction, ScriptBuf, TaprootSpendInfo) {
     let push_bytes: &PushBytes;
     unsafe {
@@ -176,10 +175,13 @@ pub fn commit_arbitrary_data(
     }
     let script = Builder::new().push_slice(push_bytes).into_script();
 
+    // this transaction can only be spent through the script path
+    let unspendable_pubkey = create_unspendable_internal_key(&secp);
+
     let taproot_spend_info = TaprootBuilder::new()
         .add_leaf(0, script.clone())
         .unwrap()
-        .finalize(secp, x_only_pubkey)
+        .finalize(secp, unspendable_pubkey)
         .unwrap();
 
     let script_pubkey = script::ScriptBuf::new_p2tr(

--- a/src/ipc_lib.rs
+++ b/src/ipc_lib.rs
@@ -1,0 +1,53 @@
+use bitcoin::{key::Secp256k1, Amount, OutPoint, TxOut};
+
+use crate::{
+    bitcoin_utils::{
+        collect_amount, commit_arbitrary_data, create_change_txout, init_rpc_client, init_wallet,
+        reveal_arbitrary_data, test_and_submit,
+    },
+    utils,
+};
+
+pub fn create_child(
+    subnet_address: bitcoin::Address,
+    subnet_data: &[u8],
+) -> Result<(), Box<dyn std::error::Error>> {
+    println!("{:?}", subnet_data);
+    let (rpc_user, rpc_pass, rpc_url, wallet_name) = utils::load_env();
+
+    let rpc = init_rpc_client(rpc_user, rpc_pass, rpc_url)?;
+
+    let (miner_address, _, _) = init_wallet(&rpc, crate::NETWORK, &wallet_name)?;
+
+    let amount_to_send = Amount::from_btc(1.0)?;
+    let fee: Amount = Amount::from_sat(200);
+
+    let input_info = collect_amount(&rpc, amount_to_send, fee).unwrap();
+
+    let change = create_change_txout(&rpc, &input_info, amount_to_send, fee).unwrap();
+
+    let secp = Secp256k1::new();
+
+    // Commit Transaction : Include Arbitrary Data in the transaction
+    let (commit_tx, script, taproot_spend_info) =
+        commit_arbitrary_data(&rpc, input_info, amount_to_send, change, subnet_data, &secp);
+
+    let commit_tx_outpoint = OutPoint {
+        txid: commit_tx.compute_txid(),
+        vout: 0,
+    };
+
+    // Get subnet PK address
+
+    let output = TxOut {
+        value: amount_to_send - fee,
+        script_pubkey: subnet_address.script_pubkey(),
+    };
+
+    // Reveal Transaction : Reveal the Arbitrary Data
+    let reveal_tx = reveal_arbitrary_data(commit_tx_outpoint, output, script, taproot_spend_info);
+
+    test_and_submit(&rpc, vec![commit_tx, reveal_tx], miner_address);
+
+    Ok(())
+}

--- a/src/ipc_lib.rs
+++ b/src/ipc_lib.rs
@@ -1,3 +1,5 @@
+use thiserror::Error;
+
 use bitcoin::{key::Secp256k1, Amount, OutPoint, TxOut};
 
 use crate::{
@@ -9,11 +11,11 @@ use crate::{
 };
 
 pub fn create_child(
-    subnet_address: bitcoin::Address,
+    subnet_address: &bitcoin::Address,
     subnet_data: &[u8],
 ) -> Result<(), Box<dyn std::error::Error>> {
     println!("{:?}", subnet_data);
-    let (rpc_user, rpc_pass, rpc_url, wallet_name) = utils::load_env();
+    let (rpc_user, rpc_pass, rpc_url, wallet_name) = utils::load_env()?;
 
     let rpc = init_rpc_client(rpc_user, rpc_pass, rpc_url)?;
 
@@ -51,3 +53,65 @@ pub fn create_child(
 
     Ok(())
 }
+
+pub fn join_child(
+    subnet_address: &bitcoin::Address,
+    collateral: Amount,
+    validator_data: &str,
+) -> Result<(), JoinChildError> {
+    let fee: Amount = Amount::from_sat(200);
+    let secp = Secp256k1::new();
+
+    // Init RPC connection and wallet
+    let (rpc_user, rpc_pass, rpc_url, wallet_name) = utils::load_env()?;
+    let rpc = init_rpc_client(rpc_user, rpc_pass, rpc_url)?;
+    let (miner_address, _, _) = init_wallet(&rpc, crate::NETWORK, &wallet_name)?;
+
+    let inputs = collect_amount(&rpc, collateral, fee).unwrap();
+    let change_ouput = create_change_txout(&rpc, &inputs, collateral, fee).unwrap();
+
+    // Commit Transaction : Include Arbitrary Data in the transaction
+    let (commit_tx, script, taproot_spend_info) = commit_arbitrary_data(
+        &rpc,
+        inputs,
+        collateral,
+        change_ouput,
+        validator_data.as_bytes(),
+        &secp,
+    );
+
+    let commit_tx_outpoint = OutPoint {
+        txid: commit_tx.compute_txid(),
+        vout: 0,
+    };
+
+    let output = TxOut {
+        value: collateral - fee,
+        script_pubkey: subnet_address.script_pubkey(),
+    };
+
+    // Reveal Transaction : Reveal the Arbitrary Data
+    let reveal_tx = reveal_arbitrary_data(commit_tx_outpoint, output, script, taproot_spend_info);
+
+    test_and_submit(&rpc, vec![commit_tx, reveal_tx], miner_address);
+    Ok(())
+}
+
+#[derive(Error, Debug)]
+pub enum JoinChildError {
+    #[error("no child subnet with address `{0}` was found")]
+    SubnetNotFound(bitcoin::Address),
+
+    #[error("error when reading an environment variable")]
+    EnvVarError(#[from] std::env::VarError),
+
+    #[error(transparent)]
+    Other(#[from] Box<dyn std::error::Error>),
+
+    #[error("internal error")]
+    Internal,
+}
+
+// Orestis: I made `validator_data` of type &str, I think it makes more sense than &[u8]. Probably we should change this in create_child() as well.
+// I also think we should merge commit_arbitrary_data() and reveal_arbitrary_data() into a common function write_arbitrary_data() or get_transactions_with_arbitrary_data(),
+// because now there are a lot of dependencies between the two functions that are not so relevant for the code that calls them.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,2 +1,8 @@
 pub mod bitcoin_utils;
+pub mod ipc_lib;
 pub mod utils;
+
+use bitcoin::Network;
+
+pub const NETWORK: Network = Network::Regtest;
+pub const IPC_CREATE_SUBNET_TAG: &str = "IPC:CREATE";

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,3 +6,4 @@ use bitcoin::Network;
 
 pub const NETWORK: Network = Network::Regtest;
 pub const IPC_CREATE_SUBNET_TAG: &str = "IPC:CREATE";
+pub const IPC_JOIN_SUBNET_TAG: &str = "IPC:JOIN";

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,7 @@
-use bitcoin::key::Secp256k1;
+use bitcoin::{key::Secp256k1, Amount};
 use bitcoin_ipc::{
-    bitcoin_utils::get_address_from_private_key, bitcoin_utils::get_private_key,
-    ipc_lib::create_child,
+    bitcoin_utils::{get_address_from_private_key, get_private_key},
+    ipc_lib::{create_child, join_child},
 };
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
@@ -11,7 +11,11 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let subnet_address =
         get_address_from_private_key(&Secp256k1::new(), &receiver_key, bitcoin_ipc::NETWORK);
 
-    create_child(subnet_address, subnet_data.as_bytes())?;
+    create_child(&subnet_address, subnet_data.as_bytes())?;
+
+    let collateral = Amount::from_btc(1.0)?;
+    let validator_data = format!("{} IP:{}", bitcoin_ipc::IPC_JOIN_SUBNET_TAG, "...");
+    join_child(&subnet_address, collateral, &validator_data)?;
 
     Ok(())
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,63 +1,17 @@
-use bitcoin_ipc::bitcoin_utils::{
-    collect_amount, commit_arbitrary_data, create_change_txout, create_unspendable_internal_key,
-    get_address_from_private_key, get_private_key, init_rpc_client, init_wallet,
-    reveal_arbitrary_data, test_and_submit,
+use bitcoin::key::Secp256k1;
+use bitcoin_ipc::{
+    bitcoin_utils::get_address_from_private_key, bitcoin_utils::get_private_key,
+    ipc_lib::create_child,
 };
-use bitcoin_ipc::utils;
-
-use bitcoin::blockdata::transaction::{OutPoint, TxOut};
-use bitcoin::secp256k1::Secp256k1;
-use bitcoin::{amount::Amount, Network};
-
-const NETWORK: Network = Network::Regtest;
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let (rpc_user, rpc_pass, rpc_url, wallet_name) = utils::load_env();
+    let subnet_data = bitcoin_ipc::IPC_CREATE_SUBNET_TAG;
 
-    let rpc = init_rpc_client(rpc_user, rpc_pass, rpc_url)?;
+    let receiver_key: bitcoin::bip32::Xpriv = get_private_key(1, bitcoin_ipc::NETWORK);
+    let subnet_address =
+        get_address_from_private_key(&Secp256k1::new(), &receiver_key, bitcoin_ipc::NETWORK);
 
-    let (miner_address, _, _) = init_wallet(&rpc, NETWORK, &wallet_name)?;
-
-    let amount_to_send = Amount::from_btc(1.0)?;
-    let fee = Amount::from_sat(200);
-
-    let input_info = collect_amount(&rpc, amount_to_send, fee).unwrap();
-
-    let change = create_change_txout(&rpc, &input_info, amount_to_send, fee).unwrap();
-
-    let secp = Secp256k1::new();
-
-    let x_only_pubkey = create_unspendable_internal_key(&secp);
-
-    // Commit Transaction : Include Arbitrary Data in the transaction
-    let (commit_tx, script, taproot_spend_info) = commit_arbitrary_data(
-        &rpc,
-        input_info,
-        amount_to_send,
-        change,
-        b"IPC:CREATE",
-        &secp,
-        x_only_pubkey,
-    );
-
-    let outpoint = OutPoint {
-        txid: commit_tx.compute_txid(),
-        vout: 0,
-    };
-
-    // Get subnet PK address
-    let receiver_key = get_private_key(1, NETWORK);
-    let subnet_address = get_address_from_private_key(&secp, &receiver_key, NETWORK);
-
-    let output = TxOut {
-        value: amount_to_send - fee,
-        script_pubkey: subnet_address.script_pubkey(),
-    };
-
-    // Reveal Transaction : Reveal the Arbitrary Data
-    let reveal_tx = reveal_arbitrary_data(outpoint, output, script, taproot_spend_info);
-
-    test_and_submit(&rpc, vec![commit_tx, reveal_tx], miner_address);
+    create_child(subnet_address, subnet_data.as_bytes())?;
 
     Ok(())
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,12 +1,12 @@
 use dotenv::dotenv;
 use std::env;
 
-pub fn load_env() -> (String, String, String, String) {
+pub fn load_env() -> Result<(String, String, String, String), env::VarError> {
     dotenv().ok();
-    let rpc_user = env::var("RPC_USER").expect("RPC_USER must be set");
-    let rpc_pass = env::var("RPC_PASS").expect("RPC_PASS must be set");
-    let rpc_url = env::var("RPC_URL").expect("RPC_URL must be set");
-    let wallet_name = env::var("WALLET_NAME").expect("WALLET_NAME must be set");
+    let rpc_user = env::var("RPC_USER")?;
+    let rpc_pass = env::var("RPC_PASS")?;
+    let rpc_url = env::var("RPC_URL")?;
+    let wallet_name = env::var("WALLET_NAME")?;
 
-    (rpc_user, rpc_pass, rpc_url, wallet_name)
+    Ok((rpc_user, rpc_pass, rpc_url, wallet_name))
 }


### PR DESCRIPTION
- Moved most of the code from main into a new create_child() function in the ipc_lib module.
- Created a new binary create_child, that parses user arguments and then calls the create_chils() function.
- Created a new generate_keypair binary, that the user can use to generate the subnetPK (needed for the create_child binary).
- Added description for the new binaries to the README.
- Created a constant for the "IPC:CREATE" tag.