### PR TITLE
Create taproot multisig for subnet validators

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -425,6 +425,8 @@ dependencies = [
  "ipc_serde",
  "jsonrpc-v2",
  "log",
+ "num-bigint",
+ "num-traits",
  "rand",
  "serde",
  "serde_json",
@@ -1332,10 +1334,38 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-bigint"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
+dependencies = [
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
 name = "num-conv"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
+
+[[package]]
+name = "num-integer"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "num-traits"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
+dependencies = [
+ "autocfg",
+]
 
 [[package]]
 name = "object"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -417,6 +417,7 @@ dependencies = [
  "actix-web-httpauth",
  "async-trait",
  "bitcoin",
+ "bitcoinconsensus",
  "bitcoincore-rpc",
  "dotenv",
  "env_logger",
@@ -455,6 +456,15 @@ dependencies = [
  "bitcoin-io",
  "hex-conservative",
  "serde",
+]
+
+[[package]]
+name = "bitcoinconsensus"
+version = "0.106.0+26.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e12cba9cce5043cdda968e07b9df6d05ec6b0b38aa27a9a40bb575cf3e521ae9"
+dependencies = [
+ "cc",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,3 +24,5 @@ ipc_serde = { path = "ipc_serde" }
 async-trait = "0.1.83"
 heed = "0.21.0"
 tokio-util = "0.7.13"
+num-traits = "0.2.19"
+num-bigint = "0.4.6"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,3 +26,6 @@ heed = "0.21.0"
 tokio-util = "0.7.13"
 num-traits = "0.2.19"
 num-bigint = "0.4.6"
+
+[dev-dependencies]
+bitcoinconsensus = "0.106.0"

--- a/src/bin/monitor.rs
+++ b/src/bin/monitor.rs
@@ -307,6 +307,12 @@ where
 
                 let subnet_id = ipc_lib::subnet_id_from_txid(txid);
 
+                let multisig_addr = create_subnet_params
+                    .multisig_address_from_whitelist()
+                    .map_err(|e| MonitorError::IpcMsgError(e.to_string()))?;
+
+                debug!("multisig_address: {}", multisig_addr);
+
                 debug!(
                     "block={} subnet_id={} msg={:?}",
                     block_height, subnet_id, create_subnet_params
@@ -342,6 +348,10 @@ fn find_valid_utf8(data: &[u8]) -> &str {
 pub enum MonitorError {
     #[error("Current block height ahead of tip. Latest: {0}. Current: {1}")]
     BlockHeightAheadOfTip(u64, u64),
+
+    // TODO better errors
+    #[error("Error processing IPC message: {0}")]
+    IpcMsgError(String),
 
     #[error(transparent)]
     DbError(#[from] db::DbError),

--- a/src/bitcoin_utils.rs
+++ b/src/bitcoin_utils.rs
@@ -4,6 +4,10 @@ use std::cmp::min;
 use std::vec;
 use thiserror::Error;
 
+use bitcoin::key::UntweakedPublicKey;
+use num_bigint::BigUint;
+use num_traits::ops::bytes::ToBytes;
+
 use bitcoin::blockdata::script::Builder;
 use bitcoin::blockdata::transaction::{OutPoint, Transaction, TxIn, TxOut};
 use bitcoin::script::{Instruction, PushBytes};
@@ -60,12 +64,29 @@ pub const fn confirmations(network: Network) -> u64 {
 /// # Returns
 ///
 /// * `XOnlyPublicKey` - An unspendable internal key
-pub fn create_unspendable_internal_key(secp: &Secp256k1<All>) -> XOnlyPublicKey {
+pub fn create_random_unspendable_internal_key(secp: &Secp256k1<All>) -> XOnlyPublicKey {
     let secret_key =
         bitcoin::secp256k1::SecretKey::new(&mut bitcoin::secp256k1::rand::thread_rng());
     let keypair = Keypair::from_secret_key(secp, &secret_key);
     let (x_only_pubkey, _parity) = XOnlyPublicKey::from_keypair(&keypair);
     x_only_pubkey
+}
+
+pub fn create_unspendable_internal_key() -> XOnlyPublicKey {
+    // the Gx of SECP, incremented till a valid x is found
+    // See
+    // https://github.com/bitcoin/bips/blob/master/bip-0341.mediawiki#constructing-and-spending-taproot-outputs,
+    // bullet 3, for a proper way to choose such a key
+    let nothing_up_my_sleeve_key = [
+        0x79, 0xBE, 0x66, 0x7E, 0xF9, 0xDC, 0xBB, 0xAC, 0x55, 0xA0, 0x62, 0x95, 0xCE, 0x87, 0x0B,
+        0x07, 0x02, 0x9B, 0xFC, 0xDB, 0x2D, 0xCE, 0x28, 0xD9, 0x59, 0xF2, 0x81, 0x5B, 0x16, 0xF8,
+        0x17, 0x99,
+    ];
+    let mut int_key = BigUint::from_bytes_be(&nothing_up_my_sleeve_key);
+    while UntweakedPublicKey::from_slice(&int_key.to_be_bytes()).is_err() {
+        int_key += 1u32;
+    }
+    UntweakedPublicKey::from_slice(&int_key.to_be_bytes()).unwrap()
 }
 
 pub fn make_rpc_client_from_env() -> Client {
@@ -281,7 +302,7 @@ pub fn commit_arbitrary_data(
     secp: &Secp256k1<All>,
 ) -> Result<(Transaction, ScriptBuf, TaprootSpendInfo), BitcoinUtilsError> {
     // this transaction can only be spent through the script path
-    let unspendable_pubkey = create_unspendable_internal_key(secp);
+    let unspendable_pubkey = create_random_unspendable_internal_key(secp);
 
     let mut builder = Builder::new();
     let mut offset = 0;
@@ -1126,12 +1147,16 @@ pub fn concatenate_op_push_data(witness: &[u8]) -> Result<Vec<u8>, BitcoinUtilsE
     Ok(concatenated_data)
 }
 
-pub fn create_multisig_address(
+pub fn create_multisig_spend_info(
+    secp: &Secp256k1<All>,
     public_keys: &[XOnlyPublicKey],
-    // TODO should we accept a u8?
     required_sigs: i64,
-    network: Network,
-) -> Address {
+) -> Result<TaprootSpendInfo, BitcoinUtilsError> {
+    // check if enough public keys are provided
+    if (public_keys.len() as i64) < required_sigs {
+        return Err(BitcoinUtilsError::InsufficientPublicKeys);
+    }
+
     // Create a multisig script from the public keys
     let multisig_script = public_keys
         .iter()
@@ -1149,10 +1174,32 @@ pub fn create_multisig_address(
         .push_opcode(opcodes::all::OP_GREATERTHANOREQUAL)
         .into_script();
 
-    // TODO decide on the multisig address format: taproot, p2sh or p2wsh
-    Address::p2wsh(&multisig_script, network)
+    let builder = TaprootBuilder::with_huffman_tree(vec![(1, multisig_script)])?;
+    let internal_key = create_unspendable_internal_key();
+    let spend_info = builder
+        .finalize(secp, internal_key)
+        .map_err(|_| BitcoinUtilsError::TaprootBuilderNotFinalizable)?;
+
+    Ok(spend_info)
 }
 
+pub fn create_multisig_address(
+    secp: &Secp256k1<All>,
+    public_keys: &[XOnlyPublicKey],
+    required_sigs: i64,
+    network: Network,
+) -> Result<Address, BitcoinUtilsError> {
+    let spend_info = create_multisig_spend_info(secp, public_keys, required_sigs)?;
+
+    Ok(Address::p2tr(
+        secp,
+        spend_info.internal_key(),
+        spend_info.merkle_root(),
+        network,
+    ))
+}
+
+// TODO decouple errors
 #[derive(Error, Debug)]
 pub enum BitcoinUtilsError {
     #[error("cannot connect to the bitcoin node")]
@@ -1171,6 +1218,12 @@ pub enum BitcoinUtilsError {
 
     #[error("an error related to the BIP32 specification occured")]
     Bip32Error(#[from] bitcoin::bip32::Error),
+
+    #[error("insufficient public keys provided")]
+    InsufficientPublicKeys,
+
+    #[error("taproot builder is not finalizable")]
+    TaprootBuilderNotFinalizable,
 
     #[error("an error occured when building a taproot transaction")]
     TaprootBuilderError(#[from] bitcoin::taproot::TaprootBuilderError),
@@ -1233,8 +1286,10 @@ pub enum BitcoinUtilsError {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use bitcoin::secp256k1::{PublicKey, Secp256k1, SecretKey};
-    use bitcoin::{AddressType, Network, XOnlyPublicKey};
+    use bitcoin::{
+        secp256k1::{PublicKey, Secp256k1, SecretKey},
+        AddressType,
+    };
 
     fn generate_xonly_pubkeys(n: usize) -> Vec<XOnlyPublicKey> {
         let secp = Secp256k1::new();
@@ -1249,25 +1304,42 @@ mod tests {
 
     #[test]
     fn test_create_multisig_address_single_key() {
+        let secp = Secp256k1::new();
         let public_keys = generate_xonly_pubkeys(1);
         let required_sigs = 1;
         let network = Network::Bitcoin;
 
-        let address = create_multisig_address(&public_keys, required_sigs, network);
+        let address = create_multisig_address(&secp, &public_keys, required_sigs, network)
+            .expect("Failed to create multisig address");
 
-        assert_eq!(address.address_type(), Some(AddressType::P2wsh));
+        assert_eq!(address.address_type(), Some(AddressType::P2tr));
     }
 
     #[test]
     fn test_create_multisig_address_multiple_keys() {
+        let secp = Secp256k1::new();
         let public_keys = generate_xonly_pubkeys(3);
         let required_sigs = 2;
         let network = Network::Bitcoin;
 
-        let address = create_multisig_address(&public_keys, required_sigs, network);
+        let address = create_multisig_address(&secp, &public_keys, required_sigs, network)
+            .expect("Failed to create multisig address");
 
-        assert_eq!(address.address_type(), Some(AddressType::P2wsh));
+        assert_eq!(address.address_type(), Some(AddressType::P2tr));
     }
 
-    // TODO more tests for create_multisig_address
+    #[test]
+    fn test_create_multisig_address_insufficient_keys() {
+        let secp = Secp256k1::new();
+        let public_keys = generate_xonly_pubkeys(1);
+        let required_sigs = 2; // More signatures required than keys available
+        let network = Network::Bitcoin;
+
+        let result = create_multisig_address(&secp, &public_keys, required_sigs, network);
+
+        assert!(matches!(
+            result,
+            Err(BitcoinUtilsError::InsufficientPublicKeys)
+        ));
+    }
 }

--- a/src/bitcoin_utils.rs
+++ b/src/bitcoin_utils.rs
@@ -1147,18 +1147,16 @@ pub fn concatenate_op_push_data(witness: &[u8]) -> Result<Vec<u8>, BitcoinUtilsE
     Ok(concatenated_data)
 }
 
-pub fn create_multisig_spend_info(
-    secp: &Secp256k1<All>,
+pub fn create_multisig_script(
     public_keys: &[XOnlyPublicKey],
     required_sigs: i64,
-) -> Result<TaprootSpendInfo, BitcoinUtilsError> {
+) -> Result<ScriptBuf, BitcoinUtilsError> {
     // check if enough public keys are provided
     if (public_keys.len() as i64) < required_sigs {
         return Err(BitcoinUtilsError::InsufficientPublicKeys);
     }
 
-    // Create a multisig script from the public keys
-    let multisig_script = public_keys
+    Ok(public_keys
         .iter()
         .enumerate()
         .fold(Builder::new(), |builder, (index, key)| {
@@ -1169,10 +1167,17 @@ pub fn create_multisig_spend_info(
                 builder.push_opcode(opcodes::all::OP_CHECKSIGADD)
             }
         })
-        // TODO should we fail?
-        .push_int(std::cmp::min(public_keys.len() as i64, required_sigs))
+        .push_int(required_sigs)
         .push_opcode(opcodes::all::OP_GREATERTHANOREQUAL)
-        .into_script();
+        .into_script())
+}
+
+pub fn create_multisig_spend_info(
+    secp: &Secp256k1<All>,
+    public_keys: &[XOnlyPublicKey],
+    required_sigs: i64,
+) -> Result<TaprootSpendInfo, BitcoinUtilsError> {
+    let multisig_script = create_multisig_script(public_keys, required_sigs)?;
 
     let builder = TaprootBuilder::with_huffman_tree(vec![(1, multisig_script)])?;
     let internal_key = create_unspendable_internal_key();
@@ -1286,10 +1291,53 @@ pub enum BitcoinUtilsError {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use bitcoin::consensus::encode;
+    use bitcoin::hashes::Hash;
+    use bitcoin::sighash::{Prevouts, SighashCache, TapSighashType};
+    use bitcoin::taproot::LeafVersion;
     use bitcoin::{
+        absolute::LockTime,
         secp256k1::{PublicKey, Secp256k1, SecretKey},
-        AddressType,
+        AddressType, Amount, Network, Sequence, Transaction, TxIn, TxOut, Witness,
     };
+
+    /// Verifies that this transaction is able to spend its inputs.
+    ///
+    /// The `spent` closure should return the [`TxOut`] for the given [`OutPoint`] (the ones we're spending).
+    /// The `spent` closure should not return the same [`TxOut`] twice!
+    pub fn verify_transaction<S>(
+        tx: &Transaction,
+        mut spent: S,
+    ) -> Result<(), bitcoinconsensus::Error>
+    where
+        S: FnMut(&OutPoint) -> Option<TxOut>,
+    {
+        let serialized_tx = encode::serialize(tx);
+        for (idx, input) in tx.input.iter().enumerate() {
+            if let Some(output) = spent(&input.previous_output) {
+                // duplicating the same output because bitcoinconsensus is weird
+                // this is needed for taproot verification
+                let spent_utxo = bitcoinconsensus::Utxo {
+                    script_pubkey: output.script_pubkey.as_bytes().as_ptr(),
+                    script_pubkey_len: output.script_pubkey.len() as u32,
+                    value: output.value.to_sat() as i64,
+                };
+
+                bitcoinconsensus::verify_with_flags(
+                    &output.script_pubkey.as_bytes(),
+                    output.value.to_sat(),
+                    serialized_tx.as_slice(),
+                    Some(&vec![spent_utxo]),
+                    idx,
+                    bitcoinconsensus::VERIFY_ALL_PRE_TAPROOT | bitcoinconsensus::VERIFY_TAPROOT,
+                )?;
+            } else {
+                println!("Unknown spent output: {:?}", input.previous_output);
+                panic!("Unknown spent output");
+            }
+        }
+        Ok(())
+    }
 
     fn generate_xonly_pubkeys(n: usize) -> Vec<XOnlyPublicKey> {
         let secp = Secp256k1::new();
@@ -1298,6 +1346,16 @@ mod tests {
                 let secret_key = SecretKey::new(&mut rand::thread_rng());
                 let public_key = PublicKey::from_secret_key(&secp, &secret_key);
                 XOnlyPublicKey::from(public_key)
+            })
+            .collect()
+    }
+
+    fn generate_keypairs(n: usize) -> Vec<Keypair> {
+        let secp = Secp256k1::new();
+        (0..n)
+            .map(|_| {
+                let secret_key = SecretKey::new(&mut rand::thread_rng());
+                Keypair::from_secret_key(&secp, &secret_key)
             })
             .collect()
     }
@@ -1341,5 +1399,245 @@ mod tests {
             result,
             Err(BitcoinUtilsError::InsufficientPublicKeys)
         ));
+    }
+
+    //
+    // Test spending
+    //
+
+    #[test]
+    fn test_spend_multisig_script() {
+        let secp = Secp256k1::new();
+
+        //
+        // Setup: Create 3-of-5 multisig
+        //
+
+        let keypairs = generate_keypairs(5);
+        let public_keys: Vec<XOnlyPublicKey> =
+            keypairs.iter().map(|kp| kp.x_only_public_key().0).collect();
+
+        let required_sigs = 3;
+        let network = Network::Regtest;
+
+        let script = create_multisig_script(&public_keys, required_sigs)
+            .expect("Failed to create multisig script");
+
+        let spend_info = create_multisig_spend_info(&secp, &public_keys, required_sigs)
+            .expect("Failed to create multisig spend info");
+
+        let control_block = spend_info
+            .control_block(&(script.clone(), LeafVersion::TapScript))
+            .expect("Should create control block");
+
+        let multisig_address = create_multisig_address(&secp, &public_keys, required_sigs, network)
+            .expect("Failed to create multisig address");
+
+        //
+        // Create funding transaction
+        //
+
+        let funding_amount = Amount::from_sat(100_000);
+        let funding_tx = Transaction {
+            version: transaction::Version::TWO,
+            lock_time: LockTime::ZERO,
+            input: vec![TxIn {
+                previous_output: OutPoint {
+                    txid: Txid::all_zeros(),
+                    vout: 0,
+                },
+                script_sig: ScriptBuf::new(),
+                sequence: Sequence::MAX,
+                witness: Witness::new(),
+            }],
+            output: vec![TxOut {
+                value: funding_amount,
+                script_pubkey: multisig_address.script_pubkey(),
+            }],
+        };
+        let funding_txid = funding_tx.compute_txid();
+
+        //
+        // Create spending transaction
+        //
+
+        let spending_amount = Amount::from_sat(90_000);
+        let spending_tx = Transaction {
+            version: transaction::Version::TWO,
+            lock_time: LockTime::ZERO,
+            input: vec![TxIn {
+                previous_output: OutPoint {
+                    txid: funding_txid,
+                    vout: 0,
+                },
+                script_sig: ScriptBuf::new(),
+                sequence: Sequence::MAX,
+                witness: Witness::new(),
+            }],
+            output: vec![TxOut {
+                value: spending_amount,
+                script_pubkey: ScriptBuf::new_op_return(&[1]),
+            }],
+        };
+
+        //
+        //  Create sighash for signing
+        //
+
+        let mut sighash_cache = SighashCache::new(&spending_tx);
+        let leaf_hash = script.tapscript_leaf_hash();
+        let sighash = sighash_cache
+            .taproot_script_spend_signature_hash(
+                0,
+                &Prevouts::All(&[funding_tx.output[0].clone()]),
+                leaf_hash,
+                TapSighashType::Default,
+            )
+            .expect("Failed to create sighash");
+
+        //
+        // Case 1: Not enough signatures (only 2)
+        //
+
+        {
+            let mut tx_insufficient = spending_tx.clone();
+            let mut witness = Witness::new();
+
+            // Sign with only 2 keys
+            for keypair in keypairs.iter().take(2) {
+                let msg =
+                    Message::from_digest_slice(sighash.as_ref()).expect("Failed to create message");
+                let sig = secp.sign_schnorr(&msg, keypair);
+                witness.push(sig.serialize());
+            }
+
+            // Push empty signatures for the remaining keys
+            for _ in 2..keypairs.len() {
+                witness.push(&[]); // Empty signature slots for unused keys
+            }
+
+            witness.push(&script.to_bytes());
+            witness.push(control_block.serialize());
+
+            tx_insufficient.input[0].witness = witness;
+
+            let verify_result =
+                verify_transaction(&tx_insufficient, |_| Some(funding_tx.output[0].clone()));
+
+            dbg!(&verify_result);
+
+            assert!(
+                verify_result.is_err(),
+                "Transaction with insufficient signatures should fail"
+            );
+        }
+
+        //
+        // Case 2: Valid spend with required signatures (3 of 3)
+        //
+        {
+            let mut tx_valid = spending_tx.clone();
+            let mut witness = Witness::new();
+
+            // Sign with 3 keys
+            for (idx, keypair) in keypairs.iter().rev().enumerate() {
+                // Skip keys 4 and 5, pushing empty signatures
+                if idx > 2 {
+                    witness.push(&[]);
+                    continue;
+                }
+                let msg =
+                    Message::from_digest_slice(sighash.as_ref()).expect("Failed to create message");
+                let sig = secp.sign_schnorr(&msg, keypair);
+                witness.push(sig.serialize());
+            }
+
+            witness.push(&script.to_bytes());
+            witness.push(control_block.serialize());
+
+            tx_valid.input[0].witness = witness;
+
+            let verify_result =
+                verify_transaction(&tx_valid, |_| Some(funding_tx.output[0].clone()));
+
+            dbg!(&verify_result);
+
+            assert!(
+                verify_result.is_ok(),
+                "Transaction with sufficient signatures should pass"
+            );
+        }
+
+        //
+        // Case 3: Valid spend with all signatures
+        //
+        {
+            let mut tx_all = spending_tx.clone();
+            let mut witness = Witness::new();
+
+            // Sign with all keys
+            for keypair in keypairs.iter().rev() {
+                let msg =
+                    Message::from_digest_slice(sighash.as_ref()).expect("Failed to create message");
+                let sig = secp.sign_schnorr(&msg, keypair);
+                witness.push(sig.serialize());
+            }
+
+            witness.push(&script.to_bytes());
+            witness.push(control_block.serialize());
+
+            tx_all.input[0].witness = witness;
+
+            let verify_result = verify_transaction(&tx_all, |_| Some(funding_tx.output[0].clone()));
+
+            dbg!(&verify_result);
+
+            assert!(
+                verify_result.is_ok(),
+                "Transaction with all signatures should pass"
+            );
+        }
+
+        //
+        // Case 4: Wrong signature order
+        //
+        {
+            let mut tx_wrong_order = spending_tx.clone();
+            let mut witness = Witness::new();
+
+            // Sign with 3 keys but push signatures in wrong order
+            for keypair in keypairs.iter().take(3).rev() {
+                // Reverse order
+                let msg =
+                    Message::from_digest_slice(sighash.as_ref()).expect("Failed to create message");
+                let sig = secp.sign_schnorr(&msg, keypair);
+                witness.push(sig.serialize());
+            }
+
+            // Push empty signatures for the remaining keys
+            for _ in 3..keypairs.len() {
+                witness.push(&[]); // Empty signature slots for unused keys
+            }
+
+            witness.push(&script.to_bytes());
+            witness.push(
+                spend_info
+                    .control_block(&(script.clone(), LeafVersion::TapScript))
+                    .unwrap()
+                    .serialize(),
+            );
+
+            tx_wrong_order.input[0].witness = witness;
+
+            let verify_result =
+                verify_transaction(&tx_wrong_order, |_| Some(funding_tx.output[0].clone()));
+
+            dbg!(&verify_result);
+
+            assert!(
+                verify_result.is_err(),
+                "Transaction with wrong signature order should fail"
+            );
+        }
     }
 }

--- a/src/ipc_lib.rs
+++ b/src/ipc_lib.rs
@@ -5,7 +5,10 @@ use serde::{Deserialize, Serialize};
 use std::str::FromStr;
 use thiserror::Error;
 
-use crate::bitcoin_utils::{self, test_and_submit, write_arbitrary_data, CommitRevealFee};
+use crate::bitcoin_utils::{
+    self, create_multisig_address, test_and_submit, write_arbitrary_data, CommitRevealFee,
+};
+use crate::NETWORK;
 
 // Temporary prelude module to re-export the necessary types
 pub mod prelude {
@@ -93,7 +96,7 @@ pub struct IpcCreateSubnetMsg {
     /// The minimum number of collateral required for validators in Satoshis
     pub min_validator_stake: u64,
     /// Minimum number of validators required to bootstrap the subnet
-    pub min_validators: u64,
+    pub min_validators: u16,
     /// The bottom up checkpoint period in number of blocks
     pub bottomup_check_period: u64,
     /// The max number of active validators in subnet
@@ -103,6 +106,21 @@ pub struct IpcCreateSubnetMsg {
     pub min_cross_msg_fee: Amount,
     /// The addresses of whitelisted validators
     pub whitelist: Vec<XOnlyPublicKey>,
+}
+
+impl IpcCreateSubnetMsg {
+    /// Creates a multisig address from the whitelisted public keys
+    pub fn multisig_address_from_whitelist(&self) -> Result<bitcoin::Address, IpcLibError> {
+        let secp = bitcoin::secp256k1::Secp256k1::new();
+        let multisig_address = create_multisig_address(
+            &secp,
+            &self.whitelist.clone(),
+            self.min_validators.into(),
+            NETWORK,
+        )?;
+
+        Ok(multisig_address)
+    }
 }
 
 impl IpcValidate for IpcCreateSubnetMsg {
@@ -129,7 +147,7 @@ impl IpcValidate for IpcCreateSubnetMsg {
             ));
         }
 
-        if (self.active_validators_limit as u64) < self.min_validators {
+        if self.active_validators_limit < self.min_validators {
             return Err(IpcValidateError::InvalidField(
                 "active_validators_limit",
                 "Must be greater than or equal to min_validators".to_string(),

--- a/src/provider/rpc.rs
+++ b/src/provider/rpc.rs
@@ -1,7 +1,6 @@
 use crate::{
-    bitcoin_utils::create_multisig_address,
     ipc_lib::{self, IpcValidate},
-    IpcCreateSubnetMsg, IpcSerialize, BTC_CONFIRMATIONS, NETWORK,
+    IpcCreateSubnetMsg, IpcSerialize, BTC_CONFIRMATIONS,
 };
 use bitcoincore_rpc::{Client, RpcApi};
 use jsonrpc_v2::{Data, Error as JsonRpcError, ErrorLike, MapRouter, Params};
@@ -142,17 +141,12 @@ pub async fn create_subnet(
         return Err(RpcError::InvalidParams(err.to_string()).into());
     }
 
-    // TODO check the maximum size of the multisig signatures
-    let required_sigs: i64 = params.min_validators.try_into().map_err(|_| {
+    let multisig_address = params.multisig_address_from_whitelist().map_err(|e| {
         RpcError::InvalidParams(format!(
-            "The minimum number of validators must not be greater than {}",
-            i64::MAX
+            "There was an error creating the multisig address: {}",
+            e
         ))
     })?;
-
-    // Create a multisig address from the public keys
-    let multisig_address = create_multisig_address(&params.whitelist, required_sigs, NETWORK);
-
     debug!("multisig_address: {}", multisig_address);
 
     let subnet_data = params.ipc_serialize();

--- a/src/provider/rpc.rs
+++ b/src/provider/rpc.rs
@@ -114,6 +114,17 @@ pub async fn get_confirmed_block(data: Data<Arc<ServerData>>) -> Result<String, 
     }
 }
 
+/// Get the balance of the wallet in Satoshis
+/// Note: Bitcoin Core RPC returns the balance in BTC (using f64)
+pub async fn get_balance(data: Data<Arc<ServerData>>) -> Result<u64, JsonRpcError> {
+    let client = data.btc_rpc.as_ref();
+
+    match client.get_balance(None, None) {
+        Ok(balance) => Ok(balance.to_sat()),
+        Err(e) => Err(JsonRpcError::internal(e)),
+    }
+}
+
 //
 // IPC
 //
@@ -171,6 +182,7 @@ pub fn make_rpc_server(server_data: Arc<ServerData>) -> RpcServer {
         .with_method("getblockhash", get_block_hash)
         .with_method("getblockcount", get_block_count)
         .with_method("getconfirmedblock", get_confirmed_block)
+        .with_method("getbalance", get_balance)
         .with_method("createsubnet", create_subnet)
         .finish()
 }


### PR DESCRIPTION
@themicp @OrestisAlpos let me know how this looks. One thing to note is that for the same list of public keys, the address will be the same regardless of the subnet id. Would this complicate things? I assume so, if ever the same validators want to spin another subnet. We could add a new tapleaf with `OP_RETURN` and the subnet id? It would make using the multisig a bit more expensive because we'll need to provide the hash. Let me know if this is something we might need.

I also sneaked in a new RPC method, `getbalance`. 🫢 It returns the number of satoshis (`u64`) and not number of bitcoins (`f64`) which I think is better for usage in the IPC codebase. 