### PR TITLE
Implement postbox Closes #19

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,21 @@
 version = 3
 
 [[package]]
+name = "addr2line"
+version = "0.24.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f5fb1d8e4442bd405fdfd1dacb42792696b0cf9cb15882e5d097b742a676d375"
+dependencies = [
+ "gimli",
+]
+
+[[package]]
+name = "adler2"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "512761e0bb2578dd7380c6baaa0f4ce03e84f95e960231d1dec8bf4d7d6e2627"
+
+[[package]]
 name = "anstream"
 version = "0.6.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -56,6 +71,27 @@ name = "arrayvec"
 version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96d30a06541fbafbc7f82ed10c06164cfbd2c401138f6addd8404629c4b16711"
+
+[[package]]
+name = "autocfg"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c4b4d0bd25bd0b74681c0ad21497610ce1b7c91b1022cd21c80c6fbdd9476b0"
+
+[[package]]
+name = "backtrace"
+version = "0.3.74"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d82cb332cdfaed17ae235a638438ac4d4839913cc2af585c3c6746e8f8bee1a"
+dependencies = [
+ "addr2line",
+ "cfg-if",
+ "libc",
+ "miniz_oxide",
+ "object",
+ "rustc-demangle",
+ "windows-targets",
+]
 
 [[package]]
 name = "base58ck"
@@ -126,6 +162,7 @@ dependencies = [
  "serde_json",
  "thiserror",
  "tiny-keccak",
+ "tokio",
 ]
 
 [[package]]
@@ -172,6 +209,18 @@ dependencies = [
  "serde",
  "serde_json",
 ]
+
+[[package]]
+name = "bitflags"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b048fb63fd8b5923fc5aa7b340d8e156aec7ec02f0c78fa8a6ddc2613f6f71de"
+
+[[package]]
+name = "bytes"
+version = "1.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8318a53db07bb3f8dca91a600466bdb3f2eaadeedfdbcf02e1accbad9271ba50"
 
 [[package]]
 name = "cc"
@@ -255,10 +304,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "gimli"
+version = "0.31.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32085ea23f3234fc7846555e85283ba4de91e21016dc0455a16286d87a292d64"
+
+[[package]]
 name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "hermit-abi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d231dfb89cfffdbc30e7fc41579ed6066ad03abda9e567ccafae602b97ec5024"
 
 [[package]]
 name = "hex"
@@ -307,15 +368,40 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.155"
+version = "0.2.158"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97b3888a4aecf77e811145cadf6eef5901f4782c53886191b2f693f24761847c"
+checksum = "d8adc4bb1803a324070e64a98ae98f38934d91957a99cfb3a43dcbc01bc56439"
+
+[[package]]
+name = "lock_api"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07af8b9cdd281b7915f413fa73f29ebd5d55d0d3f0155584dade1ff18cea1b17"
+dependencies = [
+ "autocfg",
+ "scopeguard",
+]
 
 [[package]]
 name = "log"
 version = "0.4.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7a70ba024b9dc04c27ea2f0c0548feb474ec5c54bba33a7f72f873a39d07b24"
+
+[[package]]
+name = "memchr"
+version = "2.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
+
+[[package]]
+name = "miniz_oxide"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2d80299ef12ff69b16a84bb182e3b9df68b5a91574d3d4fa6e41b65deec4df1"
+dependencies = [
+ "adler2",
+]
 
 [[package]]
 name = "minreq"
@@ -327,6 +413,56 @@ dependencies = [
  "serde",
  "serde_json",
 ]
+
+[[package]]
+name = "mio"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "80e04d1dcff3aae0704555fe5fee3bcfaf3d1fdf8a7e521d5b9d2b42acb52cec"
+dependencies = [
+ "hermit-abi",
+ "libc",
+ "wasi",
+ "windows-sys",
+]
+
+[[package]]
+name = "object"
+version = "0.36.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "084f1a5821ac4c651660a94a7153d27ac9d8a53736203f58b31945ded098070a"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "parking_lot"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1bf18183cf54e8d6059647fc3063646a1801cf30896933ec2311622cc4b9a27"
+dependencies = [
+ "lock_api",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.9.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e401f977ab385c9e4e3ab30627d6f26d00e2c73eef317493c4ec6d468726cf8"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall",
+ "smallvec",
+ "windows-targets",
+]
+
+[[package]]
+name = "pin-project-lite"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bda66fc9667c18cb2758a2ac84d1167245054bcf85d5d1aaa6923f45801bdd02"
 
 [[package]]
 name = "ppv-lite86"
