### PR TITLE
Create basic `createsubnet` RPC method

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,7 @@
+RPC_USER=user
+RPC_PASS=pass
+RPC_URL=http://localhost:18443
+WALLET_NAME=default
+
+PROVIDER_PORT=3030
+PROVIDER_AUTH_TOKEN=xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ default-run = "bitcoin-ipc"
 
 [dependencies]
 tiny-keccak = { version = "2.0.2", features = ["keccak"] }
-bitcoin = "0.32.2"
+bitcoin = { version = "0.32.2", features = ["serde"] }
 bitcoincore-rpc = "0.19.0"
 dotenv = "0.15.0"
 serde = "1.0.203"

--- a/src/bin/provider.rs
+++ b/src/bin/provider.rs
@@ -1,5 +1,3 @@
-use actix_web;
-
 use bitcoin_ipc::provider;
 use bitcoin_ipc::{bitcoin_utils, utils};
 use std::sync::Arc;
@@ -21,8 +19,7 @@ fn make_bitcoincore_rpc() -> Arc<Client> {
         }
     };
     let _ = rpc.load_wallet(&wallet_name);
-    let rpc = Arc::new(rpc);
-    rpc
+    Arc::new(rpc)
 }
 
 #[actix_web::main]

--- a/src/bitcoin_utils.rs
+++ b/src/bitcoin_utils.rs
@@ -13,7 +13,7 @@ use bitcoin::{
     bip32::Xpriv,
     blockdata::{locktime::absolute::LockTime, script, transaction, witness::Witness},
     key::{rand, TapTweak, TweakedPublicKey},
-    opcodes::{all::OP_DROP, OP_TRUE},
+    opcodes::{self, all::OP_DROP, OP_TRUE},
     secp256k1::{schnorr::Signature, Message},
     sighash::{Prevouts, SighashCache},
     taproot::{LeafVersion, TaprootBuilder},
@@ -146,7 +146,6 @@ pub fn init_wallet(
 pub fn test_and_submit(
     rpc: &Client,
     txs: Vec<transaction::Transaction>,
-    miner_address: Address,
 ) -> Result<(), BitcoinUtilsError> {
     let result = match rpc
         .test_mempool_accept(&txs.iter().map(|tx| tx.raw_hex()).collect::<Vec<String>>())
@@ -184,10 +183,6 @@ pub fn test_and_submit(
             rpc.send_raw_transaction(tx.raw_hex())?
         );
     }
-    println!(
-        "Mined new block: {:#?}",
-        rpc.generate_to_address(1, &miner_address)?
-    );
 
     Ok(())
 }
@@ -1127,7 +1122,7 @@ pub fn verify_taproot_signature(
     Ok(false)
 }
 
-fn concatenate_op_push_data(witness: &[u8]) -> Result<Vec<u8>, BitcoinUtilsError> {
+pub fn concatenate_op_push_data(witness: &[u8]) -> Result<Vec<u8>, BitcoinUtilsError> {
     let mut concatenated_data = Vec::new();
 
     let script = ScriptBuf::from(witness.to_vec().clone());
@@ -1153,6 +1148,33 @@ fn concatenate_op_push_data(witness: &[u8]) -> Result<Vec<u8>, BitcoinUtilsError
     }
 
     Ok(concatenated_data)
+}
+
+pub fn create_multisig_address(
+    public_keys: &[XOnlyPublicKey],
+    // TODO should we accept a u8?
+    required_sigs: i64,
+    network: Network,
+) -> Address {
+    // Create a multisig script from the public keys
+    let multisig_script = public_keys
+        .iter()
+        .enumerate()
+        .fold(Builder::new(), |builder, (index, key)| {
+            let builder = builder.push_x_only_key(key);
+            if index == 0 {
+                builder.push_opcode(opcodes::all::OP_CHECKSIG)
+            } else {
+                builder.push_opcode(opcodes::all::OP_CHECKSIGADD)
+            }
+        })
+        // TODO should we fail?
+        .push_int(std::cmp::min(public_keys.len() as i64, required_sigs))
+        .push_opcode(opcodes::all::OP_GREATERTHANOREQUAL)
+        .into_script();
+
+    // TODO decide on the multisig address format: taproot, p2sh or p2wsh
+    Address::p2wsh(&multisig_script, network)
 }
 
 #[derive(Error, Debug)]
@@ -1230,4 +1252,46 @@ pub enum BitcoinUtilsError {
 
     #[error("internal error")]
     Internal,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use bitcoin::secp256k1::{PublicKey, Secp256k1, SecretKey};
+    use bitcoin::{AddressType, Network, XOnlyPublicKey};
+
+    fn generate_xonly_pubkeys(n: usize) -> Vec<XOnlyPublicKey> {
+        let secp = Secp256k1::new();
+        (0..n)
+            .map(|_| {
+                let secret_key = SecretKey::new(&mut rand::thread_rng());
+                let public_key = PublicKey::from_secret_key(&secp, &secret_key);
+                XOnlyPublicKey::from(public_key)
+            })
+            .collect()
+    }
+
+    #[test]
+    fn test_create_multisig_address_single_key() {
+        let public_keys = generate_xonly_pubkeys(1);
+        let required_sigs = 1;
+        let network = Network::Bitcoin;
+
+        let address = create_multisig_address(&public_keys, required_sigs, network);
+
+        assert_eq!(address.address_type(), Some(AddressType::P2wsh));
+    }
+
+    #[test]
+    fn test_create_multisig_address_multiple_keys() {
+        let public_keys = generate_xonly_pubkeys(3);
+        let required_sigs = 2;
+        let network = Network::Bitcoin;
+
+        let address = create_multisig_address(&public_keys, required_sigs, network);
+
+        assert_eq!(address.address_type(), Some(AddressType::P2wsh));
+    }
+
+    // TODO more tests for create_multisig_address
 }

--- a/src/ipc_lib.rs
+++ b/src/ipc_lib.rs
@@ -1,17 +1,8 @@
-use std::collections::{BTreeMap, BTreeSet, HashMap};
-
 use bitcoin::ScriptBuf;
-use bitcoin::{
-    address::NetworkUnchecked, secp256k1::PublicKey, Amount, Transaction, TxOut, XOnlyPublicKey,
-};
+use bitcoin::{Amount, Transaction, TxOut};
 use thiserror::Error;
 
-use crate::{
-    bitcoin_utils::{
-        self, init_rpc_client, init_wallet, test_and_submit, write_arbitrary_data, CommitRevealFee,
-    },
-    utils,
-};
+use crate::bitcoin_utils::{self, test_and_submit, write_arbitrary_data, CommitRevealFee};
 
 /// Creates a child subnet by attaching arbitrary data to a Bitcoin transaction.
 ///
@@ -34,15 +25,12 @@ use crate::{
 /// * `Ok(())` - If the transaction is successfully created and submitted.
 /// * `Err(Box<dyn std::error::Error>)` - If an error occurs during the process.
 pub fn create_and_submit_create_child_tx(
+    rpc: &bitcoincore_rpc::Client,
     subnet_address: &bitcoin::Address,
     subnet_data: &str,
 ) -> Result<(Transaction, Transaction), IpcLibError> {
-    let (rpc_user, rpc_pass, rpc_url, wallet_name) = utils::load_env()?;
-    let rpc = init_rpc_client(rpc_user, rpc_pass, rpc_url)?;
-    let (miner_address, _, _) = init_wallet(&rpc, crate::NETWORK, &wallet_name)?;
-
-    let commit_fee = bitcoin_utils::calculate_fee(&rpc, 2, 3, 65);
-    let reveal_fee = bitcoin_utils::calculate_fee(&rpc, 1, 1, subnet_data.as_bytes().len());
+    let commit_fee = bitcoin_utils::calculate_fee(rpc, 2, 3, 65);
+    let reveal_fee = bitcoin_utils::calculate_fee(rpc, 1, 1, subnet_data.as_bytes().len());
 
     let fee = CommitRevealFee::new(commit_fee, reveal_fee);
 
@@ -52,7 +40,7 @@ pub fn create_and_submit_create_child_tx(
     };
 
     let (commit_tx, reveal_tx) = write_arbitrary_data(
-        &rpc,
+        rpc,
         Amount::ZERO,
         fee,
         subnet_data,
@@ -61,11 +49,7 @@ pub fn create_and_submit_create_child_tx(
         None,
     )?;
 
-    match test_and_submit(
-        &rpc,
-        vec![commit_tx.clone(), reveal_tx.clone()],
-        miner_address,
-    ) {
+    match test_and_submit(rpc, vec![commit_tx.clone(), reveal_tx.clone()]) {
         Ok(_) => Ok((commit_tx, reveal_tx)),
         Err(e) => Err(IpcLibError::BitcoinUtilsError(e)),
     }
@@ -92,27 +76,24 @@ pub fn create_and_submit_create_child_tx(
 /// * `Ok(())` - If the transaction is successfully created and submitted.
 /// * `Err(JoinChildError)` - If an error occurs during the process.
 pub fn create_and_submit_join_child_tx(
+    rpc: &bitcoincore_rpc::Client,
     subnet_address: &bitcoin::Address,
     collateral: Amount,
     initial_funding: Amount,
     validator_data: &str,
 ) -> Result<(), IpcLibError> {
-    let (rpc_user, rpc_pass, rpc_url, wallet_name) = utils::load_env()?;
-    let rpc = init_rpc_client(rpc_user, rpc_pass, rpc_url)?;
-    let (miner_address, _, _) = init_wallet(&rpc, crate::NETWORK, &wallet_name)?;
-
     let output = TxOut {
         value: collateral + initial_funding,
         script_pubkey: subnet_address.script_pubkey(),
     };
 
-    let commit_fee = bitcoin_utils::calculate_fee(&rpc, 2, 3, 65);
-    let reveal_fee = bitcoin_utils::calculate_fee(&rpc, 1, 1, validator_data.as_bytes().len());
+    let commit_fee = bitcoin_utils::calculate_fee(rpc, 2, 3, 65);
+    let reveal_fee = bitcoin_utils::calculate_fee(rpc, 1, 1, validator_data.as_bytes().len());
 
     let fee = CommitRevealFee::new(commit_fee, reveal_fee);
 
     let (commit_tx, reveal_tx) = write_arbitrary_data(
-        &rpc,
+        rpc,
         collateral + initial_funding,
         fee,
         validator_data,
@@ -121,7 +102,7 @@ pub fn create_and_submit_join_child_tx(
         None,
     )?;
 
-    match test_and_submit(&rpc, vec![commit_tx, reveal_tx], miner_address) {
+    match test_and_submit(rpc, vec![commit_tx, reveal_tx]) {
         Ok(_) => Ok(()),
         Err(e) => Err(IpcLibError::BitcoinUtilsError(e)),
     }

--- a/src/provider/rpc.rs
+++ b/src/provider/rpc.rs
@@ -1,16 +1,65 @@
-use crate::utils;
+use crate::{bitcoin_utils::create_multisig_address, utils, NETWORK};
+use bitcoin::{Amount, XOnlyPublicKey};
 use bitcoincore_rpc::{Client, RpcApi};
-use jsonrpc_v2::{Data, Error as JsonRpcError, MapRouter, Params};
+use jsonrpc_v2::{Data, Error as JsonRpcError, ErrorLike, MapRouter, Params};
 use serde::{Deserialize, Serialize};
-use std::sync::Arc;
+use serde_json::json;
+use std::{str::FromStr, sync::Arc};
+use thiserror::Error;
 
 pub type RpcServer = Arc<jsonrpc_v2::Server<MapRouter>>;
+
+#[derive(Error, Debug)]
+pub enum RpcError {
+    #[error("Unauthorized: Invalid token")]
+    Unauthorized,
+
+    #[error("Invalid params: {0}")]
+    InvalidParams(String),
+
+    #[error("Internal server error: {0}")]
+    InternalError(String),
+}
+
+impl ErrorLike for RpcError {
+    fn code(&self) -> i64 {
+        match self {
+            RpcError::Unauthorized => -32001,
+            RpcError::InvalidParams(_) => -32602,
+            RpcError::InternalError(_) => -32603,
+        }
+    }
+
+    fn message(&self) -> String {
+        self.to_string()
+    }
+}
+
+impl actix_web::error::ResponseError for RpcError {
+    fn error_response(&self) -> actix_web::HttpResponse {
+        let json_rpc_error = json!({
+            "jsonrpc": "2.0",
+            "error": {
+                "code": &self.code(),
+                "message": &self.message()
+            },
+            "id": null
+        });
+        actix_web::HttpResponse::Unauthorized()
+            .content_type("application/json")
+            .body(json_rpc_error.to_string())
+    }
+}
 
 #[derive(Clone)]
 pub struct ServerData {
     pub btc_rpc: Arc<Client>,
     pub config: utils::Config,
 }
+
+//
+// Bitcoin RPC
+//
 
 #[derive(Serialize, Deserialize)]
 pub struct GetBlockHashParams {
@@ -25,11 +74,7 @@ pub async fn get_block_hash(
 
     match client.get_block_hash(params.height) {
         Ok(block_hash) => Ok(block_hash.to_string()),
-        Err(e) => Err(JsonRpcError::Full {
-            code: -1,
-            message: e.to_string(),
-            data: None,
-        }),
+        Err(e) => Err(JsonRpcError::internal(e)),
     }
 }
 
@@ -38,11 +83,7 @@ pub async fn get_block_count(data: Data<Arc<ServerData>>) -> Result<u64, JsonRpc
 
     match client.get_block_count() {
         Ok(block_count) => Ok(block_count),
-        Err(e) => Err(JsonRpcError::Full {
-            code: -1,
-            message: e.to_string(),
-            data: None,
-        }),
+        Err(e) => Err(RpcError::InternalError(e.to_string()).into()),
     }
 }
 
@@ -54,29 +95,135 @@ pub async fn get_confirmed_block(data: Data<Arc<ServerData>>) -> Result<String, 
     match client.get_block_count() {
         Ok(current_height) => {
             if current_height < confirmations {
-                return Err(JsonRpcError::Full {
-                    code: -1,
-                    message: "Not enough blocks to have a final block".to_string(),
-                    data: None,
-                });
+                return Err(JsonRpcError::internal(
+                    "Not enough blocks to have a final block",
+                ));
             }
 
             let final_block_height = current_height - confirmations;
             match client.get_block_hash(final_block_height) {
                 Ok(block_hash) => Ok(block_hash.to_string()),
-                Err(e) => Err(JsonRpcError::Full {
-                    code: -1,
-                    message: e.to_string(),
-                    data: None,
-                }),
+                Err(e) => Err(JsonRpcError::internal(e)),
             }
         }
-        Err(e) => Err(JsonRpcError::Full {
-            code: -1,
-            message: e.to_string(),
-            data: None,
-        }),
+        Err(e) => Err(JsonRpcError::internal(e)),
     }
+}
+
+//
+// IPC
+//
+
+#[derive(Serialize, Deserialize)]
+pub struct CreateSubnetParams {
+    /// The minimum number of collateral required for validators in Satoshis
+    min_validator_stake: u64,
+    /// Minimum number of validators required to bootstrap the subnet
+    min_validators: u64,
+    /// The max number of active validators in subnet
+    active_validators_limit: u16,
+    /// The addresses of whitelisted validators
+    whitelist: Vec<String>,
+}
+
+#[derive(Serialize, Deserialize)]
+pub struct CreateSubnetResponse {
+    subnet_id: String,
+}
+
+pub async fn create_subnet(
+    data: Data<Arc<ServerData>>,
+    Params(params): Params<CreateSubnetParams>,
+) -> Result<CreateSubnetResponse, JsonRpcError> {
+    println!("create_subnet");
+
+    if params.min_validators == 0 {
+        return Err(RpcError::InvalidParams(
+            "The minimum number of validators must be greater than 0".to_string(),
+        )
+        .into());
+    }
+
+    if params.whitelist.len() < params.min_validators as usize {
+        return Err(RpcError::InvalidParams(
+            "Number of whitelisted validators is less than the minimum required validators"
+                .to_string(),
+        )
+        .into());
+    }
+
+    // TODO check the maximum size of the multisig signatures
+    let required_sigs: i64 = params.min_validators.try_into().map_err(|_| {
+        RpcError::InvalidParams(format!(
+            "The minimum number of validators must not be greater than {}",
+            i64::MAX
+        ))
+    })?;
+
+    // Parse the min_validator_stake as Amount
+    let min_validator_stake = Amount::from_sat(params.min_validator_stake);
+
+    // Parse the whitelist addresses as XOnlyPublicKey
+    let public_keys: Result<Vec<XOnlyPublicKey>, _> = params
+        .whitelist
+        .iter()
+        .map(|addr| {
+            XOnlyPublicKey::from_str(addr)
+                .map_err(|_e| RpcError::InvalidParams(format!("Public key {} is invalid", &addr)))
+        })
+        .collect();
+
+    // TODO handle errors
+    let public_keys = public_keys?;
+
+    // Create a multisig address from the public keys
+    let multisig_address = create_multisig_address(&public_keys, required_sigs, NETWORK);
+
+    println!("multisig_address: {}", multisig_address);
+
+    // Create the subnet data string
+    let mut subnet_data = String::new();
+    subnet_data.push_str(crate::IPC_CREATE_SUBNET_TAG);
+    subnet_data.push_str(&format!(
+        "{}min_validator_stake={}{}",
+        crate::DELIMITER,
+        min_validator_stake.to_sat(),
+        crate::DELIMITER
+    ));
+    subnet_data.push_str(&format!(
+        "min_validators={}{}",
+        params.min_validators,
+        crate::DELIMITER
+    ));
+    subnet_data.push_str(&format!(
+        "active_validators_limit={}{}",
+        params.active_validators_limit,
+        crate::DELIMITER
+    ));
+    subnet_data.push_str(&format!(
+        "whitelist={}{}",
+        params.whitelist.join(","),
+        crate::DELIMITER
+    ));
+
+    println!("subnet_data: {}", subnet_data);
+
+    // Create and submit the create child transaction
+    let (commit_tx, _) = crate::ipc_lib::create_and_submit_create_child_tx(
+        &data.btc_rpc,
+        &multisig_address,
+        &subnet_data,
+    )
+    .map_err(|e| JsonRpcError::internal(e.to_string()))?;
+
+    // Compute the transaction ID
+    let commit_tx_id: bitcoin::Txid = commit_tx.compute_txid();
+
+    // Generate the subnet ID
+    let subnet_id = format!("{}/{}", crate::L1_NAME, commit_tx_id);
+
+    // Return the response
+    Ok(CreateSubnetResponse { subnet_id })
 }
 
 pub fn make_rpc_server(server_data: Arc<ServerData>) -> RpcServer {
@@ -85,5 +232,6 @@ pub fn make_rpc_server(server_data: Arc<ServerData>) -> RpcServer {
         .with_method("getblockhash", get_block_hash)
         .with_method("getblockcount", get_block_count)
         .with_method("getconfirmedblock", get_confirmed_block)
+        .with_method("createsubnet", create_subnet)
         .finish()
 }

--- a/src/provider/rpc.rs
+++ b/src/provider/rpc.rs
@@ -120,8 +120,12 @@ pub struct CreateSubnetParams {
     min_validator_stake: u64,
     /// Minimum number of validators required to bootstrap the subnet
     min_validators: u64,
+    /// The bottom up checkpoint period in number of blocks
+    bottomup_check_period: u64,
     /// The max number of active validators in subnet
     active_validators_limit: u16,
+    /// Minimum fee for cross-net messages in subnet (in Satoshis)
+    min_cross_msg_fee: Amount,
     /// The addresses of whitelisted validators
     whitelist: Vec<String>,
 }
@@ -181,30 +185,33 @@ pub async fn create_subnet(
 
     println!("multisig_address: {}", multisig_address);
 
+    let mut params_map = std::collections::HashMap::new();
+    params_map.insert(
+        "min_validator_stake",
+        min_validator_stake.to_sat().to_string(),
+    );
+    params_map.insert("min_validators", params.min_validators.to_string());
+    params_map.insert(
+        "bottomup_check_period",
+        params.bottomup_check_period.to_string(),
+    );
+    params_map.insert(
+        "active_validators_limit",
+        params.active_validators_limit.to_string(),
+    );
+    params_map.insert(
+        "min_cross_msg_fee",
+        params.min_cross_msg_fee.to_sat().to_string(),
+    );
+    params_map.insert("whitelist", params.whitelist.join(","));
+
     // Create the subnet data string
     let mut subnet_data = String::new();
     subnet_data.push_str(crate::IPC_CREATE_SUBNET_TAG);
-    subnet_data.push_str(&format!(
-        "{}min_validator_stake={}{}",
-        crate::DELIMITER,
-        min_validator_stake.to_sat(),
-        crate::DELIMITER
-    ));
-    subnet_data.push_str(&format!(
-        "min_validators={}{}",
-        params.min_validators,
-        crate::DELIMITER
-    ));
-    subnet_data.push_str(&format!(
-        "active_validators_limit={}{}",
-        params.active_validators_limit,
-        crate::DELIMITER
-    ));
-    subnet_data.push_str(&format!(
-        "whitelist={}{}",
-        params.whitelist.join(","),
-        crate::DELIMITER
-    ));
+
+    for (key, value) in &params_map {
+        subnet_data.push_str(&format!("{}{}={}", crate::DELIMITER, key, value));
+    }
 
     println!("subnet_data: {}", subnet_data);
 

--- a/src/provider/server.rs
+++ b/src/provider/server.rs
@@ -1,37 +1,9 @@
-use serde::{Deserialize, Serialize};
-use serde_json::json;
 use std::sync::Arc;
-use thiserror::Error;
 
 use actix_web_httpauth::extractors::bearer::BearerAuth;
 use actix_web_httpauth::middleware::HttpAuthentication;
 
 use super::rpc;
-
-#[derive(Serialize, Deserialize)]
-pub enum CustomRPCErrorCode {
-    Unauthorized = -32001,
-}
-
-#[derive(Debug, Error)]
-#[error("Unauthorized: Invalid token")]
-struct UnauthorizedError;
-
-impl actix_web::error::ResponseError for UnauthorizedError {
-    fn error_response(&self) -> actix_web::HttpResponse {
-        let json_rpc_error = json!({
-            "jsonrpc": "2.0",
-            "error": {
-                "code": CustomRPCErrorCode::Unauthorized,
-                "message": "Unauthorized: Invalid token"
-            },
-            "id": null
-        });
-        actix_web::HttpResponse::Unauthorized()
-            .content_type("application/json")
-            .body(json_rpc_error.to_string())
-    }
-}
 
 async fn auth_guard(
     req: actix_web::dev::ServiceRequest,
@@ -39,14 +11,14 @@ async fn auth_guard(
     token: String,
 ) -> Result<actix_web::dev::ServiceRequest, (actix_web::Error, actix_web::dev::ServiceRequest)> {
     let Some(credentials) = credentials else {
-        return Err((UnauthorizedError.into(), req));
+        return Err((rpc::RpcError::Unauthorized.into(), req));
     };
 
     let provided_token = credentials.token();
     if provided_token == token {
         Ok(req)
     } else {
-        Err((UnauthorizedError.into(), req))
+        Err((rpc::RpcError::Unauthorized.into(), req))
     }
 }
 
@@ -103,6 +75,7 @@ mod tests {
     use actix_web::test::TestRequest;
     use actix_web::FromRequest;
     use actix_web_httpauth::extractors::bearer::BearerAuth;
+    use serde_json::json;
 
     async fn bearer_token(token: &str) -> BearerAuth {
         let req =
@@ -126,7 +99,7 @@ mod tests {
             let expected_body = json!({
                 "jsonrpc": "2.0",
                 "error": {
-                    "code": CustomRPCErrorCode::Unauthorized,
+                    "code": -32001,
                     "message": "Unauthorized: Invalid token"
                 },
                 "id": null


### PR DESCRIPTION
Opens a basic `createsubnet` RPC method. To test, do the following:

0. Run `bitcoind` regtest. Make sure your wallet is loaded and funded.
```sh
bitcoin-cli loadwallet default # or another name, make sure it matches the .env file
bitcoin-cli getnewaddress "" bech32 # grab the address
bitcoin-cli generatetoaddress 1 $addr
```
2. Add the following to `.env`. See `.env.example` for a full list.
```sh
PROVIDER_PORT=3030
PROVIDER_AUTH_TOKEN=xxx # any auth token you'd like
```

3. Run `cargo run --bin provider`. You should see the printed address of the provider.
4.  Use `curl` or similar to test the RPC. Use your auth token in the auth header.
```sh
curl -X POST http://localhost:3030/api \
    -H "Content-Type: application/json" \
    -H "Authorization: Bearer asda123123jhaskjdhgbjsjhdj" \
    -d '{
    "jsonrpc": "2.0",
    "method": "createsubnet",
    "params": {
    "min_validator_stake": 100000000,
    "min_validators": 3,
    "bottomup_check_period": 5,
    "active_validators_limit": 10,
    "min_cross_msg_fee": 200,
    "whitelist": [
        "18845781f631c48f1c9709e23092067d06837f30aa0cd0544ac887fe91ddd166",
        "6a6538f93a1ae66a2b68aad837dbf3ce97010ecafbed440b79ab798cf28984df",
        "1dc9a71014974bcf298f71fbcfffa42e891d3f5376baa712f7379909a05b6be7"
    ]
    },
    "id": 1
}'
```

You should see the subnet id in the response, and additional data printed by the server.

Next up:
- Add docs on running the provider to README
- Discuss on how to construct the multisig