### PR TITLE
Implement the deposit to a subnet functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,11 @@ This guide will walk you through the necessary steps needed to setup the environ
 ./scripts/demo_ubuntu.sh 
 ```
 
+- Or if there are already existing subnets that have the required number of validators, the subnet names can be supplied as arguments to the demo scripts
+for example
+```sh
+./scripts/demo_ubuntu.sh "<subnet-name1>" "<subnet-name2>" ...
+
 This will run `bitcoind`, `btc_monitor`, the `l1_manager` and it will open a `subnet_interactor` terminal for every existing subnet that has the required number of validators.
 
 Additionally, when interacting with the `l1_manager`, after enough validators join a subnet, you can run the `subnet_interactor` for that subnet by exectuing

--- a/src/bin/btc_monitor.rs
+++ b/src/bin/btc_monitor.rs
@@ -3,7 +3,12 @@ use thiserror::Error;
 use std::{thread, time::Duration};
 
 use bitcoin::script::Instruction;
-use bitcoin_ipc::{bitcoin_utils, ipc_state::IPCState, utils};
+use bitcoin_ipc::{
+    bitcoin_utils,
+    ipc_state::IPCState,
+    subnet_simulator::{SubnetSimulator, SubnetSimulatorError},
+    utils,
+};
 
 use bitcoincore_rpc::RpcApi;
 
@@ -108,6 +113,50 @@ fn parse_join_command(witness_str: &str) -> Result<IPCState, ParseIpcTransaction
     Ok(ipc_subnet_state)
 }
 