@@ -383,10 +519,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "redox_syscall"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0884ad60e090bf1345b93da0a5de8923c93884cd03f40dfcfddd3b4bee661853"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
+name = "rustc-demangle"
+version = "0.1.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f"
+
+[[package]]
 name = "ryu"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f3cb5ba0dc43242ce17de99c180e96db90b235b8a9fdc9543c96d2209116bd9f"
+
+[[package]]
+name = "scopeguard"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "secp256k1"
@@ -441,6 +598,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "signal-hook-registry"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9e9e0b4211b72e7b8b6e85c807d36c212bdb33ea8587f7569562a84df5465b1"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "smallvec"
+version = "1.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
+
+[[package]]
+name = "socket2"
+version = "0.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce305eb0b4296696835b71df73eb912e0f1ffd2556a501fcede6e0c50349191c"
+dependencies = [
+ "libc",
+ "windows-sys",
+]
+
+[[package]]
 name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -484,6 +666,35 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2c9d3793400a45f954c52e73d068316d76b6f4e36977e3fcebb13a2721e80237"
 dependencies = [
  "crunchy",
+]
+
+[[package]]
+name = "tokio"
+version = "1.40.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2b070231665d27ad9ec9b8df639893f46727666c6767db40317fbe920a5d998"
+dependencies = [
+ "backtrace",
+ "bytes",
+ "libc",
+ "mio",
+ "parking_lot",
+ "pin-project-lite",
+ "signal-hook-registry",
+ "socket2",
+ "tokio-macros",
+ "windows-sys",
+]
+
+[[package]]
+name = "tokio-macros"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "693d596312e88961bc67d7f1f97af8a70227d9f90c31bba5806eec004978d752"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,3 +15,4 @@ thiserror = "1.0.61"
 serde_json = "1.0.120"
 hex = "0.4.3"
 rand = "0.8.5"
+tokio = { version = "1.40.0", features = ["full"] }

--- a/config.json
+++ b/config.json
@@ -1,4 +1,6 @@
 {
   "listener_interval": 10,
-  "ipc_finalization_parameter": 1
+  "ipc_finalization_parameter": 1,
+  "checkpoint_interval": 100,
+  "postbox_interval": 5
 }

--- a/docs/specs/architecture.md
+++ b/docs/specs/architecture.md
@@ -45,6 +45,10 @@ Hence, the interface of the Subnet Simulator looks like the following (described
 
 As the Subnet Simulator is the only point in the architecture where the `SubnetState` is held, it is responsible to return the state to be checkpointed. This is facilitated by the `get_checkpoint()` method.
 
+Among other things, it contains a `postBox` component. Since the subnet itself cannot process these commands 
+independently,  `withdraw` or cross-subnet `transfer` commands  are submitted to the `postBox` for handling
+and further processing.
+
 Since the node runs a bitcoin full node, it can use that node for bridging events from the bitcoin chain into the subnet.
 
 
@@ -55,7 +59,7 @@ This component is responsible for monitoring all IPC subnets and relaying necess
 It could also run on a different machine, by a different entity, or be implemented in a decentralized manner. Here we make it a process run by an IPC node.
 
 It works as follows:
-- It periodically checks the `postBox` of each subnet. If there are cross-chain `transfer` or `withdraw` commands, it uses the BTC-IPC library to submit the appropriate transaction to bitcoin.
+- It periodically checks the `postBox` of each subnet. If it is not empty, it uses the BTC-IPC library to submit the appropriate transaction to bitcoin.
 - It periodically calls `get_checkpoint()` on the subnet and submits the checkpoint to bitcoin, using the BTC-IPC library.
 
 To achieve these, it connects to all the validators of the subnet. In the initial stages, where the subnet is instantiated by a Subnet Simulator, the Relayer only uses the interface of the Subnet Simulator to read the postbox and perform the checkpointing.

--- a/src/bin/relayer.rs
+++ b/src/bin/relayer.rs
@@ -1,61 +1,144 @@
 use clap::Parser;
 use thiserror::Error;
 
-use std::{thread, time::Duration};
+use tokio::{task, time};
 
-use bitcoin_ipc::{ipc_lib, ipc_state::IPCState, subnet_simulator::SubnetSimulator};
+use std::time::Duration;
 
-fn checkpoint(subnet_id: String) -> Result<(), RelayerError> {
+use bitcoin_ipc::{ipc_lib, ipc_state::IPCState, subnet_simulator::SubnetSimulator, utils};
+
+async fn get_subnet_and_simulator(
+    subnet_id: &String,
+) -> Result<(IPCState, SubnetSimulator), RelayerError> {
     let subnet_address = match subnet_id.split("/").last() {
         Some(subnet_address) => subnet_address,
         None => return Err(RelayerError::InvalidId),
     };
 
-    loop {
-        let subnet = match IPCState::load_state(format!("{}/{}.json", subnet_id, subnet_address)) {
+    let subnet = match IPCState::load_state(format!("{}/{}.json", subnet_id, subnet_address)) {
+        Ok(s) => s,
+        Err(e) => {
+            return Err(RelayerError::IpcStateError(e));
+        }
+    };
+
+    if subnet.has_required_validators() {
+        let simulator = match SubnetSimulator::new(subnet_id) {
             Ok(s) => s,
             Err(e) => {
-                println!("Failed to load subnet state: {}", e);
-                thread::sleep(Duration::from_secs(10));
-                continue;
+                return Err(RelayerError::SubnetSimulatorError(e));
             }
         };
 
-        if subnet.has_required_validators() {
-            let mut simulator = match SubnetSimulator::new(&subnet_id) {
-                Ok(s) => s,
-                Err(e) => {
-                    println!("Failed to start simulator: {}", e);
-                    thread::sleep(Duration::from_secs(10));
-                    continue;
-                }
-            };
-            let hash = match simulator.get_checkpoint() {
-                Ok(h) => h,
-                Err(e) => {
-                    println!("Failed to get checkpoint: {}", e);
-                    thread::sleep(Duration::from_secs(10));
-                    continue;
-                }
-            };
+        Ok((subnet, simulator))
+    } else {
+        println!(
+            "Waiting for validators to join subnet: {}",
+            subnet.get_subnet_id()
+        );
+        Err(RelayerError::WaitingForValidators)
+    }
+}
 
-            if ipc_lib::submit_checkpoint(hash, subnet.clone(), simulator).is_ok() {
-                println!(
-                    "Checkpoint for {} submitted successfully",
-                    subnet.get_subnet_id()
-                )
-            } else {
-                println!("Failed to submit checkpoint for {}", subnet.get_subnet_id());
+async fn checkpoint(subnet_id: &String) -> Result<(), RelayerError> {
+    let (subnet, mut simulator) = match get_subnet_and_simulator(subnet_id).await {
+        Ok(s) => s,
+        Err(e) => {
+            return Err(e);
+        }
+    };
+
+    let hash = match simulator.get_checkpoint() {
+        Ok(h) => h,
+        Err(e) => {
+            return Err(RelayerError::SubnetStateError(e));
+        }
+    };
+
+    if ipc_lib::submit_checkpoint(hash, subnet.clone(), simulator).is_ok() {
+        println!(
+            "Checkpoint for {} submitted successfully",
+            subnet.get_subnet_id()
+        )
+    } else {
+        println!("Failed to submit checkpoint for {}", subnet.get_subnet_id());
+    }
+
+    Ok(())
+}
+
+async fn check_postbox(subnet_id: &String) -> Result<(), RelayerError> {
+    let (subnet, mut simulator) = match get_subnet_and_simulator(subnet_id).await {
+        Ok(s) => s,
+        Err(e) => {
+            return Err(e);
+        }
+    };
+
+    {
+        let transfers = simulator.get_postbox_transfers();
+        if !transfers.is_empty() {
+            // TODO: batch and send transfers here!
+
+            match simulator.empty_postbox_transfers() {
+                Ok(_) => {
+                    println!(
+                        "Handled transfers in postbox for subnet: {}",
+                        subnet.get_subnet_id()
+                    );
+                }
+                Err(e) => {
+                    return Err(RelayerError::SubnetStateError(e));
+                }
             }
         } else {
-            println!(
-                "Waiting for validators to join subnet: {}",
-                subnet.get_subnet_id()
-            );
+            println!("No transfers in postbox")
         }
-
-        thread::sleep(Duration::from_secs(100));
     }
+
+    {
+        let withdraws = simulator.get_postbox_withdraws();
+        if !withdraws.is_empty() {
+            // TODO: batch and send withdraws here!
+
+            match simulator.empty_postbox_withdraws() {
+                Ok(_) => {
+                    println!(
+                        "Handled withdraws in postbox for subnet: {}",
+                        subnet.get_subnet_id()
+                    );
+                }
+                Err(e) => {
+                    return Err(RelayerError::SubnetStateError(e));
+                }
+            }
+        } else {
+            println!("No withdraws in postbox")
+        }
+    }
+
+    {
+        let delete = simulator.get_postbox_delete();
+        if delete.is_some() {
+            // TODO: send delete tx here!
+
+            match simulator.empty_postbox_delete() {
+                Ok(_) => {
+                    println!(
+                        "Handled delete in postbox for subnet: {}",
+                        subnet.get_subnet_id()
+                    );
+                }
+                Err(e) => {
+                    return Err(RelayerError::SubnetStateError(e));
+                }
+            }
+        } else {
+            println!("No delete in postbox")
+        }
+    }
+
+    Ok(())
 }
 
 #[derive(Parser, Debug)]
@@ -71,20 +154,63 @@ pub enum RelayerError {
     SubnetSimulatorError(#[from] bitcoin_ipc::subnet_simulator::SubnetSimulatorError),
 
     #[error(transparent)]
+    SubnetStateError(#[from] bitcoin_ipc::subnet_simulator::SubnetStateError),
+
+    #[error(transparent)]
     IpcStateError(#[from] bitcoin_ipc::ipc_state::IpcStateError),
 
     #[error("invalid id")]
     InvalidId,
 
+    #[error("waiting for validators to join subnet")]
+    WaitingForValidators,
+
     #[error(transparent)]
     Other(#[from] Box<dyn std::error::Error>),
 }
 
-fn main() {
+#[tokio::main]
+async fn main() {
     let args = Args::parse();
 
-    match checkpoint(args.subnet_id) {
-        Ok(_) => println!("Relayer stopped"),
-        Err(e) => println!("Relayer error: {}", e),
-    }
+    let config = match utils::load_config() {
+        Ok(config) => config,
+        Err(e) => {
+            println!("Error loading config: {}", e);
+            return;
+        }
+    };
+
+    let checkpoint_interval = Duration::from_secs(config.checkpoint_interval);
+    let postbox_interval = Duration::from_secs(config.postbox_interval);
+
+    let mut subnet_id = args.subnet_id.clone();
+
+    let checkpoint_task = task::spawn(async move {
+        let mut interval = time::interval(checkpoint_interval);
+        loop {
+            interval.tick().await;
+            match checkpoint(&subnet_id).await {
+                Ok(_) => println!("Checkpoint submitted successfully"),
+                Err(e) => println!("Error submitting checkpoint: {}", e),
+            }
+        }
+    });
+
+    subnet_id = args.subnet_id.clone();
+
+    let postbox_task = task::spawn(async move {
+        let mut interval = time::interval(postbox_interval);
+        loop {
+            interval.tick().await;
+            match check_postbox(&subnet_id).await {
+                Ok(_) => println!("Postbox checked successfully"),
+                Err(e) => println!("Error checking postbox: {}", e),
+            }
+        }
+    });
+
+    let _ = tokio::try_join!(checkpoint_task, postbox_task);
+
+    println!("Relayer stopped");
 }

--- a/src/bin/subnet_interactor.rs
+++ b/src/bin/subnet_interactor.rs
@@ -1,6 +1,8 @@
 // subnet_interactor.rs
 use thiserror::Error;
 
+use std::str::FromStr;
+
 use bitcoin_ipc::subnet_simulator::SubnetSimulator;
 use clap::Parser;
 use std::io::{self};
@@ -41,8 +43,10 @@ impl SubnetInteractor {
                                 2. Fund account\n\
                                 3. Transfer funds\n\
                                 4. Checkpoint state\n\
-                                5. Print state\n\
-                                6. Exit";
+                                5. Withdraw funds\n\
+                                6. Delete subnet\n\
+                                7. Print state\n\
+                                8. Exit";
 
             let choice = match get_user_input(prompt) {
                 Ok(c) => c,
@@ -142,8 +146,58 @@ impl SubnetInteractor {
                     let str_cp = hex::encode(checkpoint);
                     println!("Checkpoint: {:?}", str_cp);
                 }
-                5 => self.subnet.print_state(),
-                6 => break,
+                5 => {
+                    let address = match get_user_input("Enter account address:") {
+                        Ok(a) => a,
+                        Err(e) => {
+                            println!("Failed to read account address: {}", e);
+                            continue;
+                        }
+                    };
+                    let amount = match get_user_input("Enter amount to withdraw:") {
+                        Ok(a) => a,
+                        Err(e) => {
+                            println!("Failed to read amount: {}", e);
+                            continue;
+                        }
+                    };
+
+                    let amount: u64 = match amount.parse() {
+                        Ok(a) => a,
+                        Err(e) => {
+                            println!("Invalid balance amount: {}", e);
+                            continue;
+                        }
+                    };
+
+                    let btc_address_str = match get_user_input("Enter BTC address to withdraw to:")
+                    {
+                        Ok(a) => a,
+                        Err(e) => {
+                            println!("Failed to read BTC address: {}", e);
+                            continue;
+                        }
+                    };
+
+                    let btc_address = match bitcoin::Address::from_str(&btc_address_str) {
+                        Ok(a) => a,
+                        Err(e) => {
+                            println!("Failed to parse BTC address: {}", e);
+                            continue;
+                        }
+                    };
+
+                    match self.subnet.withdraw(&address, amount, btc_address) {
+                        Ok(_) => {}
+                        Err(e) => println!("Failed to submit withdraw request: {}", e),
+                    };
+                }
+                6 => match self.subnet.delete() {
+                    Ok(_) => {}
+                    Err(e) => println!("Failed to submit delete subnet request: {}", e),
+                },
+                7 => self.subnet.print_state(),
+                8 => break,
                 _ => println!("Invalid option. Please try again."),
             }
         }

--- a/src/subnet_simulator.rs
+++ b/src/subnet_simulator.rs
@@ -4,10 +4,10 @@ use bitcoin::key::{TapTweak, TweakedKeypair};
 use bitcoin::sighash::{Prevouts, SighashCache};
 use bitcoin::{TapSighashType, Transaction, TxOut};
 use serde::{Deserialize, Serialize};
-use std::{collections::BTreeMap, fs::File};
+use std::{collections::BTreeMap, collections::BTreeSet, fs::File};
 
 use bitcoin::secp256k1::{Message, Secp256k1};
-use bitcoin::XOnlyPublicKey;
+use bitcoin::{address::NetworkUnchecked, Address, XOnlyPublicKey};
 use std::io::{Read, Write};
 use std::path::Path;
 
@@ -21,12 +21,43 @@ pub struct Account {
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct SubnetState {
     accounts: BTreeMap<String, Account>,
+    postbox: Postbox,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone, Ord, Eq, PartialEq, PartialOrd)]
+pub struct TransferEvent {
+    subnet_id: String,
+    deposit_address: String,
+    amount: u64,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone, Ord, Eq, PartialEq, PartialOrd)]
+pub struct WithdrawEvent {
+    target_address: Address<NetworkUnchecked>,
+    amount: u64,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct DeleteEvent {
+    subnet_id: String,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct Postbox {
+    transfers: BTreeSet<TransferEvent>,
+    withdraws: BTreeSet<WithdrawEvent>,
+    deletes: Option<DeleteEvent>,
 }
 
 impl SubnetState {
     pub fn new() -> Self {
         SubnetState {
             accounts: BTreeMap::new(),
+            postbox: Postbox {
+                transfers: BTreeSet::new(),
+                withdraws: BTreeSet::new(),
+                deletes: None,
+            },
         }
     }
 }
@@ -153,18 +184,87 @@ impl SubnetSimulator {
 
         from_account.balance -= amount;
 
-        // TODO: update logic when address is from another subnet.
-        let to_account = self
-            .state
-            .accounts
-            .entry(to.to_string())
-            .or_insert(Account { balance: 0 });
+        if to.contains("/") {
+            let address = match to.split("/").last() {
+                Some(a) => a,
+                None => {
+                    return Err(SubnetStateError::AccountNotFound);
+                }
+            };
 
-        to_account.balance += amount;
+            let subnet_id = match to.strip_suffix(&format!("/{}", address)) {
+                Some(s) => s,
+                None => {
+                    return Err(SubnetStateError::AccountNotFound);
+                }
+            };
+
+            self.state.postbox.transfers.insert(TransferEvent {
+                subnet_id: subnet_id.to_string(),
+                deposit_address: address.to_string(),
+                amount,
+            });
+
+            println!("Transfer request submitted to postbox");
+        } else {
+            let to_account = self
+                .state
+                .accounts
+                .entry(to.to_string())
+                .or_insert(Account { balance: 0 });
+
+            to_account.balance += amount;
+
+            println!("Transfer successful");
+        }
 
         self.save_state()?;
 
-        println!("Transfer successful");
+        Ok(())
+    }
+
+    pub fn withdraw(
+        &mut self,
+        from: &String,
+        amount: u64,
+        target_address: Address<NetworkUnchecked>,
+    ) -> Result<(), SubnetStateError> {
+        self.state = SubnetSimulator::load_state(&self.subnet_id)?;
+
+        let from_account = match self.state.accounts.get_mut(from) {
+            Some(a) => a,
+            None => {
+                return Err(SubnetStateError::AccountNotFound);
+            }
+        };
+
+        if from_account.balance < amount {
+            return Err(SubnetStateError::InsufficientFunds);
+        }
+
+        from_account.balance -= amount;
+
+        self.state.postbox.withdraws.insert(WithdrawEvent {
+            target_address,
+            amount,
+        });
+
+        self.save_state()?;
+
+        println!("Withdraw request submitted to postbox");
+        Ok(())
+    }
+
+    pub fn delete(&mut self) -> Result<(), SubnetStateError> {
+        self.state = SubnetSimulator::load_state(&self.subnet_id)?;
+
+        self.state.postbox.deletes = Some(DeleteEvent {
+            subnet_id: self.subnet_id.clone(),
+        });
+
+        self.save_state()?;
+
+        println!("Delete request submitted to postbox");
         Ok(())
     }
 
@@ -254,6 +354,36 @@ impl SubnetSimulator {
         tx
     }
 
+    pub fn get_postbox_transfers(&mut self) -> &BTreeSet<TransferEvent> {
+        &self.state.postbox.transfers
+    }
+
+    pub fn empty_postbox_transfers(&mut self) -> Result<(), SubnetStateError> {
+        self.state.postbox.transfers = BTreeSet::new();
+        self.save_state()?;
+        Ok(())
+    }
+
+    pub fn get_postbox_withdraws(&mut self) -> &BTreeSet<WithdrawEvent> {
+        &self.state.postbox.withdraws
+    }
+
+    pub fn empty_postbox_withdraws(&mut self) -> Result<(), SubnetStateError> {
+        self.state.postbox.withdraws = BTreeSet::new();
+        self.save_state()?;
+        Ok(())
+    }
+
+    pub fn get_postbox_delete(&mut self) -> Option<&DeleteEvent> {
+        self.state.postbox.deletes.as_ref()
+    }
+
+    pub fn empty_postbox_delete(&mut self) -> Result<(), SubnetStateError> {
+        self.state.postbox.deletes = None;
+        self.save_state()?;
+        Ok(())
+    }
+
     pub fn get_public_key(&self) -> bitcoin::secp256k1::PublicKey {
         self.keypair.public_key()
     }
@@ -276,6 +406,23 @@ impl SubnetSimulator {
         for (address, account) in &self.state.accounts {
             println!("  {}: {}", address, account.balance);
         }
+
+        println!("Postbox:");
+        for transfer in &self.state.postbox.transfers {
+            println!(
+                "  Transfer to {}/{} : {}",
+                transfer.subnet_id, transfer.deposit_address, transfer.amount
+            );
+        }
+        for withdraw in &self.state.postbox.withdraws {
+            println!(
+                "  Withdraw: {} : {}",
+                withdraw.target_address.clone().assume_checked(),
+                withdraw.amount
+            );
+        }
+
+        println!("  Delete: {:?}", self.state.postbox.deletes);
 
         let checkpoint = match self.get_checkpoint() {
             Ok(cp) => cp,

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -7,6 +7,8 @@ use thiserror::Error;
 pub struct Config {
     pub listener_interval: u64,
     pub ipc_finalization_parameter: u64,
+    pub checkpoint_interval: u64,
+    pub postbox_interval: u64,
 }
 
 /// Load environment variables from a .env file


### PR DESCRIPTION
Store all cross-subnet transfers, withdraws and delete in postbox. 
Create interval parameters for checkpointing and reading postbox. 
Have relayer checkpoint every "checkpoint interval" and read the postbox every "postbox  interval" 
Add withdraw and delete functionality to subnet simulator and subnet interactor
Modify transfer functionality to handle destintion addresses prefixed with another subnet id