+fn parse_deposit_command(witness_str: &str) -> Result<SubnetSimulator, ParseIpcTransactionError> {
+    let parts: Vec<&str> = witness_str.split(bitcoin_ipc::DELIMITER).collect();
+
+    if parts.len() != 4 {
+        return Err(ParseIpcTransactionError::InvalidWitnessFormat);
+    }
+
+    let amount: u64 = parts[1]
+        .strip_prefix("amount=")
+        .unwrap_or("")
+        .trim()
+        .parse()
+        .map_err(|_| ParseIpcTransactionError::CannotParseAmount)?;
+
+    let subnet_name = match parts[2].strip_prefix("subnet_name=") {
+        Some(subnet_name) => subnet_name,
+        None => return Err(ParseIpcTransactionError::MissingName),
+    };
+
+    let target_address = match parts[3].strip_prefix("target_address=") {
+        Some(target_address) => target_address,
+        None => return Err(ParseIpcTransactionError::MissingTargetAddress),
+    };
+
+    let mut simulator = match SubnetSimulator::new(&subnet_name) {
+        Ok(s) => s,
+        Err(e) => {
+            println!("Failed to start simulator: {}", e);
+            return Err(ParseIpcTransactionError::CannotLaunchSimulator);
+        }
+    };
+
+    match simulator.fund_account(&target_address.to_string(), amount) {
+        Ok(_) => {}
+        Err(_) => {
+            return Err(ParseIpcTransactionError::SubnetSimulatorError(
+                SubnetSimulatorError::CannotFundAccount,
+            ))
+        }
+    }
+
+    Ok(simulator)
+}
+
 fn find_valid_utf8(data: &[u8]) -> &str {
     let mut start = 0;
     while start < data.len() {
@@ -206,6 +255,19 @@ pub fn main() {
                                         Ok(_) => println!("JOIN Command successfully parsed"),
                                         Err(e) => {
                                             println!("JOIN Command could not be parsed. Error: {e}")
+                                        }
+                                    };
+                                }
+                                _ if witness_str.contains(bitcoin_ipc::IPC_DEPOSIT_TAG) => {
+                                    println!("Transaction {} at block height {} contains the keyword '{:?}'", tx.compute_txid(), block_height, bitcoin_ipc::IPC_DEPOSIT_TAG);
+                                    println!("Command: {}", witness_str);
+                                    println!("Executing the DEPOSIT command...");
+                                    match parse_deposit_command(witness_str) {
+                                        Ok(_) => println!("DEPOSIT Command successfully parsed"),
+                                        Err(e) => {
+                                            println!(
+                                                "DEPOSIT Command could not be parsed. Error: {e}"
+                                            )
                                         }
                                     };
                                 }
@@ -325,8 +387,14 @@ pub enum ParseIpcTransactionError {
     #[error("Cannot parse collateral")]
     CannotParseCollateral,
 
-    #[error("cannot launch subnet interactor")]
-    CannotLaunchInteractor,
+    #[error("Cannot parse amount")]
+    CannotParseAmount,
+
+    #[error("cannot launch subnet simulator")]
+    CannotLaunchSimulator,
+
+    #[error("subnet simulator error")]
+    SubnetSimulatorError(#[from] bitcoin_ipc::subnet_simulator::SubnetSimulatorError),
 
     #[error("number of validators cannot be 0")]
     NumberOfValidatorsZero,
@@ -336,6 +404,9 @@ pub enum ParseIpcTransactionError {
 
     #[error("missing field name")]
     MissingName,
+
+    #[error("missing target address")]
+    MissingTargetAddress,
 
     #[error("missing field pk")]
     MissingPk,

--- a/src/bin/l1_manager.rs
+++ b/src/bin/l1_manager.rs
@@ -27,7 +27,7 @@ impl L1Manager {
             "".to_string()
         });
 
-        let file_path = &format!("{}/{}/keypair.yaml", bitcoin_ipc::L1_NAME, name);
+        let file_path = &format!("{}/{}/keypair.json", bitcoin_ipc::L1_NAME, name);
         let path = std::path::Path::new(file_path);
 
         if let Some(parent) = path.parent() {
@@ -44,6 +44,31 @@ impl L1Manager {
 
         Ok(())
     }
+
+    // fn create_state_file(name: &str) -> Result<(), L1ManagerError> {
+    //     let state = SubnetState::new();
+    //     let serialized = serde_json::to_string(state).unwrap_or_else(|_| {
+    //         println!("Failed to serialize keypair");
+    //         "".to_string()
+    //     });
+
+    //     let file_path = &format!("{}/{}/keypair.json", bitcoin_ipc::L1_NAME, name);
+    //     let path = std::path::Path::new(file_path);
+
+    //     if let Some(parent) = path.parent() {
+    //         std::fs::create_dir_all(parent)?;
+    //     }
+
+    //     let mut file = OpenOptions::new()
+    //         .write(true)
+    //         .create(true)
+    //         .truncate(true)
+    //         .open(file_path)?;
+
+    //     file.write_all(serialized.as_bytes())?;
+
+    //     Ok(())
+    // }
 
     fn create_child(&self) -> Result<(), L1ManagerError> {
         let name = get_user_input("Enter subnet name:")?;
@@ -99,7 +124,7 @@ impl L1Manager {
         Ok(())
     }
 
-    fn join_child(&self) -> Result<(), L1ManagerError> {
+    fn choose_subnet(&self) -> Result<IPCState, L1ManagerError> {
         let subnets = IPCState::load_all()?;
 
         if subnets.len() == 0 {
@@ -107,12 +132,14 @@ impl L1Manager {
         }
 
         let mut prompt: String = format!(
-            "Select a subnet (between 1 and {}) to join:\n",
+            "Select a subnet (between 1 and {}) to deposit funds:\n",
             subnets.len()
         );
+
         for (i, subnet) in subnets.iter().enumerate() {
             prompt.push_str(&format!("{}. {}\n", i + 1, subnet.get_name()));
         }
+
         let choice = get_user_input(&prompt)?;
 
         let choice: usize = choice
@@ -127,7 +154,11 @@ impl L1Manager {
             });
         }
 
-        let ipc_state = &subnets[choice - 1];
+        Ok(subnets[choice - 1].clone())
+    }
+
+    fn join_child(&self) -> Result<(), L1ManagerError> {
+        let ipc_state = self.choose_subnet()?;
 
         let ip = get_user_input("Enter validator's IP address:")?;
         let pk = get_user_input("Enter validator's public key:")?;
@@ -155,12 +186,56 @@ impl L1Manager {
         Ok(())
     }
 
+    fn deposit(&self) -> Result<(), L1ManagerError> {
+        let ipc_state = self.choose_subnet()?;
+
+        let amount = get_user_input("Enter amount to deposit (in satoshis):")?;
+
+        let amount: u64 = amount
+            .parse()
+            .map_err(|_| L1ManagerError::InvalidUserInput { field: "amount" })?;
+
+        if amount < 200 {
+            return Err(L1ManagerError::InvalidUserInput {
+                field: "amount must be at least 200 satoshis",
+            });
+        }
+
+        let subnet_address = &ipc_state.get_subnet_address()?;
+
+        let target_address = get_user_input("Enter target address:")?;
+
+        let mut deposit_data = String::new();
+        deposit_data.push_str(bitcoin_ipc::IPC_DEPOSIT_TAG);
+        deposit_data.push_str(&format!(
+            "{}amount={}{}",
+            bitcoin_ipc::DELIMITER,
+            amount,
+            bitcoin_ipc::DELIMITER
+        ));
+        deposit_data.push_str(&format!(
+            "subnet_name={}{}",
+            ipc_state.get_name(),
+            bitcoin_ipc::DELIMITER
+        ));
+        deposit_data.push_str(&format!("target_address={}", target_address));
+
+        bitcoin_ipc::ipc_lib::create_and_submit_deposit_tx(
+            subnet_address,
+            Amount::from_sat(amount),
+            &deposit_data,
+        )?;
+
+        Ok(())
+    }
+
     fn interactive_interface(&mut self) {
         let prompt = "Select an option:\n\
             1. Read state\n\
             2. Create child\n\
             3. Join child\n\
-            4. Exit";
+            4. Deposit\n\
+            5. Exit";
 
         loop {
             let choice = match get_user_input(prompt) {
@@ -211,7 +286,16 @@ impl L1Manager {
                     }
                 },
 
-                4 => break,
+                4 => match self.deposit() {
+                    Ok(_) => {
+                        println!("Transaction to deposit funds has been submited to bitcoin, please wait for confirmation.");
+                    }
+                    Err(e) => {
+                        println!("An error occured, funds were not deposited. Error: {e}");
+                    }
+                },
+
+                5 => break,
 
                 _ => println!("Invalid option. Please try again."),
             }

--- a/src/bin/l1_manager.rs
+++ b/src/bin/l1_manager.rs
@@ -45,31 +45,6 @@ impl L1Manager {
         Ok(())
     }
 
-    // fn create_state_file(name: &str) -> Result<(), L1ManagerError> {
-    //     let state = SubnetState::new();
-    //     let serialized = serde_json::to_string(state).unwrap_or_else(|_| {
-    //         println!("Failed to serialize keypair");
-    //         "".to_string()
-    //     });
-
-    //     let file_path = &format!("{}/{}/keypair.json", bitcoin_ipc::L1_NAME, name);
-    //     let path = std::path::Path::new(file_path);
-
-    //     if let Some(parent) = path.parent() {
-    //         std::fs::create_dir_all(parent)?;
-    //     }
-
-    //     let mut file = OpenOptions::new()
-    //         .write(true)
-    //         .create(true)
-    //         .truncate(true)
-    //         .open(file_path)?;
-
-    //     file.write_all(serialized.as_bytes())?;
-
-    //     Ok(())
-    // }
-
     fn create_child(&self) -> Result<(), L1ManagerError> {
         let name = get_user_input("Enter subnet name:")?;
         let required_number_of_validators = get_user_input("Enter required number of validators:")?;

--- a/src/bin/relayer.rs
+++ b/src/bin/relayer.rs
@@ -31,9 +31,17 @@ fn checkpoint(subnet_name: String) {
                 }
             };
 
-            let hash = simulator.get_checkpoint();
+            let hash = match simulator.get_checkpoint() {
+                Ok(h) => h,
+                Err(e) => {
+                    println!("Failed to get checkpoint: {}", e);
+                    thread::sleep(Duration::from_secs(10));
+                    continue;
+                }
+            };
 
-            if let Ok(_) = ipc_lib::submit_checkpoint(hash, subnet.clone(), simulator) {
+            if let Ok(_) = ipc_lib::create_and_submit_checkpoint_tx(hash, subnet.clone(), simulator)
+            {
                 println!("Checkpoint for {} submitted successfully", subnet.get_url());
             } else {
                 println!("Failed to submit checkpoint for {}", subnet.get_url());

--- a/src/bin/subnet_interactor.rs
+++ b/src/bin/subnet_interactor.rs
@@ -68,7 +68,10 @@ impl SubnetInteractor {
                         }
                     };
 
-                    self.subnet.create_account(&address);
+                    match self.subnet.create_account(&address) {
+                        Ok(_) => {}
+                        Err(e) => println!("Account creation failed: {}", e),
+                    }
                 }
                 2 => {
                     let address = match get_user_input("Enter account address:") {
@@ -94,7 +97,10 @@ impl SubnetInteractor {
                         }
                     };
 
-                    self.subnet.fund_account(&address, amount);
+                    match self.subnet.fund_account(&address, amount) {
+                        Ok(_) => {}
+                        Err(e) => println!("Account funding failed: {}", e),
+                    }
                 }
                 3 => {
                     let from = match get_user_input("Enter from account address:") {
@@ -132,7 +138,13 @@ impl SubnetInteractor {
                     }
                 }
                 4 => {
-                    let checkpoint = self.subnet.get_checkpoint();
+                    let checkpoint = match self.subnet.get_checkpoint() {
+                        Ok(cp) => cp,
+                        Err(e) => {
+                            println!("Failed to get checkpoint: {}", e);
+                            continue;
+                        }
+                    };
                     let str_cp = hex::encode(checkpoint);
                     println!("Checkpoint: {:?}", str_cp);
                 }

--- a/src/ipc_lib.rs
+++ b/src/ipc_lib.rs
@@ -104,7 +104,7 @@ pub fn create_and_submit_join_child_tx(
 /// * `checkpoint_hash` - A string representing the hash of the checkpoint to be submitted.
 /// * `ipc_state` - An instance of IPCState representing the state of the subnet.
 /// * `simulator` - An instance of SubnetSimulator representing the state of the subnet.
-pub fn submit_checkpoint(
+pub fn create_and_submit_checkpoint_tx(
     checkpoint_hash: [u8; 32],
     ipc_state: IPCState,
     simulator: SubnetSimulator,
@@ -133,6 +133,39 @@ pub fn submit_checkpoint(
     match test_and_submit(&rpc, vec![signed_transaction], miner_address) {
         Ok(_) => Ok(()),
         Err(e) => Err(SubmitCheckpointError::BitcoinUtilsError(e)),
+    }
+}
+
+/// Creates a deposit transaction for a subnet represented by a Bitcoin address and submits it to the Bitcoin network.
+///
+/// This function creates a Bitcoin transaction that includes specified deposit data
+/// and submits it to the Bitcoin network. The transaction involves creating and revealing
+/// a script containing the data using the Taproot script-path. This process ensures
+/// the data is embedded in the blockchain.
+///
+/// # Arguments
+///
+/// * `subnet_address` - A reference to a `bitcoin::Address` that represents the subnet's multisig address.
+/// * `amount` - An `Amount` representing the amount to be deposited to the subnet's multisig address.
+/// * `deposit_data` - A string slice that holds the deposit data to be embedded in the transaction.
+pub fn create_and_submit_deposit_tx(
+    subnet_address: &bitcoin::Address,
+    amount: Amount,
+    deposit_data: &str,
+) -> Result<(), IpcLibError> {
+    // Init RPC connection and wallet
+    let fee: Amount = Amount::from_sat(200);
+
+    let (rpc_user, rpc_pass, rpc_url, wallet_name) = utils::load_env()?;
+    let rpc = init_rpc_client(rpc_user, rpc_pass, rpc_url)?;
+    let (miner_address, _, _) = init_wallet(&rpc, crate::NETWORK, &wallet_name)?;
+
+    let (commit_tx, reveal_tx) =
+        write_arbitrary_data(&rpc, amount + fee, fee, deposit_data, subnet_address)?;
+
+    match test_and_submit(&rpc, vec![commit_tx, reveal_tx], miner_address) {
+        Ok(_) => Ok(()),
+        Err(e) => Err(IpcLibError::BitcoinUtilsError(e)),
     }
 }
 

--- a/src/ipc_state.rs
+++ b/src/ipc_state.rs
@@ -125,7 +125,18 @@ impl IPCState {
                         let sub_entry = sub_entry?;
                         let sub_path = sub_entry.path();
 
-                        if sub_path.extension().and_then(|s| s.to_str()) == Some("json") {
+                        if sub_path.extension().and_then(|s| s.to_str()) == Some("json")
+                            && !sub_path
+                                .file_name()
+                                .and_then(|s| s.to_str())
+                                .unwrap()
+                                .starts_with("subnet_state")
+                            && !sub_path
+                                .file_name()
+                                .and_then(|s| s.to_str())
+                                .unwrap()
+                                .starts_with("keypair")
+                        {
                             let file = File::open(&sub_path)?;
                             let ipc_state: IPCState = serde_json::from_reader(file)?;
                             ipc_states.push(ipc_state);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,6 +9,7 @@ use bitcoin::Network;
 pub const NETWORK: Network = Network::Regtest;
 pub const IPC_CREATE_SUBNET_TAG: &str = "IPC:CREATE";
 pub const IPC_JOIN_SUBNET_TAG: &str = "IPC:JOIN";
+pub const IPC_DEPOSIT_TAG: &str = "IPC:DEPOSIT";
 pub const DELIMITER: &str = "<-->";
 
 pub const DEMO_UBUNTU: &str = "scripts/demo_ubuntu.sh";

--- a/src/subnet_simulator.rs
+++ b/src/subnet_simulator.rs
@@ -4,8 +4,10 @@ use bitcoin::key::{TapTweak, TweakedKeypair};
 use bitcoin::sighash::{Prevouts, SighashCache};
 use bitcoin::{TapSighashType, Transaction, TxOut};
 use serde::{Deserialize, Serialize};
-use std::io::Read;
-use std::{collections::HashMap, fs::File};
+use std::collections::BTreeMap;
+use std::fs::File;
+use std::io::{Read, Write};
+use std::path::Path;
 
 use bitcoin::secp256k1::{Message, Secp256k1};
 
@@ -18,13 +20,13 @@ pub struct Account {
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct SubnetState {
-    accounts: HashMap<String, Account>,
+    accounts: BTreeMap<String, Account>,
 }
 
 impl SubnetState {
     pub fn new() -> Self {
         SubnetState {
-            accounts: HashMap::new(),
+            accounts: BTreeMap::new(),
         }
     }
 }
@@ -39,18 +41,39 @@ impl SubnetSimulator {
     pub fn new(subnet_name: &str) -> Result<Self, SubnetSimulatorError> {
         println!("Starting simulator for subnet {subnet_name}.");
 
-        if let Ok(mut file) = File::open(format!("{}/{}/keypair.yaml", crate::L1_NAME, subnet_name))
+        let state_file_path = &format!("{}/{}/subnet_state.json", crate::L1_NAME, subnet_name);
+
+        if !Path::new(state_file_path).exists() {
+            let json = serde_json::to_string(&SubnetState::new())?;
+
+            let mut file = std::fs::OpenOptions::new()
+                .write(true)
+                .create(true)
+                .truncate(true)
+                .open(state_file_path)?;
+
+            file.write_all(json.as_bytes())?;
+        }
+
+        if let Ok(mut file) = File::open(format!("{}/{}/keypair.json", crate::L1_NAME, subnet_name))
         {
             let mut json = String::new();
             file.read_to_string(&mut json)?;
 
-            if let Ok(keypair) = serde_json::from_str(&json) {
-                return Ok(SubnetSimulator {
-                    subnet_name: String::from(subnet_name),
-                    state: SubnetState::new(),
-                    keypair,
-                });
-            }
+            let keypair = match serde_json::from_str(&json) {
+                Ok(kp) => kp,
+                Err(_) => bitcoin_utils::generate_keypair(subnet_name.to_string())?,
+            };
+            let state = match SubnetSimulator::load_state(subnet_name) {
+                Ok(st) => st,
+                Err(_) => SubnetState::new(),
+            };
+
+            return Ok(SubnetSimulator {
+                subnet_name: String::from(subnet_name),
+                state,
+                keypair,
+            });
         }
 
         return Ok(SubnetSimulator {
@@ -59,44 +82,74 @@ impl SubnetSimulator {
             keypair: bitcoin_utils::generate_keypair(subnet_name.to_string())?,
         });
     }
+    pub fn create_account(&mut self, address: &String) -> Result<(), SubnetStateError> {
+        self.state = SubnetSimulator::load_state(&self.subnet_name)?;
 
-    pub fn create_account(&mut self, address: &String) {
         if self.state.accounts.contains_key(address) {
-            println!("Account {} already exists", address);
-            return;
+            return Err(SubnetStateError::AccountAlreadyExists);
         }
 
         self.state
             .accounts
             .insert(address.to_string(), Account { balance: 0 });
 
-        println!("Account {}", address);
+        self.save_state()?;
+
+        println!("Account {} created", address);
+
+        Ok(())
     }
 
-    pub fn fund_account(&mut self, address: &String, amount: u64) {
-        let account = self
-            .state
-            .accounts
-            .get_mut(address)
-            .expect("Account not found");
+    pub fn fund_account(&mut self, address: &String, amount: u64) -> Result<(), SubnetStateError> {
+        self.state = SubnetSimulator::load_state(&self.subnet_name)?;
+
+        if !self.state.accounts.contains_key(address) {
+            match self.create_account(address) {
+                Ok(_) => {}
+                Err(_) => {
+                    return Err(SubnetStateError::CannotCreateAccount);
+                }
+            }
+        }
+
+        let account = match self.state.accounts.get_mut(address) {
+            Some(a) => a,
+            None => {
+                return Err(SubnetStateError::AccountNotFound);
+            }
+        };
 
         account.balance += amount;
 
+        self.save_state()?;
+
         println!("Account {} funded", address);
+
+        Ok(())
     }
 
-    pub fn transfer(&mut self, from: &String, to: &String, amount: u64) -> Result<(), String> {
-        let from_account = self
-            .state
-            .accounts
-            .get_mut(from)
-            .ok_or("From account not found")?;
+    pub fn transfer(
+        &mut self,
+        from: &String,
+        to: &String,
+        amount: u64,
+    ) -> Result<(), SubnetStateError> {
+        self.state = SubnetSimulator::load_state(&self.subnet_name)?;
+
+        let from_account = match self.state.accounts.get_mut(from) {
+            Some(a) => a,
+            None => {
+                return Err(SubnetStateError::AccountNotFound);
+            }
+        };
+
         if from_account.balance < amount {
-            return Err("Insufficient balance".to_string());
+            return Err(SubnetStateError::InsufficientFunds);
         }
 
         from_account.balance -= amount;
 
+        // TODO: update logic when address is from another subnet.
         let to_account = self
             .state
             .accounts
@@ -105,18 +158,21 @@ impl SubnetSimulator {
 
         to_account.balance += amount;
 
+        self.save_state()?;
+
         println!("Transfer successful");
         Ok(())
     }
 
-    pub fn get_checkpoint(&mut self) -> [u8; 32] {
+    pub fn get_checkpoint(&mut self) -> Result<[u8; 32], SubnetStateError> {
         println!("Computing state checkpoint...");
+        self.state = SubnetSimulator::load_state(&self.subnet_name)?;
 
-        // Disclaimer: this is not secure. It has not checked whether the serialization method and the HashMap
+        // Disclaimer: this is not secure. It has not checked whether the serialization method and the BTreeMap
         // implementations avoid collisions.
         let json = serde_json::to_string(&self.state.accounts).expect("Failed to serialize state");
 
-        bitcoin_utils::hash(json)
+        Ok(bitcoin_utils::hash(json))
     }
 
     /// This function signs a transaction with the keypair of the subnet a.k.a. subnetPK
@@ -162,7 +218,6 @@ impl SubnetSimulator {
             input.witness.push(signatures[i].clone());
             println!("Signed input {}", i);
         }
-
         tx
     }
 
@@ -174,8 +229,50 @@ impl SubnetSimulator {
         self.keypair
     }
 
+    pub fn load_state(subnet_name: &str) -> Result<SubnetState, SubnetStateError> {
+        let mut file = File::open(format!(
+            "{}/{}/subnet_state.json",
+            crate::L1_NAME,
+            subnet_name
+        ))?;
+        let mut content = String::new();
+        file.read_to_string(&mut content)?;
+        let subnet_state = serde_json::from_str(&content)?;
+        Ok(subnet_state)
+    }
+
+    pub fn save_state(&self) -> Result<String, SubnetStateError> {
+        let json = serde_json::to_string(&self.state)?;
+
+        let path = std::path::Path::new(&self.subnet_name);
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent)?;
+        }
+
+        let mut file = std::fs::OpenOptions::new()
+            .write(true)
+            .create(true)
+            .truncate(true)
+            .open(format!(
+                "{}/{}/subnet_state.json",
+                crate::L1_NAME,
+                self.subnet_name
+            ))?;
+
+        file.write_all(json.as_bytes())?;
+
+        Ok(json)
+    }
+
     pub fn print_state(&mut self) {
         println!("#################################");
+        self.state = match SubnetSimulator::load_state(&self.subnet_name) {
+            Ok(st) => st,
+            Err(_) => {
+                println!("Failed to load state");
+                return;
+            }
+        };
         // print in a more organized manner:
         println!("Subnet: {}", self.subnet_name);
         println!("Subnet PK: {}", self.get_public_key());
@@ -184,7 +281,13 @@ impl SubnetSimulator {
             println!("  {}: {}", address, account.balance);
         }
 
-        let checkpoint = self.get_checkpoint();
+        let checkpoint = match self.get_checkpoint() {
+            Ok(cp) => cp,
+            Err(_) => {
+                println!("Failed to get checkpoint");
+                return;
+            }
+        };
         let str_cp = hex::encode(checkpoint);
 
         println!("Checkpoint: {}", str_cp);
@@ -199,4 +302,34 @@ pub enum SubnetSimulatorError {
 
     #[error("error when reading the keypair file")]
     IoError(#[from] std::io::Error),
+
+    #[error("error when reading the file")]
+    JsonError(#[from] serde_json::Error),
+
+    #[error("error while funding account")]
+    CannotFundAccount,
+}
+
+#[derive(Error, Debug)]
+pub enum SubnetStateError {
+    #[error("invalid subnet PK")]
+    InvalidSubnetPK,
+
+    #[error("cannot open or read file")]
+    IoError(#[from] std::io::Error),
+
+    #[error("cannot open or read file")]
+    JsonError(#[from] serde_json::Error),
+
+    #[error("account not found")]
+    AccountNotFound,
+
+    #[error("insufficient funds")]
+    InsufficientFunds,
+
+    #[error("account already exists")]
+    AccountAlreadyExists,
+
+    #[error("cannot create account")]
+    CannotCreateAccount,
 }


### PR DESCRIPTION
- Add deposit transaction functionality to the ipc lib which submits commit and reveal transactions on bitcoin
- Add a listener in the btc_monitor for deposit transactions.
- Modify subnet state to be stored in a file so that the deposits can be reflected and noticed by the subnet interactor
- Improve the error handling in the subnet interactor