### PR TITLE
Join subnet

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -35,7 +35,7 @@ dependencies = [
  "brotli",
  "bytes",
  "bytestring",
- "derive_more",
+ "derive_more 0.99.18",
  "encoding_rs",
  "flate2",
  "futures-core",
@@ -65,7 +65,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e01ed3140b2f8d422c68afa1ed2e85d996ea619c988ac834d255db32138655cb"
 dependencies = [
  "quote",
- "syn",
+ "syn 2.0.91",
 ]
 
 [[package]]
@@ -151,7 +151,7 @@ dependencies = [
  "bytestring",
  "cfg-if",
  "cookie",
- "derive_more",
+ "derive_more 0.99.18",
  "encoding_rs",
  "futures-core",
  "futures-util",
@@ -182,7 +182,7 @@ dependencies = [
  "actix-router",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.91",
 ]
 
 [[package]]
@@ -253,6 +253,43 @@ dependencies = [
 ]
 
 [[package]]
+name = "alloy-primitives"
+version = "0.8.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec878088ec6283ce1e90d280316aadd3d6ce3de06ff63d68953c855e7e447e92"
+dependencies = [
+ "alloy-rlp",
+ "bytes",
+ "cfg-if",
+ "const-hex",
+ "derive_more 1.0.0",
+ "foldhash",
+ "hashbrown",
+ "indexmap",
+ "itoa",
+ "k256",
+ "keccak-asm",
+ "paste",
+ "proptest",
+ "rand",
+ "ruint",
+ "rustc-hash",
+ "serde",
+ "sha3",
+ "tiny-keccak",
+]
+
+[[package]]
+name = "alloy-rlp"
+version = "0.3.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d6c1d995bff8d011f7cd6c81820d51825e6e06d6db73914c1630ecf544d83d6"
+dependencies = [
+ "arrayvec",
+ "bytes",
+]
+
+[[package]]
 name = "anstream"
 version = "0.6.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -302,6 +339,130 @@ dependencies = [
 ]
 
 [[package]]
+name = "ark-ff"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b3235cc41ee7a12aaaf2c575a2ad7b46713a8a50bda2fc3b003a04845c05dd6"
+dependencies = [
+ "ark-ff-asm 0.3.0",
+ "ark-ff-macros 0.3.0",
+ "ark-serialize 0.3.0",
+ "ark-std 0.3.0",
+ "derivative",
+ "num-bigint",
+ "num-traits",
+ "paste",
+ "rustc_version 0.3.3",
+ "zeroize",
+]
+
+[[package]]
+name = "ark-ff"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec847af850f44ad29048935519032c33da8aa03340876d351dfab5660d2966ba"
+dependencies = [
+ "ark-ff-asm 0.4.2",
+ "ark-ff-macros 0.4.2",
+ "ark-serialize 0.4.2",
+ "ark-std 0.4.0",
+ "derivative",
+ "digest 0.10.7",
+ "itertools",
+ "num-bigint",
+ "num-traits",
+ "paste",
+ "rustc_version 0.4.1",
+ "zeroize",
+]
+
+[[package]]
+name = "ark-ff-asm"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db02d390bf6643fb404d3d22d31aee1c4bc4459600aef9113833d17e786c6e44"
+dependencies = [
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "ark-ff-asm"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ed4aa4fe255d0bc6d79373f7e31d2ea147bcf486cba1be5ba7ea85abdb92348"
+dependencies = [
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "ark-ff-macros"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db2fd794a08ccb318058009eefdf15bcaaaaf6f8161eb3345f907222bac38b20"
+dependencies = [
+ "num-bigint",
+ "num-traits",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "ark-ff-macros"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7abe79b0e4288889c4574159ab790824d0033b9fdcb2a112a3182fac2e514565"
+dependencies = [
+ "num-bigint",
+ "num-traits",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "ark-serialize"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d6c2b318ee6e10f8c2853e73a83adc0ccb88995aa978d8a3408d492ab2ee671"
+dependencies = [
+ "ark-std 0.3.0",
+ "digest 0.9.0",
+]
+
+[[package]]
+name = "ark-serialize"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "adb7b85a02b83d2f22f89bd5cac66c9c89474240cb6207cb1efc16d098e822a5"
+dependencies = [
+ "ark-std 0.4.0",
+ "digest 0.10.7",
+ "num-bigint",
+]
+
+[[package]]
+name = "ark-std"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1df2c09229cbc5a028b1d70e00fdb2acee28b1055dfb5ca73eea49c5a25c4e7c"
+dependencies = [
+ "num-traits",
+ "rand",
+]
+
+[[package]]
+name = "ark-std"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94893f1e0c6eeab764ade8dc4c0db24caf4fe7cbbaafc0eba0a9030f447b5185"
+dependencies = [
+ "num-traits",
+ "rand",
+]
+
+[[package]]
 name = "arrayvec"
 version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -315,7 +476,18 @@ checksum = "721cae7de5c34fbb2acd27e21e6d2cf7b886dce0c27388d46c4e6c47ea4318dd"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.91",
+]
+
+[[package]]
+name = "auto_impl"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e12882f59de5360c748c4cbf569a042d5fb0eb515f7bea9c1f470b47f6ffbd73"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.91",
 ]
 
 [[package]]
@@ -340,6 +512,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "base16ct"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
+
+[[package]]
 name = "base58ck"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -362,6 +540,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
+name = "base64ct"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b"
+
+[[package]]
 name = "bech32"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -375,6 +559,21 @@ checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
 dependencies = [
  "serde",
 ]
+
+[[package]]
+name = "bit-set"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0700ddab506f33b20a03b13996eccd309a48e5ff77d0d95926aa0210fb4e95f1"
+dependencies = [
+ "bit-vec",
+]
+
+[[package]]
+name = "bit-vec"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb"
 
 [[package]]
 name = "bitcoin"
@@ -415,6 +614,7 @@ version = "0.1.0"
 dependencies = [
  "actix-web",
  "actix-web-httpauth",
+ "alloy-primitives",
  "async-trait",
  "bitcoin",
  "bitcoinconsensus",
@@ -431,7 +631,7 @@ dependencies = [
  "rand",
  "serde",
  "serde_json",
- "thiserror",
+ "thiserror 1.0.61",
  "tokio",
  "tokio-util",
 ]
@@ -500,6 +700,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "bitvec"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bc2832c24239b0141d5674bb9174f9d68a8b5b3f2753311927c172ca46f7e9c"
+dependencies = [
+ "funty",
+ "radium",
+ "tap",
+ "wyz",
+]
+
+[[package]]
 name = "block-buffer"
 version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -530,6 +742,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "byte-slice-cast"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3ac9f8b63eca6fd385229b3675f6cc0dc5c8a5c8a54a59d4f52ffd670d87b0c"
+
+[[package]]
 name = "byteorder"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -540,6 +758,9 @@ name = "bytes"
 version = "1.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8318a53db07bb3f8dca91a600466bdb3f2eaadeedfdbcf02e1accbad9271ba50"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "bytestring"
@@ -572,6 +793,25 @@ name = "colorchoice"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b63caa9aa9397e2d9480a9b13673856c78d8ac123288526c37d7839f2a86990"
+
+[[package]]
+name = "const-hex"
+version = "1.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b0485bab839b018a8f1723fc5391819fea5f8f0f32288ef8a735fd096b6160c"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "hex",
+ "proptest",
+ "serde",
+]
+
+[[package]]
+name = "const-oid"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
 
 [[package]]
 name = "convert_case"
@@ -624,6 +864,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
+name = "crunchy"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
+
+[[package]]
+name = "crypto-bigint"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0dc92fb57ca44df6db8059111ab3af99a63d5d0f8375d9972e319a379c6bab76"
+dependencies = [
+ "generic-array",
+ "rand_core",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
 name = "crypto-common"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -631,6 +889,16 @@ checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
 dependencies = [
  "generic-array",
  "typenum",
+]
+
+[[package]]
+name = "der"
+version = "0.7.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f55bf8e7b65898637379c1b74eb1551107c8294ed26d855ceb9fd1a09cfc9bc0"
+dependencies = [
+ "const-oid",
+ "zeroize",
 ]
 
 [[package]]
@@ -643,6 +911,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "derivative"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fcc3dd5e9e9c0b295d6e1e4d811fb6f157d5ffd784b8d202fc62eac8035a770b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "derive_more"
 version = "0.99.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -651,8 +930,38 @@ dependencies = [
  "convert_case",
  "proc-macro2",
  "quote",
- "rustc_version",
- "syn",
+ "rustc_version 0.4.1",
+ "syn 2.0.91",
+]
+
+[[package]]
+name = "derive_more"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a9b99b9cbbe49445b21764dc0625032a89b145a2642e67603e1c936f5458d05"
+dependencies = [
+ "derive_more-impl",
+]
+
+[[package]]
+name = "derive_more-impl"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb7330aeadfbe296029522e6c40f315320aba36fc43a5b3632f3795348f3bd22"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.91",
+ "unicode-xid",
+]
+
+[[package]]
+name = "digest"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3dd60d1080a57a05ab032377049e0591415d2b31afd7028356dbf3cc6dcb066"
+dependencies = [
+ "generic-array",
 ]
 
 [[package]]
@@ -662,7 +971,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer",
+ "const-oid",
  "crypto-common",
+ "subtle",
 ]
 
 [[package]]
@@ -673,7 +984,7 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.91",
 ]
 
 [[package]]
@@ -689,6 +1000,45 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "415b6ec780d34dcf624666747194393603d0373b7141eef01d12ee58881507d9"
 dependencies = [
  "phf",
+]
+
+[[package]]
+name = "ecdsa"
+version = "0.16.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee27f32b5c5292967d2d4a9d7f1e0b0aed2c15daded5a60300e4abb9d8020bca"
+dependencies = [
+ "der",
+ "digest 0.10.7",
+ "elliptic-curve",
+ "rfc6979",
+ "signature",
+ "spki",
+]
+
+[[package]]
+name = "either"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60b1af1c220855b6ceac025d3f6ecdd2b7c4894bfe9cd9bda4fbb4bc7c0d4cf0"
+
+[[package]]
+name = "elliptic-curve"
+version = "0.13.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5e6043086bf7973472e0c7dff2142ea0b680d30e18d9cc40f267efbf222bd47"
+dependencies = [
+ "base16ct",
+ "crypto-bigint",
+ "digest 0.10.7",
+ "ff",
+ "generic-array",
+ "group",
+ "pkcs8",
+ "rand_core",
+ "sec1",
+ "subtle",
+ "zeroize",
 ]
 
 [[package]]
@@ -739,12 +1089,72 @@ dependencies = [
 ]
 
 [[package]]
+name = "errno"
+version = "0.3.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33d852cb9b869c2a9b3df2f71a3074817f01e1844f839a144f5fcef059a4eb5d"
+dependencies = [
+ "libc",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "extensions"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "258f70bd2b060d448403a66d420e81dcac3e5247a4928a887404a5e03715e2e0"
 dependencies = [
  "fxhash",
+]
+
+[[package]]
+name = "fastrand"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+
+[[package]]
+name = "fastrlp"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "139834ddba373bbdd213dffe02c8d110508dcf1726c2be27e8d1f7d7e1856418"
+dependencies = [
+ "arrayvec",
+ "auto_impl",
+ "bytes",
+]
+
+[[package]]
+name = "fastrlp"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce8dba4714ef14b8274c371879b175aa55b16b30f269663f19d576f380018dc4"
+dependencies = [
+ "arrayvec",
+ "auto_impl",
+ "bytes",
+]
+
+[[package]]
+name = "ff"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ded41244b729663b1e574f1b4fb731469f69f79c17667b5d776b16cda0479449"
+dependencies = [
+ "rand_core",
+ "subtle",
+]
+
+[[package]]
+name = "fixed-hash"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "835c052cb0c08c1acf6ffd71c022172e18723949c8282f2b9f27efbc51e64534"
+dependencies = [
+ "byteorder",
+ "rand",
+ "rustc-hex",
+ "static_assertions",
 ]
 
 [[package]]
@@ -764,6 +1174,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
+name = "foldhash"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0d2fde1f7b3d48b8395d5f2de76c18a528bd6a9cdde438df747bfcba3e05d6f"
+
+[[package]]
 name = "form_urlencoded"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -771,6 +1187,12 @@ checksum = "e13624c2627564efccf4934284bdd98cbaa14e79b0b5a141218e507b3a823456"
 dependencies = [
  "percent-encoding",
 ]
+
+[[package]]
+name = "funty"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
 
 [[package]]
 name = "futures"
@@ -828,7 +1250,7 @@ checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.91",
 ]
 
 [[package]]
@@ -878,6 +1300,7 @@ checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
 dependencies = [
  "typenum",
  "version_check",
+ "zeroize",
 ]
 
 [[package]]
@@ -896,6 +1319,17 @@ name = "gimli"
 version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32085ea23f3234fc7846555e85283ba4de91e21016dc0455a16286d87a292d64"
+
+[[package]]
+name = "group"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0f9ef7462f7c099f518d754361858f86d8a07af53ba9af0fe635bbccb151a63"
+dependencies = [
+ "ff",
+ "rand_core",
+ "subtle",
+]
 
 [[package]]
 name = "h2"
@@ -921,6 +1355,10 @@ name = "hashbrown"
 version = "0.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf151400ff0baff5465007dd2f3e717f3fe502074ca563069ce3a6629d07b289"
+dependencies = [
+ "foldhash",
+ "serde",
+]
 
 [[package]]
 name = "heed"
@@ -971,6 +1409,9 @@ name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "hex-conservative"
@@ -986,6 +1427,15 @@ name = "hex_lit"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3011d1213f159867b13cfd6ac92d2cd5f1345762c63be3554e84092d85a50bbd"
+
+[[package]]
+name = "hmac"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
+dependencies = [
+ "digest 0.10.7",
+]
 
 [[package]]
 name = "http"
@@ -1131,7 +1581,7 @@ checksum = "1ec89e9337638ecdc08744df490b221a7399bf8d164eb52a665454e60e075ad6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.91",
 ]
 
 [[package]]
@@ -1156,10 +1606,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "impl-codec"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba6a270039626615617f3f36d15fc827041df3b78c439da2cadfa47455a77f2f"
+dependencies = [
+ "parity-scale-codec",
+]
+
+[[package]]
 name = "impl-more"
 version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aae21c3177a27788957044151cc2800043d127acaa460a47ebb9b84dfa2c6aa0"
+
+[[package]]
+name = "impl-trait-for-tuples"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0eb5a3343abf848c0984fe4604b2b105da9539376e24fc0a3b0007411ae4fd9"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.91",
+]
 
 [[package]]
 name = "indexmap"
@@ -1169,6 +1639,7 @@ checksum = "62f822373a4fe84d4bb149bf54e584a7f4abec90e072ed49cda0edea5b95471f"
 dependencies = [
  "equivalent",
  "hashbrown",
+ "serde",
 ]
 
 [[package]]
@@ -1176,7 +1647,7 @@ name = "ipc_serde"
 version = "0.1.0"
 dependencies = [
  "quote",
- "syn",
+ "syn 2.0.91",
 ]
 
 [[package]]
@@ -1184,6 +1655,15 @@ name = "is_terminal_polyfill"
 version = "1.70.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
+
+[[package]]
+name = "itertools"
+version = "0.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+dependencies = [
+ "either",
+]
 
 [[package]]
 name = "itoa"
@@ -1230,16 +1710,66 @@ dependencies = [
 ]
 
 [[package]]
+name = "k256"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6e3919bbaa2945715f0bb6d3934a173d1e9a59ac23767fbaaef277265a7411b"
+dependencies = [
+ "cfg-if",
+ "ecdsa",
+ "elliptic-curve",
+ "once_cell",
+ "sha2",
+]
+
+[[package]]
+name = "keccak"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ecc2af9a1119c51f12a14607e783cb977bde58bc069ff0c3da1095e635d70654"
+dependencies = [
+ "cpufeatures",
+]
+
+[[package]]
+name = "keccak-asm"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "505d1856a39b200489082f90d897c3f07c455563880bc5952e38eabf731c83b6"
+dependencies = [
+ "digest 0.10.7",
+ "sha3-asm",
+]
+
+[[package]]
 name = "language-tags"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4345964bb142484797b161f473a503a434de77149dd8c7427788c6e13379388"
 
 [[package]]
+name = "lazy_static"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+
+[[package]]
 name = "libc"
 version = "0.2.169"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5aba8db14291edd000dfcc4d620c7ebfb122c613afb886ca8803fa4e128a20a"
+
+[[package]]
+name = "libm"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8355be11b20d696c8f18f6cc018c4e372165b1fa8126cef092399c9951984ffa"
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.4.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
 
 [[package]]
 name = "litemap"
@@ -1368,6 +1898,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
+ "libm",
 ]
 
 [[package]]
@@ -1393,6 +1924,32 @@ checksum = "30d5b2194ed13191c1999ae0704b7839fb18384fa22e49b57eeaa97d79ce40da"
 dependencies = [
  "libc",
  "winapi",
+]
+
+[[package]]
+name = "parity-scale-codec"
+version = "3.6.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "306800abfa29c7f16596b5970a588435e3d5b3149683d00c12b699cc19f895ee"
+dependencies = [
+ "arrayvec",
+ "bitvec",
+ "byte-slice-cast",
+ "impl-trait-for-tuples",
+ "parity-scale-codec-derive",
+ "serde",
+]
+
+[[package]]
+name = "parity-scale-codec-derive"
+version = "3.6.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d830939c76d294956402033aee57a6da7b438f2294eb94864c37b0569053a42c"
+dependencies = [
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -1431,6 +1988,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
 
 [[package]]
+name = "pest"
+version = "2.7.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b7cafe60d6cf8e62e1b9b2ea516a089c008945bb5a275416789e7db0bc199dc"
+dependencies = [
+ "memchr",
+ "thiserror 2.0.11",
+ "ucd-trie",
+]
+
+[[package]]
 name = "phf"
 version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1460,7 +2028,7 @@ dependencies = [
  "phf_shared",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.91",
 ]
 
 [[package]]
@@ -1485,6 +2053,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
+name = "pkcs8"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
+dependencies = [
+ "der",
+ "spki",
+]
+
+[[package]]
 name = "pkg-config"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1503,6 +2081,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
 
 [[package]]
+name = "primitive-types"
+version = "0.12.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b34d9fd68ae0b74a41b21c03c2f62847aa0ffea044eee893b4c140b37e244e2"
+dependencies = [
+ "fixed-hash",
+ "impl-codec",
+ "uint",
+]
+
+[[package]]
+name = "proc-macro-crate"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecf48c7ca261d60b74ab1a7b20da18bede46776b2e55535cb958eb595c5fa7b"
+dependencies = [
+ "toml_edit",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1510,6 +2108,32 @@ checksum = "37d3544b3f2748c54e147655edb5025752e2303145b5aefb3c3ea2c78b973bb0"
 dependencies = [
  "unicode-ident",
 ]
+
+[[package]]
+name = "proptest"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4c2511913b88df1637da85cc8d96ec8e43a3f8bb8ccb71ee1ac240d6f3df58d"
+dependencies = [
+ "bit-set",
+ "bit-vec",
+ "bitflags",
+ "lazy_static",
+ "num-traits",
+ "rand",
+ "rand_chacha",
+ "rand_xorshift",
+ "regex-syntax",
+ "rusty-fork",
+ "tempfile",
+ "unarray",
+]
+
+[[package]]
+name = "quick-error"
+version = "1.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quote"
@@ -1521,6 +2145,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "radium"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
+
+[[package]]
 name = "rand"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1529,6 +2159,7 @@ dependencies = [
  "libc",
  "rand_chacha",
  "rand_core",
+ "serde",
 ]
 
 [[package]]
@@ -1548,6 +2179,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom",
+]
+
+[[package]]
+name = "rand_xorshift"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d25bf25ec5ae4a3f1b92f929810509a2f53d7dca2f50b794ff57e3face536c8f"
+dependencies = [
+ "rand_core",
 ]
 
 [[package]]
@@ -1595,10 +2235,83 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
+name = "rfc6979"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dd2a808d456c4a54e300a23e9f5a67e122c3024119acbfd73e3bf664491cb2"
+dependencies = [
+ "hmac",
+ "subtle",
+]
+
+[[package]]
+name = "rlp"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb919243f34364b6bd2fc10ef797edbfa75f33c252e7998527479c6d6b47e1ec"
+dependencies = [
+ "bytes",
+ "rustc-hex",
+]
+
+[[package]]
+name = "ruint"
+version = "1.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f5ef8fb1dd8de3870cb8400d51b4c2023854bbafd5431a3ac7e7317243e22d2f"
+dependencies = [
+ "alloy-rlp",
+ "ark-ff 0.3.0",
+ "ark-ff 0.4.2",
+ "bytes",
+ "fastrlp 0.3.1",
+ "fastrlp 0.4.0",
+ "num-bigint",
+ "num-integer",
+ "num-traits",
+ "parity-scale-codec",
+ "primitive-types",
+ "proptest",
+ "rand",
+ "rlp",
+ "ruint-macro",
+ "serde",
+ "valuable",
+ "zeroize",
+]
+
+[[package]]
+name = "ruint-macro"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48fd7bd8a6377e15ad9d42a8ec25371b94ddc67abe7c8b9127bec79bebaaae18"
+
+[[package]]
 name = "rustc-demangle"
 version = "0.1.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f"
+
+[[package]]
+name = "rustc-hash"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7fb8039b3032c191086b10f11f319a6e99e1e82889c5cc6046f515c9db1d497"
+
+[[package]]
+name = "rustc-hex"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e75f6a532d0fd9f7f13144f392b6ad56a32696bfcd9c78f797f16bbb6f072d6"
+
+[[package]]
+name = "rustc_version"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0dfe2087c51c460008730de8b57e6a320782fbfb312e1f4d520e6c6fae155ee"
+dependencies = [
+ "semver 0.11.0",
+]
 
 [[package]]
 name = "rustc_version"
@@ -1606,7 +2319,32 @@ version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
 dependencies = [
- "semver",
+ "semver 1.0.24",
+]
+
+[[package]]
+name = "rustix"
+version = "0.38.43"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a78891ee6bf2340288408954ac787aa063d8e8817e9f53abb37c695c6d834ef6"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "rusty-fork"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb3dcc6e454c328bb824492db107ab7c0ae8fcffe4ad210136ef014458c1bc4f"
+dependencies = [
+ "fnv",
+ "quick-error",
+ "tempfile",
+ "wait-timeout",
 ]
 
 [[package]]
@@ -1620,6 +2358,20 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "sec1"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3e97a565f76233a6003f9f5c54be1d9c5bdfa3eccfb189469f11ec4901c47dc"
+dependencies = [
+ "base16ct",
+ "der",
+ "generic-array",
+ "pkcs8",
+ "subtle",
+ "zeroize",
+]
 
 [[package]]
 name = "secp256k1"
@@ -1644,9 +2396,27 @@ dependencies = [
 
 [[package]]
 name = "semver"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f301af10236f6df4160f7c3f04eec6dbc70ace82d23326abad5edee88801c6b6"
+dependencies = [
+ "semver-parser",
+]
+
+[[package]]
+name = "semver"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3cb6eb87a131f756572d7fb904f6e7b68633f09cca868c5df1c4b8d1a694bbba"
+
+[[package]]
+name = "semver-parser"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9900206b54a3527fdc7b8a938bffd94a568bac4f4aa8113b209df75a09c0dec2"
+dependencies = [
+ "pest",
+]
 
 [[package]]
 name = "serde"
@@ -1665,7 +2435,7 @@ checksum = "5a9bf7cf98d04a2b28aead066b7496853d4779c9cc183c440dbac457641e19a0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.91",
 ]
 
 [[package]]
@@ -1700,7 +2470,38 @@ checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
 dependencies = [
  "cfg-if",
  "cpufeatures",
- "digest",
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "sha2"
+version = "0.10.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "793db75ad2bcafc3ffa7c68b215fee268f537982cd901d132f89c6343f3a3dc8"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "sha3"
+version = "0.10.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75872d278a8f37ef87fa0ddbda7802605cb18344497949862c0d4dcb291eba60"
+dependencies = [
+ "digest 0.10.7",
+ "keccak",
+]
+
+[[package]]
+name = "sha3-asm"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c28efc5e327c837aa837c59eae585fc250715ef939ac32881bcc11677cd02d46"
+dependencies = [
+ "cc",
+ "cfg-if",
 ]
 
 [[package]]
@@ -1710,6 +2511,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a9e9e0b4211b72e7b8b6e85c807d36c212bdb33ea8587f7569562a84df5465b1"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "signature"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
+dependencies = [
+ "digest 0.10.7",
+ "rand_core",
 ]
 
 [[package]]
@@ -1744,10 +2555,43 @@ dependencies = [
 ]
 
 [[package]]
+name = "spki"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
+dependencies = [
+ "base64ct",
+ "der",
+]
+
+[[package]]
 name = "stable_deref_trait"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
+
+[[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
+name = "subtle"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
+
+[[package]]
+name = "syn"
+version = "1.0.109"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
 
 [[package]]
 name = "syn"
@@ -1777,7 +2621,27 @@ checksum = "c8af7666ab7b6390ab78131fb5b0fce11d6b7a6951602017c35fa82800708971"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.91",
+]
+
+[[package]]
+name = "tap"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
+
+[[package]]
+name = "tempfile"
+version = "3.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a8a559c81686f576e8cd0290cd2a24a2a9ad80c98b3478856500fcbd7acd704"
+dependencies = [
+ "cfg-if",
+ "fastrand",
+ "getrandom",
+ "once_cell",
+ "rustix",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1786,7 +2650,16 @@ version = "1.0.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c546c80d6be4bc6a00c0f01730c08df82eaa7a7a61f11d656526506112cc1709"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 1.0.61",
+]
+
+[[package]]
+name = "thiserror"
+version = "2.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d452f284b73e6d76dd36758a0c8684b1d5be31f92b89d07fd5822175732206fc"
+dependencies = [
+ "thiserror-impl 2.0.11",
 ]
 
 [[package]]
@@ -1797,7 +2670,18 @@ checksum = "46c3384250002a6d5af4d114f2845d37b57521033f30d5c3f46c4d70e1197533"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.91",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26afc1baea8a989337eeb52b6e72a039780ce45c3edfcc9c5b9d112feeb173c2"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.91",
 ]
 
 [[package]]
@@ -1829,6 +2713,15 @@ checksum = "2834e6017e3e5e4b9834939793b282bc03b37a3336245fa820e35e233e2a85de"
 dependencies = [
  "num-conv",
  "time-core",
+]
+
+[[package]]
+name = "tiny-keccak"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c9d3793400a45f954c52e73d068316d76b6f4e36977e3fcebb13a2721e80237"
+dependencies = [
+ "crunchy",
 ]
 
 [[package]]
@@ -1867,7 +2760,7 @@ checksum = "693d596312e88961bc67d7f1f97af8a70227d9f90c31bba5806eec004978d752"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.91",
 ]
 
 [[package]]
@@ -1881,6 +2774,23 @@ dependencies = [
  "futures-sink",
  "pin-project-lite",
  "tokio",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.6.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0dd7358ecb8fc2f8d014bf86f6f638ce72ba252a2c3a2572f2a795f1d23efb41"
+
+[[package]]
+name = "toml_edit"
+version = "0.22.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ae48d6208a266e853d946088ed816055e556cc6028c5e8e2b84d9fa5dd7c7f5"
+dependencies = [
+ "indexmap",
+ "toml_datetime",
+ "winnow",
 ]
 
 [[package]]
@@ -1910,10 +2820,40 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825"
 
 [[package]]
+name = "ucd-trie"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2896d95c02a80c6d6a5d6e953d479f5ddf2dfdb6a244441010e373ac0fb88971"
+
+[[package]]
+name = "uint"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76f64bba2c53b04fcab63c01a7d7427eadc821e3bc48c34dc9ba29c501164b52"
+dependencies = [
+ "byteorder",
+ "crunchy",
+ "hex",
+ "static_assertions",
+]
+
+[[package]]
+name = "unarray"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
+
+[[package]]
+name = "unicode-xid"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
 name = "url"
@@ -1945,10 +2885,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
+name = "valuable"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
+
+[[package]]
 name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "wait-timeout"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f200f5b12eb75f8c1ed65abd4b2db8a6e1b138a20de009dacee265a2498f3f6"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "wasi"
@@ -2061,6 +3016,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
+name = "winnow"
+version = "0.6.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8d71a593cc5c42ad7876e2c1fda56f314f3754c084128833e64f1345ff8a03a"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "write16"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2071,6 +3035,15 @@ name = "writeable"
 version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e9df38ee2d2c3c5948ea468a8406ff0db0b29ae1ffde1bcf20ef305bcc95c51"
+
+[[package]]
+name = "wyz"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05f360fc0b24296329c78fda852a1e9ae82de9cf7b27dae4b7f62f118f77b9ed"
+dependencies = [
+ "tap",
+]
 
 [[package]]
 name = "yoke"
@@ -2092,7 +3065,7 @@ checksum = "2380878cad4ac9aac1e2435f3eb4020e8374b5f13c296cb75b4620ff8e229154"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.91",
  "synstructure",
 ]
 
@@ -2113,7 +3086,7 @@ checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.91",
 ]
 
 [[package]]
@@ -2133,8 +3106,28 @@ checksum = "595eed982f7d355beb85837f651fa22e90b3c044842dc7f2c2842c086f295808"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.91",
  "synstructure",
+]
+
+[[package]]
+name = "zeroize"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ced3678a2879b30306d323f4542626697a464a97c0a07c9aebf7ebca65cd4dde"
+dependencies = [
+ "zeroize_derive",
+]
+
+[[package]]
+name = "zeroize_derive"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.91",
 ]
 
 [[package]]
@@ -2156,7 +3149,7 @@ checksum = "6eafa6dfb17584ea3e2bd6e76e0cc15ad7af12b09abdd1ca55961bed9b1063c6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.91",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,7 @@ heed = "0.21.0"
 tokio-util = "0.7.13"
 num-traits = "0.2.19"
 num-bigint = "0.4.6"
+alloy-primitives = { version = "0.8.19", features = ["serde"] }
 
 [dev-dependencies]
 bitcoinconsensus = "0.106.0"

--- a/docs/demo/create_join.md
+++ b/docs/demo/create_join.md
@@ -8,16 +8,16 @@ curl -X POST http://localhost:3030/api \
     "jsonrpc": "2.0",
     "method": "createsubnet",
     "params": {
-    "min_validator_stake": 100000000,
-    "min_validators": 2,
-    "bottomup_check_period": 5,
-    "active_validators_limit": 2,
-    "min_cross_msg_fee": 200,
-    "whitelist": [
-        "18845781f631c48f1c9709e23092067d06837f30aa0cd0544ac887fe91ddd166",
-        "6a6538f93a1ae66a2b68aad837dbf3ce97010ecafbed440b79ab798cf28984df",
-        "1dc9a71014974bcf298f71fbcfffa42e891d3f5376baa712f7379909a05b6be7"
-    ]
+	    "min_validator_stake": 100000000,
+	    "min_validators": 2,
+	    "bottomup_check_period": 5,
+	    "active_validators_limit": 2,
+	    "min_cross_msg_fee": 200,
+	    "whitelist": [
+		    "18845781f631c48f1c9709e23092067d06837f30aa0cd0544ac887fe91ddd166",
+		    "6a6538f93a1ae66a2b68aad837dbf3ce97010ecafbed440b79ab798cf28984df",
+		    "1dc9a71014974bcf298f71fbcfffa42e891d3f5376baa712f7379909a05b6be7"
+	    ]
     },
     "id": 1
 }' | jq
@@ -29,11 +29,11 @@ curl -X POST http://localhost:3030/api \
     "jsonrpc": "2.0",
     "method": "joinsubnet",
     "params": {
-    	"subnet_id": "BTC/4467317d030d3bcac27b897d05e7c1ad2aa138d669d017e512131852ccfbf287",
-    	"collateral": 20000000,
-		"ip": "66.222.44.55:8080",
-		"backup_address": "bcrt1q3fznspr3e02artm9df7tk827a2xhny2m4zzr6n",
-		"pubkey": "18845781f631c48f1c9709e23092067d06837f30aa0cd0544ac887fe91ddd166"
+			"subnet_id": "BTC/4467317d030d3bcac27b897d05e7c1ad2aa138d669d017e512131852ccfbf287",
+			"collateral": 20000000,
+			"ip": "66.222.44.55:8080",
+			"backup_address": "bcrt1q3fznspr3e02artm9df7tk827a2xhny2m4zzr6n",
+			"pubkey": "18845781f631c48f1c9709e23092067d06837f30aa0cd0544ac887fe91ddd166"
     },
     "id": 1
 }' | jq
@@ -45,11 +45,11 @@ curl -X POST http://localhost:3030/api \
     "jsonrpc": "2.0",
     "method": "joinsubnet",
     "params": {
-    	"subnet_id": "BTC/4467317d030d3bcac27b897d05e7c1ad2aa138d669d017e512131852ccfbf287",
-    	"collateral": 110000000,
-		"ip": "66.222.44.55:8080",
-		"backup_address": "bcrt1q3fznspr3e02artm9df7tk827a2xhny2m4zzr6n",
-		"pubkey": "6a6538f93a1ae66a2b68aad837dbf3ce97010ecafbed440b79ab798cf28984df"
+			"subnet_id": "BTC/4467317d030d3bcac27b897d05e7c1ad2aa138d669d017e512131852ccfbf287",
+			"collateral": 110000000,
+			"ip": "66.222.44.55:8080",
+			"backup_address": "bcrt1q3fznspr3e02artm9df7tk827a2xhny2m4zzr6n",
+			"pubkey": "6a6538f93a1ae66a2b68aad837dbf3ce97010ecafbed440b79ab798cf28984df"
     },
     "id": 1
 }' | jq
@@ -58,11 +58,11 @@ curl -X POST http://localhost:3030/api \
 -H "Content-Type: application/json" \
 -H "Authorization: Bearer asda123123jhaskjdhgbjsjhdj" \
 -d '{
-"jsonrpc": "2.0",
-"method": "getgenesisinfo",
-"params": {
-	"subnet_id": "BTC/4467317d030d3bcac27b897d05e7c1ad2aa138d669d017e512131852ccfbf287"
-},
-"id": 1
+	"jsonrpc": "2.0",
+	"method": "getgenesisinfo",
+	"params": {
+		"subnet_id": "BTC/4467317d030d3bcac27b897d05e7c1ad2aa138d669d017e512131852ccfbf287"
+	},
+	"id": 1
 }' | jq
 ```

--- a/docs/demo/create_join.md
+++ b/docs/demo/create_join.md
@@ -1,0 +1,68 @@
+```sh
+ipc-cli subnet create --parent /r314159 --min-validator-stake 10000000 --min-validators 2 --bottomup-check-period 300 --permission-mode collateral --supply-source-kind native --min-cross-msg-fee 10 --validator-whitelist 18845781f631c48f1c9709e23092067d06837f30aa0cd0544ac887fe91ddd166,6a6538f93a1ae66a2b68aad837dbf3ce97010ecafbed440b79ab798cf28984df,1dc9a71014974bcf298f71fbcfffa42e891d3f5376baa712f7379909a05b6be7
+
+curl -X POST http://localhost:3030/api \
+-H "Content-Type: application/json" \
+-H "Authorization: Bearer asda123123jhaskjdhgbjsjhdj" \
+-d '{
+    "jsonrpc": "2.0",
+    "method": "createsubnet",
+    "params": {
+    "min_validator_stake": 100000000,
+    "min_validators": 2,
+    "bottomup_check_period": 5,
+    "active_validators_limit": 2,
+    "min_cross_msg_fee": 200,
+    "whitelist": [
+        "18845781f631c48f1c9709e23092067d06837f30aa0cd0544ac887fe91ddd166",
+        "6a6538f93a1ae66a2b68aad837dbf3ce97010ecafbed440b79ab798cf28984df",
+        "1dc9a71014974bcf298f71fbcfffa42e891d3f5376baa712f7379909a05b6be7"
+    ]
+    },
+    "id": 1
+}' | jq
+
+curl -X POST http://localhost:3030/api \
+-H "Content-Type: application/json" \
+-H "Authorization: Bearer asda123123jhaskjdhgbjsjhdj" \
+-d '{
+    "jsonrpc": "2.0",
+    "method": "joinsubnet",
+    "params": {
+    	"subnet_id": "BTC/4467317d030d3bcac27b897d05e7c1ad2aa138d669d017e512131852ccfbf287",
+    	"collateral": 20000000,
+		"ip": "66.222.44.55:8080",
+		"backup_address": "bcrt1q3fznspr3e02artm9df7tk827a2xhny2m4zzr6n",
+		"pubkey": "18845781f631c48f1c9709e23092067d06837f30aa0cd0544ac887fe91ddd166"
+    },
+    "id": 1
+}' | jq
+
+curl -X POST http://localhost:3030/api \
+-H "Content-Type: application/json" \
+-H "Authorization: Bearer asda123123jhaskjdhgbjsjhdj" \
+-d '{
+    "jsonrpc": "2.0",
+    "method": "joinsubnet",
+    "params": {
+    	"subnet_id": "BTC/4467317d030d3bcac27b897d05e7c1ad2aa138d669d017e512131852ccfbf287",
+    	"collateral": 110000000,
+		"ip": "66.222.44.55:8080",
+		"backup_address": "bcrt1q3fznspr3e02artm9df7tk827a2xhny2m4zzr6n",
+		"pubkey": "6a6538f93a1ae66a2b68aad837dbf3ce97010ecafbed440b79ab798cf28984df"
+    },
+    "id": 1
+}' | jq
+
+curl -X POST http://localhost:3030/api \
+-H "Content-Type: application/json" \
+-H "Authorization: Bearer asda123123jhaskjdhgbjsjhdj" \
+-d '{
+"jsonrpc": "2.0",
+"method": "getgenesisinfo",
+"params": {
+	"subnet_id": "BTC/4467317d030d3bcac27b897d05e7c1ad2aa138d669d017e512131852ccfbf287"
+},
+"id": 1
+}' | jq
+```

--- a/ipc_serde/src/lib.rs
+++ b/ipc_serde/src/lib.rs
@@ -1,6 +1,6 @@
 use proc_macro::TokenStream;
 use quote::quote;
-use syn::{parse_macro_input, Data, DeriveInput, Expr, Fields};
+use syn::{parse_macro_input, Data, DeriveInput, Expr, Fields, Meta};
 
 /// Derive macro for IPC serialization — a custom serialization format for IPC messages in
 /// Bitcoin transactions.
@@ -9,7 +9,7 @@ use syn::{parse_macro_input, Data, DeriveInput, Expr, Fields};
 /// Differrent rules for serialization can be defined for different types.
 //
 // TODO Make a general way to handle different types of serialization
-#[proc_macro_derive(IpcSerialize, attributes(tag))]
+#[proc_macro_derive(IpcSerialize, attributes(tag, ipc_serde))]
 pub fn ipc_serialize_derive(input: TokenStream) -> TokenStream {
     let input = parse_macro_input!(input as DeriveInput);
     let name = &input.ident;
@@ -31,12 +31,45 @@ pub fn ipc_serialize_derive(input: TokenStream) -> TokenStream {
         panic!("Expected a struct");
     };
 
-    let serialize_fields = fields.iter().map(|field| {
+    /// Checks if the type should be (de)serialized without quotes
+    // TODO make this automatic or more general
+    fn without_quotes(ty: &syn::Type) -> bool {
+        let string_types = [
+            syn::parse_quote!(SubnetId),
+            syn::parse_quote!(String),
+            syn::parse_quote!(SocketAddr),
+            syn::parse_quote!(std::net::SocketAddr),
+            syn::parse_quote!(XOnlyPublicKey),
+            syn::parse_quote!(bitcoin::XOnlyPublicKey),
+            syn::parse_quote!(Address<NetworkUnchecked>),
+            syn::parse_quote!(bitcoin::Address<NetworkUnchecked>),
+            // Add other types that don't need quotes here
+        ];
+        string_types.contains(ty)
+    }
+
+    /// Checks if a field should be skipped
+    fn should_skip_field(field: &syn::Field) -> bool {
+        field.attrs.iter().any(|attr| {
+            if attr.path().is_ident("ipc_serde") {
+                if let Meta::List(list) = attr.meta.clone() {
+                    return list.tokens.to_string().contains("skip");
+                }
+            }
+            false
+        })
+    }
+
+    let serialize_fields = fields.iter().filter_map(|field| {
+    	if should_skip_field(field) {
+            return None;
+        }
+
         let field_name = &field.ident;
         let field_name_str = field_name.as_ref().unwrap().to_string();
 
         // Handle Vec<String>
-        if &field.ty == &syn::parse_quote!(Vec<String>) {
+        Some(if &field.ty == &syn::parse_quote!(Vec<String>) {
             quote! {
                 params_map.insert(#field_name_str, self.#field_name.join(","));
             }
@@ -47,20 +80,33 @@ pub fn ipc_serialize_derive(input: TokenStream) -> TokenStream {
                 params_map.insert(#field_name_str, self.#field_name.iter().map(|key| key.to_string()).collect::<Vec<_>>().join(","));
             }
 
+        } else if without_quotes(&field.ty) {
+			quote! {
+				params_map.insert(#field_name_str, serde_json::to_string(&self.#field_name).unwrap().trim_matches('"')
+					.to_string());
+			}
+
         // Handle other json-serializable types
         } else {
 		    quote! {
 		        params_map.insert(#field_name_str, serde_json::to_string(&self.#field_name).unwrap());
 		    }
-        }
+        })
     });
 
-    let deserialize_fields = fields.iter().map(|field| {
+    let deserialize_fields = fields.iter().filter_map(|field| {
          let field_name = &field.ident;
+
+         if should_skip_field(field) {
+			return Some(quote! {
+				#field_name: Default::default(),
+			});
+		}
+
          let field_name_str = field_name.as_ref().unwrap().to_string();
 
          // Handle Vec<String>
-         if &field.ty == &syn::parse_quote!(Vec<String>) {
+         Some(if &field.ty == &syn::parse_quote!(Vec<String>) {
             quote! {
 	            #field_name: params_map.remove(#field_name_str)
 	                .ok_or_else(|| MissingField(#field_name_str.to_string()))?
@@ -78,14 +124,21 @@ pub fn ipc_serialize_derive(input: TokenStream) -> TokenStream {
 	                .collect::<Result<_, _>>()?,
 			}
 
+        } else if without_quotes(&field.ty) {
+	        quote! {
+	            #field_name: serde_json::from_str(&format!("\"{}\"", params_map.remove(#field_name_str)
+	                .ok_or_else(|| MissingField(#field_name_str.to_string()))?))
+	                .map_err(|e| ParseFieldError(#field_name_str.to_string(), e.to_string()))?,
+	        }
+
 		// Handle other json-serializable types
         } else {
-	        quote! {
-		        #field_name: serde_json::from_str(&params_map.remove(#field_name_str)
+        	quote! {
+         		#field_name: serde_json::from_str(&params_map.remove(#field_name_str)
 		            .ok_or_else(|| MissingField(#field_name_str.to_string()))?)
 		            .map_err(|e| ParseFieldError(#field_name_str.to_string(), e.to_string()))?,
-	        }
-        }
+            }
+        })
      });
 
     let expanded = quote! {
@@ -99,7 +152,11 @@ pub fn ipc_serialize_derive(input: TokenStream) -> TokenStream {
                 let mut subnet_data = String::new();
                 subnet_data.push_str(#tag);
 
-                for (key, value) in &params_map {
+                // Convert to Vec, sort by key, then format
+                let mut params: Vec<_> = params_map.into_iter().collect();
+                params.sort_by(|(a, _), (b, _)| a.cmp(b));
+
+                for (key, value) in params {
                     subnet_data.push_str(&format!("{}{}={}", crate::IPC_TAG_DELIMITER, key, value));
                 }
 

--- a/src/bin/monitor.rs
+++ b/src/bin/monitor.rs
@@ -1,10 +1,10 @@
 use bitcoin_ipc::bitcoin_utils::{concatenate_op_push_data, make_rpc_client_from_env};
 use bitcoin_ipc::db::{self, Database, HeedDb};
-use bitcoin_ipc::ipc_lib::{self, IpcValidate};
+use bitcoin_ipc::ipc_lib::{self, IpcLibError, IpcValidate};
 use bitcoin_ipc::{IpcMessage, BTC_CONFIRMATIONS};
 use bitcoincore_rpc::RpcApi;
 use dotenv::dotenv;
-use log::{debug, error, info};
+use log::{debug, error, info, trace};
 use thiserror::Error;
 use tokio::signal;
 use tokio::time::Duration;
@@ -105,7 +105,10 @@ where
         info!("Syncing...");
 
         // Get the last processed block from the database
-        self.current_height = self.db.get_last_processed_block()?;
+        self.current_height = self
+            .db
+            .get_last_processed_block()
+            .map_err(|e| MonitorError::CannotGetMonitorInfo(e))?;
 
         loop {
             if self.cancel_token.is_cancelled() {
@@ -277,14 +280,37 @@ where
                 let witness_str = find_valid_utf8(&concatenated_data);
                 let ipc_message = IpcMessage::deserialize(witness_str);
 
-                // debug!("IPC message: {:?}", ipc_message);
-
-                match ipc_message {
-                    Ok(msg) => {
-                        self.process_ipc_msg(block_height, tx, txid, msg).await?;
-                    }
-                    Err(_) => {
+                let ipc_message = match ipc_message {
+                    Ok(msg) => msg,
+                    Err(e) => {
+                        trace!("Error deserializing IPC message: {:?}", e);
                         continue;
+                    }
+                };
+
+                debug!("Found IPC message: {:?}", ipc_message);
+
+                match self
+                    .process_ipc_msg(block_height, tx, txid, ipc_message)
+                    .await
+                {
+                    Ok(_) => {}
+                    // Ignorable
+                    Err(MonitorError::IpcMsgInvalid(e)) => {
+                        error!("Invalid IPC message: {:?}", e);
+                    }
+                    // Ignorable
+                    Err(MonitorError::IpcTxInvalid(e)) => {
+                        error!("Invalid IPC message transaction: {:?}", e);
+                    }
+                    // Ignorable
+                    Err(MonitorError::IpcMsgProcessingError(IpcLibError::IpcValidateError(e))) => {
+                        error!("Invalid IPC message: {:?}", e);
+                    }
+                    // Panicable, all other errors
+                    Err(e) => {
+                        error!("Fatal error processing IPC message: {:?}", e);
+                        return Err(e);
                     }
                 }
             }
@@ -302,31 +328,8 @@ where
     ) -> Result<(), MonitorError> {
         match msg {
             IpcMessage::CreateSubnet(create_subnet_msg) => {
-                if let Err(e) = create_subnet_msg.validate() {
-                    error!(
-                        "create_subnet_msg invalid {:?} error={:?}",
-                        create_subnet_msg, e
-                    );
-                    return Ok(());
-                }
-
-                let subnet_id = ipc_lib::SubnetId::from_txid(&txid);
-
-                let multisig_addr = create_subnet_msg
-                    .multisig_address_from_whitelist()
-                    .map_err(|e| MonitorError::IpcMsgError(e.to_string()))?;
-
-                debug!("multisig_address: {}", multisig_addr);
-
-                debug!(
-                    "block={} subnet_id={} msg={:?}",
-                    block_height, subnet_id, create_subnet_msg
-                );
-
-                // TODO handle errors better
-                if let Err(e) = create_subnet_msg.save_to_db(&self.db, subnet_id, block_height) {
-                    error!("Failed to save subnet to DB: {:?}", e);
-                }
+                create_subnet_msg.validate()?;
+                create_subnet_msg.save_to_db(&self.db, block_height, txid)?;
                 Ok(())
             }
 
@@ -334,26 +337,14 @@ where
                 join_subnet_msg.collateral = match tx.output.first() {
                     Some(output) => output.value,
                     None => {
-                        return Err(MonitorError::IpcMsgError(
-                            "Collaterall must be non zero".to_string(),
+                        return Err(MonitorError::IpcTxInvalid(
+                            "Transaction output must be non zero".to_string(),
                         ))
                     }
                 };
 
-                if let Err(e) = join_subnet_msg.validate() {
-                    error!(
-                        "join_subnet_msg invalid {:?} error={:?}",
-                        join_subnet_msg, e
-                    );
-                    return Ok(());
-                }
-
-                if let Err(e) = join_subnet_msg.save_to_db(&self.db, txid) {
-                    error!("Failed to save join subnet msg to DB: {:?}", e);
-                }
-
-                info!("{:?}", join_subnet_msg);
-
+                join_subnet_msg.validate()?;
+                join_subnet_msg.save_to_db(&self.db, txid)?;
                 Ok(())
             }
         }
@@ -376,12 +367,23 @@ pub enum MonitorError {
     #[error("Current block height ahead of tip. Latest: {0}. Current: {1}")]
     BlockHeightAheadOfTip(u64, u64),
 
-    // TODO better errors
-    #[error("Error processing IPC message: {0}")]
-    IpcMsgError(String),
+    #[error("IPC message error: {0}")]
+    IpcTxInvalid(String),
 
+    /// Returned when an IPC message is invalid
+    /// The message is ignored
     #[error(transparent)]
-    DbError(#[from] db::DbError),
+    IpcMsgInvalid(#[from] ipc_lib::IpcValidateError),
+
+    /// Returned when there was an error processing
+    /// an IPC message
+    ///
+    /// All variants of this error are fatal, except for `IpcValidateError`
+    #[error(transparent)]
+    IpcMsgProcessingError(#[from] IpcLibError),
+
+    #[error("Cannot get last processed block: {0}")]
+    CannotGetMonitorInfo(db::DbError),
 
     #[error(transparent)]
     BitcoinRpcError(#[from] bitcoincore_rpc::Error),

--- a/src/bin/monitor.rs
+++ b/src/bin/monitor.rs
@@ -324,13 +324,7 @@ where
                 // TODO handle errors better
                 if let Err(e) = self
                     .db
-                    .save_subnet_create_msg(
-                        subnet_id,
-                        block_height,
-                        // TODO remove the into_unchecked
-                        multisig_addr.clone().into_unchecked(),
-                        create_subnet_params.clone(),
-                    )
+                    .save_subnet_create_msg(subnet_id, block_height, create_subnet_params.clone())
                     .await
                 {
                     error!("Failed to save subnet to DB: {:?}", e);

--- a/src/bin/monitor.rs
+++ b/src/bin/monitor.rs
@@ -332,6 +332,8 @@ where
 
                 Ok(())
             }
+
+            IpcMessage::PrefundSubnet(_) => todo!(),
         }
     }
 }

--- a/src/bin/monitor.rs
+++ b/src/bin/monitor.rs
@@ -105,7 +105,7 @@ where
         info!("Syncing...");
 
         // Get the last processed block from the database
-        self.current_height = self.db.get_last_processed_block().await?;
+        self.current_height = self.db.get_last_processed_block()?;
 
         loop {
             if self.cancel_token.is_cancelled() {
@@ -138,8 +138,7 @@ where
                     Ok(_) => {
                         info!("Processed block {}", next_height);
                         self.current_height = next_height;
-                        if let Err(e) = self.db.set_last_processed_block(self.current_height).await
-                        {
+                        if let Err(e) = self.db.set_last_processed_block(self.current_height) {
                             error!("Failed to update last processed block: {:?}", e);
                         }
                     }
@@ -183,7 +182,7 @@ where
                                 info!("Processed block {}", block_count);
                                 self.current_height = block_count;
                                 if let Err(e) =
-                                    self.db.set_last_processed_block(self.current_height).await
+                                    self.db.set_last_processed_block(self.current_height)
                                 {
                                     error!("Failed to update last processed block: {:?}", e);
                                 }
@@ -282,7 +281,7 @@ where
 
                 match ipc_message {
                     Ok(msg) => {
-                        self.process_ipc_msg(block_height, &tx, &txid, msg).await?;
+                        self.process_ipc_msg(block_height, tx, txid, msg).await?;
                     }
                     Err(_) => {
                         continue;
@@ -298,7 +297,7 @@ where
         &self,
         block_height: u64,
         tx: &bitcoin::Transaction,
-        txid: &bitcoin::Txid,
+        txid: bitcoin::Txid,
         msg: IpcMessage,
     ) -> Result<(), MonitorError> {
         match msg {
@@ -311,7 +310,7 @@ where
                     return Ok(());
                 }
 
-                let subnet_id = ipc_lib::SubnetId::from_txid(txid);
+                let subnet_id = ipc_lib::SubnetId::from_txid(&txid);
 
                 let multisig_addr = create_subnet_msg
                     .multisig_address_from_whitelist()
@@ -325,14 +324,9 @@ where
                 );
 
                 // TODO handle errors better
-                if let Err(e) = self
-                    .db
-                    .save_subnet_create_msg(subnet_id, block_height, create_subnet_msg.clone())
-                    .await
-                {
+                if let Err(e) = create_subnet_msg.save_to_db(&self.db, subnet_id, block_height) {
                     error!("Failed to save subnet to DB: {:?}", e);
                 }
-
                 Ok(())
             }
 
@@ -352,6 +346,10 @@ where
                         join_subnet_msg, e
                     );
                     return Ok(());
+                }
+
+                if let Err(e) = join_subnet_msg.save_to_db(&self.db, txid) {
+                    error!("Failed to save join subnet msg to DB: {:?}", e);
                 }
 
                 info!("{:?}", join_subnet_msg);

--- a/src/bin/monitor.rs
+++ b/src/bin/monitor.rs
@@ -24,9 +24,12 @@ async fn main() {
     env_logger::init();
 
     // Initialize the database
-    let db = HeedDb::new(&std::env::var("DATABASE_URL").expect("DATABASE_URL must be set"))
-        .await
-        .expect("Failed to initialize database");
+    let db = HeedDb::new(
+        &std::env::var("DATABASE_URL").expect("DATABASE_URL must be set"),
+        false,
+    )
+    .await
+    .expect("Failed to initialize database");
 
     // Init the bitcoincore_rpc client
 

--- a/src/bin/monitor.rs
+++ b/src/bin/monitor.rs
@@ -108,7 +108,7 @@ where
         self.current_height = self
             .db
             .get_last_processed_block()
-            .map_err(|e| MonitorError::CannotGetMonitorInfo(e))?;
+            .map_err(MonitorError::CannotGetMonitorInfo)?;
 
         loop {
             if self.cancel_token.is_cancelled() {

--- a/src/bin/monitor.rs
+++ b/src/bin/monitor.rs
@@ -278,9 +278,11 @@ where
                 let witness_str = find_valid_utf8(&concatenated_data);
                 let ipc_message = IpcMessage::deserialize(witness_str);
 
+                // debug!("IPC message: {:?}", ipc_message);
+
                 match ipc_message {
                     Ok(msg) => {
-                        self.process_ipc_msg(block_height, &txid, msg).await?;
+                        self.process_ipc_msg(block_height, &tx, &txid, msg).await?;
                     }
                     Err(_) => {
                         continue;
@@ -295,22 +297,23 @@ where
     async fn process_ipc_msg(
         &self,
         block_height: u64,
+        tx: &bitcoin::Transaction,
         txid: &bitcoin::Txid,
         msg: IpcMessage,
     ) -> Result<(), MonitorError> {
         match msg {
-            IpcMessage::CreateSubnet(create_subnet_params) => {
-                if let Err(e) = create_subnet_params.validate() {
+            IpcMessage::CreateSubnet(create_subnet_msg) => {
+                if let Err(e) = create_subnet_msg.validate() {
                     error!(
-                        "create_subnet msg invalid msg={:?} error={:?}",
-                        create_subnet_params, e
+                        "create_subnet_msg invalid {:?} error={:?}",
+                        create_subnet_msg, e
                     );
                     return Ok(());
                 }
 
                 let subnet_id = ipc_lib::SubnetId::from_txid(txid);
 
-                let multisig_addr = create_subnet_params
+                let multisig_addr = create_subnet_msg
                     .multisig_address_from_whitelist()
                     .map_err(|e| MonitorError::IpcMsgError(e.to_string()))?;
 
@@ -318,13 +321,13 @@ where
 
                 debug!(
                     "block={} subnet_id={} msg={:?}",
-                    block_height, subnet_id, create_subnet_params
+                    block_height, subnet_id, create_subnet_msg
                 );
 
                 // TODO handle errors better
                 if let Err(e) = self
                     .db
-                    .save_subnet_create_msg(subnet_id, block_height, create_subnet_params.clone())
+                    .save_subnet_create_msg(subnet_id, block_height, create_subnet_msg.clone())
                     .await
                 {
                     error!("Failed to save subnet to DB: {:?}", e);
@@ -333,7 +336,28 @@ where
                 Ok(())
             }
 
-            IpcMessage::PrefundSubnet(_) => todo!(),
+            IpcMessage::JoinSubnet(mut join_subnet_msg) => {
+                join_subnet_msg.collateral = match tx.output.first() {
+                    Some(output) => output.value,
+                    None => {
+                        return Err(MonitorError::IpcMsgError(
+                            "Collaterall must be non zero".to_string(),
+                        ))
+                    }
+                };
+
+                if let Err(e) = join_subnet_msg.validate() {
+                    error!(
+                        "join_subnet_msg invalid {:?} error={:?}",
+                        join_subnet_msg, e
+                    );
+                    return Ok(());
+                }
+
+                info!("{:?}", join_subnet_msg);
+
+                Ok(())
+            }
         }
     }
 }

--- a/src/bin/monitor.rs
+++ b/src/bin/monitor.rs
@@ -146,11 +146,9 @@ where
                         }
                     }
                     Err(e) => {
-                        error!(
-                            "Error processing block {}: {:?}. Retrying...",
-                            next_height, e
-                        );
+                        error!("Error processing block {}: {:?}.", next_height, e);
                         // Retry logic can be added here if needed
+                        return Err(e);
                     }
                 }
             }
@@ -191,10 +189,9 @@ where
                                 }
                             }
                             Err(e) => {
-                                error!(
-                                    "Error processing block {}: {:?}. Retrying...",
-                                    block_count, e
-                                );
+                                error!("Error processing block {}: {:?}.", block_count, e);
+                                // Retry logic can be added here if needed
+                                return Err(e);
                             }
                         }
                     }
@@ -344,7 +341,7 @@ where
                 };
 
                 join_subnet_msg.validate()?;
-                join_subnet_msg.save_to_db(&self.db, txid)?;
+                join_subnet_msg.save_to_db(&self.db, block_height, txid)?;
                 Ok(())
             }
         }

--- a/src/bin/monitor.rs
+++ b/src/bin/monitor.rs
@@ -305,7 +305,7 @@ where
                     return Ok(());
                 }
 
-                let subnet_id = ipc_lib::subnet_id_from_txid(txid);
+                let subnet_id = ipc_lib::SubnetId::from_txid(txid);
 
                 let multisig_addr = create_subnet_params
                     .multisig_address_from_whitelist()
@@ -321,7 +321,13 @@ where
                 // TODO handle errors better
                 if let Err(e) = self
                     .db
-                    .save_subnet_create_msg(block_height, &subnet_id, &create_subnet_params)
+                    .save_subnet_create_msg(
+                        subnet_id,
+                        block_height,
+                        // TODO remove the into_unchecked
+                        multisig_addr.clone().into_unchecked(),
+                        create_subnet_params.clone(),
+                    )
                     .await
                 {
                     error!("Failed to save subnet to DB: {:?}", e);

--- a/src/bin/provider.rs
+++ b/src/bin/provider.rs
@@ -1,4 +1,5 @@
 use bitcoin_ipc::bitcoin_utils::make_rpc_client_from_env;
+use bitcoin_ipc::db::HeedDb;
 use bitcoin_ipc::provider;
 use dotenv::dotenv;
 use log::error;
@@ -15,6 +16,17 @@ async fn main() -> std::io::Result<()> {
     // Initialize the logger, configurable by the RUST_LOG env
 
     env_logger::init();
+
+    // Initialize the database
+
+    let db = Arc::new(
+        HeedDb::new(
+            &std::env::var("DATABASE_URL").expect("DATABASE_URL must be set"),
+            true, // using db in read-only mode
+        )
+        .await
+        .expect("Failed to initialize database"),
+    );
 
     // Load auth token from env
 
@@ -34,7 +46,7 @@ async fn main() -> std::io::Result<()> {
 
     let port = std::env::var("PROVIDER_PORT").unwrap_or_else(|_| DEFAULT_PROVIDER_PORT.to_string());
 
-    let server_data = Arc::new(provider::ServerData { btc_rpc });
+    let server_data = Arc::new(provider::ServerData { db, btc_rpc });
 
     provider::Server::new(token, port, server_data)
         .serve()

--- a/src/bitcoin_utils.rs
+++ b/src/bitcoin_utils.rs
@@ -19,7 +19,7 @@ use bitcoin::{
     script::{Instruction, PushBytes},
     secp256k1::{All, Secp256k1},
     taproot::{LeafVersion, TaprootBuilder, TaprootSpendInfo},
-    Address, FeeRate, Network, ScriptBuf, Weight, XOnlyPublicKey,
+    Address, Amount, FeeRate, Network, ScriptBuf, Weight, XOnlyPublicKey,
 };
 
 use bitcoincore_rpc::json::{EstimateMode, EstimateSmartFeeResult};
@@ -170,6 +170,7 @@ pub fn create_commit_reveal_txs(
     secp: &Secp256k1<bitcoin::secp256k1::All>,
     final_address: &Address,
     data: &[u8],
+    amount_to_send: Option<Amount>,
 ) -> Result<(Transaction, Transaction), BitcoinUtilsError> {
     trace!(
         "Creating commit-reveal tx for addres={}, data={:02x?}",
@@ -184,6 +185,8 @@ pub fn create_commit_reveal_txs(
 
     // this transaction can only be spent through the script path
     let unspendable_pubkey = create_unspendable_internal_key();
+
+    let amount_to_send = amount_to_send.unwrap_or(Amount::ZERO);
 
     let builder = TaprootBuilder::new().add_leaf(0, commit_script.clone())?;
     let commit_spend_info = builder
@@ -203,7 +206,7 @@ pub fn create_commit_reveal_txs(
         input: Vec::with_capacity(0),
         output: vec![TxOut {
             // This will be increased by the value needed for the reveal tx fee
-            value: commit_script_pubkey.minimal_non_dust_custom(fee_rate),
+            value: commit_script_pubkey.minimal_non_dust_custom(fee_rate) + amount_to_send,
             script_pubkey: commit_script_pubkey.clone(),
         }],
     };
@@ -215,6 +218,12 @@ pub fn create_commit_reveal_txs(
     let control_block = commit_spend_info
         .control_block(&(commit_script.clone(), LeafVersion::TapScript))
         .ok_or(BitcoinUtilsError::CannotConstructControlBlock)?;
+
+    // Provide at least the minimal value for the output
+    let reveal_output_value = std::cmp::max(
+        commit_script_pubkey.minimal_non_dust_custom(fee_rate),
+        amount_to_send,
+    );
 
     let mut reveal_tx = Transaction {
         version: transaction::Version::TWO,
@@ -235,8 +244,7 @@ pub fn create_commit_reveal_txs(
             ..Default::default()
         }],
         output: vec![TxOut {
-            // Provide the minimal value for the output
-            value: commit_script_pubkey.minimal_non_dust_custom(fee_rate),
+            value: reveal_output_value,
             // Send to the final address specified
             script_pubkey: final_address.script_pubkey(),
         }],

--- a/src/bitcoin_utils.rs
+++ b/src/bitcoin_utils.rs
@@ -435,6 +435,11 @@ pub fn create_multisig_address(
     ))
 }
 
+pub fn multisig_threshold(participants: u16) -> u16 {
+    // TODO figure out threshold
+    (participants / 2) + 1
+}
+
 // TODO decouple errors
 #[derive(Error, Debug)]
 pub enum BitcoinUtilsError {

--- a/src/db.rs
+++ b/src/db.rs
@@ -1,16 +1,26 @@
 use crate::ipc_lib::{self, SubnetId};
 use async_trait::async_trait;
 use bitcoin::{address::NetworkUnchecked, Address, XOnlyPublicKey};
-use heed::{types::*, Database as HeedDatabase, Env, EnvOpenOptions};
+use heed::{types::*, Database as HeedDatabase, Env, EnvOpenOptions, RwTxn};
 use log::{debug, error, trace};
 use serde::{Deserialize, Serialize};
 use std::{io, path::Path};
 use thiserror::Error;
 
 const LAST_PROCESSED_BLOCK_KEY: &str = "monitor:last_processed_block";
-#[allow(dead_code)]
 const SUBNET_INFO_PREFIX: &str = "subnet_info:";
 const SUBNET_GENESIS_INFO_PREFIX: &str = "subnet_genesis_info:";
+
+pub type Wtxn<'a> = &'a mut heed::RwTxn<'a>;
+
+#[allow(dead_code)]
+fn subnet_info_key(subnet_id: SubnetId) -> String {
+    format!("{SUBNET_INFO_PREFIX}:{}", subnet_id)
+}
+
+fn subnet_genesis_info_key(subnet_id: SubnetId) -> String {
+    format!("{SUBNET_GENESIS_INFO_PREFIX}:{}", subnet_id)
+}
 
 /// State of a validator in a subnet
 #[derive(Serialize, Deserialize, Debug)]
@@ -72,11 +82,10 @@ pub struct SubnetGenesisInfo {
 }
 
 impl SubnetGenesisInfo {
-    pub fn multisig_address(&self) -> Address<NetworkUnchecked> {
+    pub fn multisig_address(&self) -> Address {
         self.create_subnet_msg
             .multisig_address_from_whitelist()
             .expect("Multisig should be valid for saved subnet genesis info")
-            .into_unchecked()
     }
 }
 
@@ -168,31 +177,34 @@ impl HeedDb {
     }
 }
 
-// TODO maybe split into multiple traits
-#[async_trait]
 pub trait Database {
+    fn write_txn(&self) -> Result<RwTxn, DbError>;
+
     // Monitor Info
-    async fn get_last_processed_block(&self) -> Result<u64, DbError>;
-    async fn set_last_processed_block(&self, block: u64) -> Result<(), DbError>;
+    fn get_last_processed_block(&self) -> Result<u64, DbError>;
+    fn set_last_processed_block(&self, block: u64) -> Result<(), DbError>;
 
     // Genesis Info
-    async fn get_subnet_genesis_info(
+    fn get_subnet_genesis_info(
         &self,
         subnet_id: SubnetId,
     ) -> Result<Option<SubnetGenesisInfo>, DbError>;
-    async fn save_subnet_create_msg(
+    fn save_subnet_genesis_info(
         &self,
+        txn: &mut RwTxn,
         subnet_id: SubnetId,
-        block_height: u64,
-        create_subnet_msg: ipc_lib::IpcCreateSubnetMsg,
+        genesis_info: SubnetGenesisInfo,
     ) -> Result<(), DbError>;
-
-    // TODO Subnet State
 }
 
 #[async_trait]
 impl Database for HeedDb {
-    async fn get_last_processed_block(&self) -> Result<u64, DbError> {
+    fn write_txn(&self) -> Result<RwTxn, DbError> {
+        self.env.write_txn().map_err(|e| e.into())
+    }
+
+    // Monitor Info
+    fn get_last_processed_block(&self) -> Result<u64, DbError> {
         let txn = self.env.read_txn()?;
         match self.monitor_info.get(&txn, LAST_PROCESSED_BLOCK_KEY)? {
             Some(MonitorInfo {
@@ -208,7 +220,7 @@ impl Database for HeedDb {
         }
     }
 
-    async fn set_last_processed_block(&self, block_height: u64) -> Result<(), DbError> {
+    fn set_last_processed_block(&self, block_height: u64) -> Result<(), DbError> {
         trace!("Set last processed block = {}", block_height);
         let mut txn = self.env.write_txn()?;
         self.monitor_info.put(
@@ -224,36 +236,25 @@ impl Database for HeedDb {
 
     // Genesis Info
 
-    async fn get_subnet_genesis_info(
+    fn get_subnet_genesis_info(
         &self,
         subnet_id: SubnetId,
     ) -> Result<Option<SubnetGenesisInfo>, DbError> {
-        let key = format!("{SUBNET_GENESIS_INFO_PREFIX}:{}", subnet_id);
+        let key = subnet_genesis_info_key(subnet_id);
         let txn = self.env.read_txn()?;
         let subnet = self.subnet_genesis_db.get(&txn, &key)?;
         Ok(subnet)
     }
 
-    async fn save_subnet_create_msg(
+    fn save_subnet_genesis_info(
         &self,
+        txn: &mut RwTxn,
         subnet_id: SubnetId,
-        genesis_block_height: u64,
-        create_subnet_msg: ipc_lib::IpcCreateSubnetMsg,
+        subnet_genesis_info: SubnetGenesisInfo,
     ) -> Result<(), DbError> {
-        // TODO check network
-
-        let subnet = SubnetGenesisInfo {
-            create_subnet_msg,
-            bootstrapped: false,
-            genesis_block_height,
-            boostrap_block_height: None,
-            genesis_validators: Vec::with_capacity(0),
-        };
-        let key = format!("{SUBNET_GENESIS_INFO_PREFIX}:{}", subnet_id);
-        debug!("key={} subnet={:#?}", key, &subnet);
-        let mut txn = self.env.write_txn()?;
-        self.subnet_genesis_db.put(&mut txn, &key, &subnet)?;
-        txn.commit()?;
+        let key = subnet_genesis_info_key(subnet_id);
+        self.subnet_genesis_db
+            .put(txn, &key, &subnet_genesis_info)?;
         Ok(())
     }
 }
@@ -267,6 +268,12 @@ pub enum DbError {
     /// LMDB database not found and cannot be created in read-only mode
     #[error("Database {0} not found and cannot be created in read-only mode")]
     DbNotFound(String),
+
+    #[error("Value not found for key {0}")]
+    KeyValueNotFound(String),
+
+    #[error("Key {0} could not be modified: {1}")]
+    KeyModificationError(String, String),
 
     #[error(transparent)]
     IoError(#[from] io::Error),

--- a/src/db.rs
+++ b/src/db.rs
@@ -29,6 +29,8 @@ pub struct SubnetValidator {
     pub pubkey: XOnlyPublicKey,
     /// The current balance of the validator's stake
     pub collateral: bitcoin::Amount,
+    /// Validator backup address
+    pub backup_address: Address<NetworkUnchecked>,
     /// The IP address of the validator, as
     /// advertised in the subnet's join message
     pub ip: std::net::SocketAddr,
@@ -65,7 +67,7 @@ pub struct SubnetState {
 #[derive(Serialize, Deserialize, Debug)]
 pub struct SubnetGenesisInfo {
     /// The original create subnet msg, which holds
-    /// the configuration alongside the validatorsg whitelist
+    /// the configuration alongside the validator whitelist
     ///
     /// The pre-boostrap multisig is constructed from the whitelist
     pub create_subnet_msg: ipc_lib::IpcCreateSubnetMsg,

--- a/src/db.rs
+++ b/src/db.rs
@@ -4,23 +4,24 @@ use bitcoin::{address::NetworkUnchecked, Address};
 use heed::{types::*, Database as HeedDatabase, Env, EnvOpenOptions};
 use log::{debug, error, trace};
 use serde::{Deserialize, Serialize};
-use std::path::Path;
+use std::{io, path::Path};
 use thiserror::Error;
 
 const LAST_PROCESSED_BLOCK_KEY: &str = "monitor:last_processed_block";
+const SUBNET_INFO_PREFIX: &str = "subnet_info:";
 
 // Temporary struct until the DB structure is better defined
 #[derive(Serialize, Deserialize, Debug)]
 pub struct Subnet {
-    genesis_block_height: u64,
-    subnet_id: SubnetId,
-    multisig_address: Address<NetworkUnchecked>,
-    create_subnet_msg: ipc_lib::IpcCreateSubnetMsg,
+    pub genesis_block_height: u64,
+    pub subnet_id: SubnetId,
+    pub multisig_address: Address<NetworkUnchecked>,
+    pub create_subnet_msg: ipc_lib::IpcCreateSubnetMsg,
 }
 
 #[derive(Serialize, Deserialize)]
 struct MonitorInfo {
-    last_processed_block: u64,
+    pub last_processed_block: u64,
 }
 
 pub struct HeedDb {
@@ -30,10 +31,16 @@ pub struct HeedDb {
 }
 
 impl HeedDb {
-    pub async fn new(database_path: &str) -> Result<Self, DbError> {
+    pub async fn new(database_path: &str, read_only: bool) -> Result<Self, DbError> {
         let database_path = Path::new(&database_path);
 
         if !database_path.exists() {
+            if read_only {
+                return Err(DbError::DbEnvironmentNotFound(
+                    database_path.display().to_string(),
+                ));
+            }
+
             debug!(
                 "Database directory does not exist, creating: {}",
                 database_path.display()
@@ -42,20 +49,53 @@ impl HeedDb {
             // Ensure the directory exists
             std::fs::create_dir_all(database_path).map_err(|e| {
                 error!("Error creating database directory: {}", e);
-                DbError::HeedError(heed::Error::Io(e))
+                e
             })?;
         }
 
-        let env = unsafe { EnvOpenOptions::new().max_dbs(10).open(database_path)? };
-        let mut txn = env.write_txn()?;
-        let monitor_info = env.create_database(&mut txn, Some("monitor_info"))?;
-        let subnet_db = env.create_database(&mut txn, Some("subnet_db"))?;
-        txn.commit()?;
-        Ok(Self {
-            env,
-            monitor_info,
-            subnet_db,
-        })
+        let flags = if read_only {
+            debug!("Opening database in read-only mode");
+            heed::EnvFlags::READ_ONLY
+        } else {
+            heed::EnvFlags::empty()
+        };
+        let env = unsafe {
+            EnvOpenOptions::new()
+                .flags(flags)
+                // TODO set max_dbs automatically
+                .max_dbs(10)
+                .open(database_path)?
+        };
+
+        if read_only {
+            // In read-only mode, we need to open existing databases
+            let rtxn = env.read_txn()?;
+            let monitor_info = env
+                .open_database(&rtxn, Some("monitor_info"))?
+                .ok_or(DbError::DbNotFound("monitor_info".to_string()))?;
+            let subnet_db = env
+                .open_database(&rtxn, Some("subnet_db"))?
+                .ok_or(DbError::DbNotFound("subnet_db".to_string()))?;
+            rtxn.commit()?;
+
+            Ok(Self {
+                env,
+                monitor_info,
+                subnet_db,
+            })
+        } else {
+            // In write mode, we can create the databases if they don't exist
+            let mut txn = env.write_txn()?;
+            let monitor_info = env.create_database(&mut txn, Some("monitor_info"))?;
+            let subnet_db = env.create_database(&mut txn, Some("subnet_db"))?;
+            txn.commit()?;
+
+            Ok(Self {
+                env,
+                monitor_info,
+                subnet_db,
+            })
+        }
     }
 }
 
@@ -70,7 +110,7 @@ pub trait Database {
         multisig_address: bitcoin::Address<NetworkUnchecked>,
         create_subnet_msg: ipc_lib::IpcCreateSubnetMsg,
     ) -> Result<(), DbError>;
-    async fn get_subnet_create_msg(&self, subnet_id: &str) -> Result<Option<Subnet>, DbError>;
+    async fn get_subnet_info(&self, subnet_id: SubnetId) -> Result<Option<Subnet>, DbError>;
 }
 
 #[async_trait]
@@ -112,21 +152,24 @@ impl Database for HeedDb {
         multisig_address: bitcoin::Address<NetworkUnchecked>,
         create_subnet_msg: ipc_lib::IpcCreateSubnetMsg,
     ) -> Result<(), DbError> {
+        // TODO check network
+
         let subnet = Subnet {
             genesis_block_height,
             subnet_id,
             multisig_address,
             create_subnet_msg,
         };
-        let key = format!("create_msg:{}", subnet_id);
+        let key = format!("{SUBNET_INFO_PREFIX}:{}", subnet_id);
+        debug!("key={} subnet={:#?}", key, &subnet);
         let mut txn = self.env.write_txn()?;
         self.subnet_db.put(&mut txn, &key, &subnet)?;
         txn.commit()?;
         Ok(())
     }
 
-    async fn get_subnet_create_msg(&self, subnet_id: &str) -> Result<Option<Subnet>, DbError> {
-        let key = format!("create_msg:{}", subnet_id);
+    async fn get_subnet_info(&self, subnet_id: SubnetId) -> Result<Option<Subnet>, DbError> {
+        let key = format!("{SUBNET_INFO_PREFIX}:{}", subnet_id);
         let txn = self.env.read_txn()?;
         let subnet = self.subnet_db.get(&txn, &key)?;
         Ok(subnet)
@@ -135,6 +178,17 @@ impl Database for HeedDb {
 
 #[derive(Error, Debug)]
 pub enum DbError {
+    /// Database environment not found and cannot be created in read-only mode
+    #[error("Database environment {0} not found and cannot be created in read-only mode")]
+    DbEnvironmentNotFound(String),
+
+    /// LMDB database not found and cannot be created in read-only mode
+    #[error("Database {0} not found and cannot be created in read-only mode")]
+    DbNotFound(String),
+
+    #[error(transparent)]
+    IoError(#[from] io::Error),
+
     #[error(transparent)]
     HeedError(#[from] heed::Error),
 

--- a/src/db.rs
+++ b/src/db.rs
@@ -1,6 +1,6 @@
 use crate::ipc_lib::{self, SubnetId};
 use async_trait::async_trait;
-use bitcoin::{address::NetworkUnchecked, Address};
+use bitcoin::{address::NetworkUnchecked, Address, XOnlyPublicKey};
 use heed::{types::*, Database as HeedDatabase, Env, EnvOpenOptions};
 use log::{debug, error, trace};
 use serde::{Deserialize, Serialize};
@@ -8,15 +8,66 @@ use std::{io, path::Path};
 use thiserror::Error;
 
 const LAST_PROCESSED_BLOCK_KEY: &str = "monitor:last_processed_block";
+#[allow(dead_code)]
 const SUBNET_INFO_PREFIX: &str = "subnet_info:";
+const SUBNET_GENESIS_INFO_PREFIX: &str = "subnet_genesis_info:";
 
-// Temporary struct until the DB structure is better defined
+/// State of a validator in a subnet
 #[derive(Serialize, Deserialize, Debug)]
-pub struct Subnet {
-    pub genesis_block_height: u64,
+pub struct SubnetValidator {
+    /// The public key of the validator
+    pub pubkey: XOnlyPublicKey,
+    /// The current balance of the validator's stake
+    pub balance: bitcoin::Amount,
+    /// The IP address of the validator, as
+    /// advertised in the subnet's join/pre-fund message
+    pub ip: std::net::SocketAddr,
+    /// The transaction ID of the join/pre-fund message
+    pub join_txid: bitcoin::Txid,
+}
+
+/// The current state of a subnet
+/// Must only exist if the subnet is bootstrapped
+///
+/// Note: many more fields will be added here
+#[derive(Serialize, Deserialize, Debug)]
+pub struct SubnetState {
+    /// Duplicate of the subnet ID, for easy access
     pub subnet_id: SubnetId,
+    /// The current list of validators, with their balances
+    pub validators: Vec<SubnetValidator>,
+    /// The subnet multisig address
     pub multisig_address: Address<NetworkUnchecked>,
+}
+
+/// Genesis info for a subnet
+#[derive(Serialize, Deserialize, Debug)]
+pub struct SubnetGenesisInfo {
+    /// The original create subnet msg, which holds
+    /// the configuration alongside the validatorsg whitelist
+    ///
+    /// The pre-boostrap multisig is constructed from the whitelist
     pub create_subnet_msg: ipc_lib::IpcCreateSubnetMsg,
+    /// Marks if the subnet is bootstrapped
+    /// The struct should never be modified after bootstrapping
+    pub bootstrapped: bool,
+    /// The height of the block where the create subnet
+    /// message was included
+    pub genesis_block_height: u64,
+    /// The height of the block where the subnet was bootstrapped
+    pub boostrap_block_height: Option<u64>,
+    /// The list of validators that boostrapped the subnet
+    /// (by pre-funding the subnet)
+    pub genesis_validators: Vec<SubnetValidator>,
+}
+
+impl SubnetGenesisInfo {
+    pub fn multisig_address(&self) -> Address<NetworkUnchecked> {
+        self.create_subnet_msg
+            .multisig_address_from_whitelist()
+            .expect("Multisig should be valid for saved subnet genesis info")
+            .into_unchecked()
+    }
 }
 
 #[derive(Serialize, Deserialize)]
@@ -27,7 +78,9 @@ struct MonitorInfo {
 pub struct HeedDb {
     env: Env,
     monitor_info: HeedDatabase<Str, SerdeBincode<MonitorInfo>>,
-    subnet_db: HeedDatabase<Str, SerdeBincode<Subnet>>,
+    #[allow(dead_code)]
+    subnet_db: HeedDatabase<Str, SerdeBincode<SubnetState>>,
+    subnet_genesis_db: HeedDatabase<Str, SerdeBincode<SubnetGenesisInfo>>,
 }
 
 impl HeedDb {
@@ -76,41 +129,55 @@ impl HeedDb {
             let subnet_db = env
                 .open_database(&rtxn, Some("subnet_db"))?
                 .ok_or(DbError::DbNotFound("subnet_db".to_string()))?;
+            let subnet_genesis_db = env
+                .open_database(&rtxn, Some("subnet_genesis_db"))?
+                .ok_or(DbError::DbNotFound("subnet_genesis_db".to_string()))?;
             rtxn.commit()?;
 
             Ok(Self {
                 env,
                 monitor_info,
                 subnet_db,
+                subnet_genesis_db,
             })
         } else {
             // In write mode, we can create the databases if they don't exist
             let mut txn = env.write_txn()?;
             let monitor_info = env.create_database(&mut txn, Some("monitor_info"))?;
             let subnet_db = env.create_database(&mut txn, Some("subnet_db"))?;
+            let subnet_genesis_db = env.create_database(&mut txn, Some("subnet_genesis_db"))?;
             txn.commit()?;
 
             Ok(Self {
                 env,
                 monitor_info,
                 subnet_db,
+                subnet_genesis_db,
             })
         }
     }
 }
 
+// TODO maybe split into multiple traits
 #[async_trait]
 pub trait Database {
+    // Monitor Info
     async fn get_last_processed_block(&self) -> Result<u64, DbError>;
     async fn set_last_processed_block(&self, block: u64) -> Result<(), DbError>;
+
+    // Genesis Info
+    async fn get_subnet_genesis_info(
+        &self,
+        subnet_id: SubnetId,
+    ) -> Result<Option<SubnetGenesisInfo>, DbError>;
     async fn save_subnet_create_msg(
         &self,
         subnet_id: SubnetId,
         block_height: u64,
-        multisig_address: bitcoin::Address<NetworkUnchecked>,
         create_subnet_msg: ipc_lib::IpcCreateSubnetMsg,
     ) -> Result<(), DbError>;
-    async fn get_subnet_info(&self, subnet_id: SubnetId) -> Result<Option<Subnet>, DbError>;
+
+    // TODO Subnet State
 }
 
 #[async_trait]
@@ -145,34 +212,39 @@ impl Database for HeedDb {
         Ok(())
     }
 
+    // Genesis Info
+
+    async fn get_subnet_genesis_info(
+        &self,
+        subnet_id: SubnetId,
+    ) -> Result<Option<SubnetGenesisInfo>, DbError> {
+        let key = format!("{SUBNET_GENESIS_INFO_PREFIX}:{}", subnet_id);
+        let txn = self.env.read_txn()?;
+        let subnet = self.subnet_genesis_db.get(&txn, &key)?;
+        Ok(subnet)
+    }
+
     async fn save_subnet_create_msg(
         &self,
         subnet_id: SubnetId,
         genesis_block_height: u64,
-        multisig_address: bitcoin::Address<NetworkUnchecked>,
         create_subnet_msg: ipc_lib::IpcCreateSubnetMsg,
     ) -> Result<(), DbError> {
         // TODO check network
 
-        let subnet = Subnet {
-            genesis_block_height,
-            subnet_id,
-            multisig_address,
+        let subnet = SubnetGenesisInfo {
             create_subnet_msg,
+            bootstrapped: false,
+            genesis_block_height,
+            boostrap_block_height: None,
+            genesis_validators: Vec::with_capacity(0),
         };
-        let key = format!("{SUBNET_INFO_PREFIX}:{}", subnet_id);
+        let key = format!("{SUBNET_GENESIS_INFO_PREFIX}:{}", subnet_id);
         debug!("key={} subnet={:#?}", key, &subnet);
         let mut txn = self.env.write_txn()?;
-        self.subnet_db.put(&mut txn, &key, &subnet)?;
+        self.subnet_genesis_db.put(&mut txn, &key, &subnet)?;
         txn.commit()?;
         Ok(())
-    }
-
-    async fn get_subnet_info(&self, subnet_id: SubnetId) -> Result<Option<Subnet>, DbError> {
-        let key = format!("{SUBNET_INFO_PREFIX}:{}", subnet_id);
-        let txn = self.env.read_txn()?;
-        let subnet = self.subnet_db.get(&txn, &key)?;
-        Ok(subnet)
     }
 }
 

--- a/src/db.rs
+++ b/src/db.rs
@@ -32,7 +32,7 @@ pub struct SubnetValidator {
     /// The public key of the validator
     pub pubkey: XOnlyPublicKey,
     /// The ethereum address of the validator pubkey
-    pub eth_address: alloy_primitives::Address,
+    pub subnet_address: alloy_primitives::Address,
     /// The current balance of the validator's stake
     pub collateral: bitcoin::Amount,
     /// Validator backup address

--- a/src/db.rs
+++ b/src/db.rs
@@ -31,6 +31,8 @@ fn subnet_genesis_info_key(subnet_id: SubnetId) -> String {
 pub struct SubnetValidator {
     /// The public key of the validator
     pub pubkey: XOnlyPublicKey,
+    /// The ethereum address of the validator pubkey
+    pub eth_address: alloy_primitives::Address,
     /// The current balance of the validator's stake
     pub collateral: bitcoin::Amount,
     /// Validator backup address

--- a/src/db.rs
+++ b/src/db.rs
@@ -1,5 +1,6 @@
-use crate::ipc_lib;
+use crate::ipc_lib::{self, SubnetId};
 use async_trait::async_trait;
+use bitcoin::{address::NetworkUnchecked, Address};
 use heed::{types::*, Database as HeedDatabase, Env, EnvOpenOptions};
 use log::{debug, error, trace};
 use serde::{Deserialize, Serialize};
@@ -11,8 +12,9 @@ const LAST_PROCESSED_BLOCK_KEY: &str = "monitor:last_processed_block";
 // Temporary struct until the DB structure is better defined
 #[derive(Serialize, Deserialize, Debug)]
 pub struct Subnet {
-    block_height: u64,
-    subnet_id: String,
+    genesis_block_height: u64,
+    subnet_id: SubnetId,
+    multisig_address: Address<NetworkUnchecked>,
     create_subnet_msg: ipc_lib::IpcCreateSubnetMsg,
 }
 
@@ -63,9 +65,10 @@ pub trait Database {
     async fn set_last_processed_block(&self, block: u64) -> Result<(), DbError>;
     async fn save_subnet_create_msg(
         &self,
+        subnet_id: SubnetId,
         block_height: u64,
-        subnet_id: &str,
-        create_subnet_msg: &ipc_lib::IpcCreateSubnetMsg,
+        multisig_address: bitcoin::Address<NetworkUnchecked>,
+        create_subnet_msg: ipc_lib::IpcCreateSubnetMsg,
     ) -> Result<(), DbError>;
     async fn get_subnet_create_msg(&self, subnet_id: &str) -> Result<Option<Subnet>, DbError>;
 }
@@ -104,14 +107,16 @@ impl Database for HeedDb {
 
     async fn save_subnet_create_msg(
         &self,
-        block_height: u64,
-        subnet_id: &str,
-        create_subnet_params: &ipc_lib::IpcCreateSubnetMsg,
+        subnet_id: SubnetId,
+        genesis_block_height: u64,
+        multisig_address: bitcoin::Address<NetworkUnchecked>,
+        create_subnet_msg: ipc_lib::IpcCreateSubnetMsg,
     ) -> Result<(), DbError> {
         let subnet = Subnet {
-            block_height,
-            subnet_id: subnet_id.to_string(),
-            create_subnet_msg: create_subnet_params.clone(),
+            genesis_block_height,
+            subnet_id,
+            multisig_address,
+            create_subnet_msg,
         };
         let key = format!("create_msg:{}", subnet_id);
         let mut txn = self.env.write_txn()?;

--- a/src/db.rs
+++ b/src/db.rs
@@ -1,4 +1,8 @@
-use crate::ipc_lib::{self, SubnetId};
+use crate::{
+    bitcoin_utils::{create_multisig_address, multisig_threshold},
+    ipc_lib::{self, SubnetId},
+    NETWORK,
+};
 use async_trait::async_trait;
 use bitcoin::{address::NetworkUnchecked, Address, XOnlyPublicKey};
 use heed::{types::*, Database as HeedDatabase, Env, EnvOpenOptions, RwTxn};
@@ -23,7 +27,7 @@ fn subnet_genesis_info_key(subnet_id: SubnetId) -> String {
 }
 
 /// State of a validator in a subnet
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct SubnetValidator {
     /// The public key of the validator
     pub pubkey: XOnlyPublicKey,
@@ -36,6 +40,38 @@ pub struct SubnetValidator {
     pub ip: std::net::SocketAddr,
     /// The transaction ID of the join message
     pub join_txid: bitcoin::Txid,
+}
+
+trait SubnetValidators {
+    fn multisig_address(&self) -> Address<NetworkUnchecked>;
+    fn threshold(&self) -> u16;
+    fn to_committee(&self) -> SubnetCommittee;
+}
+
+impl SubnetValidators for Vec<SubnetValidator> {
+    fn multisig_address(&self) -> Address<NetworkUnchecked> {
+        let secp = bitcoin::secp256k1::Secp256k1::new();
+        let pubkeys = self.iter().map(|v| v.pubkey).collect::<Vec<_>>();
+        // TODO remove as 16
+        let threshold = multisig_threshold(pubkeys.len() as u16);
+        let multisig_address = create_multisig_address(&secp, &pubkeys, threshold.into(), NETWORK)
+            .expect("Multisig address should be valid");
+
+        multisig_address.into_unchecked()
+    }
+
+    fn threshold(&self) -> u16 {
+        // TODO remove as 16
+        multisig_threshold(self.len() as u16)
+    }
+
+    fn to_committee(&self) -> SubnetCommittee {
+        SubnetCommittee {
+            threshold: self.threshold() as u16,
+            validators: self.to_vec(),
+            multisig_address: self.multisig_address(),
+        }
+    }
 }
 
 /// The committee of a subnet
@@ -56,11 +92,17 @@ pub struct SubnetCommittee {
 #[derive(Serialize, Deserialize, Debug)]
 pub struct SubnetState {
     /// Duplicate of the subnet ID, for easy access
-    pub subnet_id: SubnetId,
+    pub id: SubnetId,
     /// The current committee number
     pub committee_number: u64,
     /// The current commitee
     pub committee: SubnetCommittee,
+}
+
+impl SubnetState {
+    pub fn stake(&self) -> bitcoin::Amount {
+        self.committee.validators.iter().map(|v| v.collateral).sum()
+    }
 }
 
 /// Genesis info for a subnet
@@ -88,6 +130,14 @@ impl SubnetGenesisInfo {
         self.create_subnet_msg
             .multisig_address_from_whitelist()
             .expect("Multisig should be valid for saved subnet genesis info")
+    }
+
+    pub fn into_subnet(self, subnet_id: SubnetId) -> SubnetState {
+        SubnetState {
+            id: subnet_id,
+            committee_number: 1,
+            committee: self.genesis_validators.to_committee(),
+        }
     }
 }
 

--- a/src/db.rs
+++ b/src/db.rs
@@ -18,12 +18,23 @@ pub struct SubnetValidator {
     /// The public key of the validator
     pub pubkey: XOnlyPublicKey,
     /// The current balance of the validator's stake
-    pub balance: bitcoin::Amount,
+    pub collateral: bitcoin::Amount,
     /// The IP address of the validator, as
-    /// advertised in the subnet's join/pre-fund message
+    /// advertised in the subnet's join message
     pub ip: std::net::SocketAddr,
-    /// The transaction ID of the join/pre-fund message
+    /// The transaction ID of the join message
     pub join_txid: bitcoin::Txid,
+}
+
+/// The committee of a subnet
+#[derive(Serialize, Deserialize, Debug)]
+pub struct SubnetCommittee {
+    /// The threshold for the multisig
+    pub threshold: u16,
+    /// The current list of validators, with their balances
+    pub validators: Vec<SubnetValidator>,
+    /// The subnet multisig address
+    pub multisig_address: Address<NetworkUnchecked>,
 }
 
 /// The current state of a subnet
@@ -34,10 +45,10 @@ pub struct SubnetValidator {
 pub struct SubnetState {
     /// Duplicate of the subnet ID, for easy access
     pub subnet_id: SubnetId,
-    /// The current list of validators, with their balances
-    pub validators: Vec<SubnetValidator>,
-    /// The subnet multisig address
-    pub multisig_address: Address<NetworkUnchecked>,
+    /// The current committee number
+    pub committee_number: u64,
+    /// The current commitee
+    pub committee: SubnetCommittee,
 }
 
 /// Genesis info for a subnet
@@ -57,7 +68,6 @@ pub struct SubnetGenesisInfo {
     /// The height of the block where the subnet was bootstrapped
     pub boostrap_block_height: Option<u64>,
     /// The list of validators that boostrapped the subnet
-    /// (by pre-funding the subnet)
     pub genesis_validators: Vec<SubnetValidator>,
 }
 

--- a/src/eth_utils.rs
+++ b/src/eth_utils.rs
@@ -1,0 +1,59 @@
+/// Derives the Ethereum address from a Bitcoin x-only public key
+// TODO from_raw_public_key could panic if pubkey.len() is not 64
+pub fn eth_addr_from_x_only_pubkey(pubkey: bitcoin::XOnlyPublicKey) -> alloy_primitives::Address {
+    // In Bitcoin, XOnlyPublicKey is assumed to have even parity
+    let pubkey = pubkey.public_key(bitcoin::key::Parity::Even);
+    // Remove the prefix
+    let pubkey = &pubkey.serialize_uncompressed()[1..];
+
+    alloy_primitives::Address::from_raw_public_key(pubkey)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloy_primitives::Address;
+    use bitcoin::key::{Keypair, XOnlyPublicKey};
+    use bitcoin::secp256k1::Secp256k1;
+
+    #[test]
+    fn test_eth_addr_from_x_only_pubkey() {
+        let secp = Secp256k1::new();
+
+        // Keep generating keypairs until we get one with even parity
+        let (keypair, x_only_pubkey) = loop {
+            let keypair = Keypair::new(&secp, &mut rand::thread_rng());
+            let (x_only_pubkey, parity) = XOnlyPublicKey::from_keypair(&keypair);
+
+            if parity == bitcoin::key::Parity::Even {
+                break (keypair, x_only_pubkey);
+            }
+        };
+        let eth_addr = eth_addr_from_x_only_pubkey(x_only_pubkey);
+        let pubkey = &keypair.public_key().serialize_uncompressed()[1..];
+        let expected_addr = Address::from_raw_public_key(pubkey);
+        assert_eq!(eth_addr, expected_addr);
+    }
+
+    #[test]
+    fn test_eth_addr_from_x_only_pubkey_odd_parity() {
+        let secp = Secp256k1::new();
+
+        // Keep generating keypairs until we get one with odd parity
+        let (keypair, x_only_pubkey) = loop {
+            let keypair = Keypair::new(&secp, &mut rand::thread_rng());
+            let (x_only_pubkey, parity) = XOnlyPublicKey::from_keypair(&keypair);
+
+            if parity == bitcoin::key::Parity::Odd {
+                break (keypair, x_only_pubkey);
+            }
+        };
+
+        let eth_addr = eth_addr_from_x_only_pubkey(x_only_pubkey);
+        let pubkey = &keypair.public_key().serialize_uncompressed()[1..];
+        let expected_addr = Address::from_raw_public_key(pubkey);
+
+        // The addresses should NOT match when parity is odd
+        assert_ne!(eth_addr, expected_addr);
+    }
+}

--- a/src/ipc_lib.rs
+++ b/src/ipc_lib.rs
@@ -12,6 +12,7 @@ use thiserror::Error;
 
 use crate::bitcoin_utils::{self, create_multisig_address, submit_to_mempool};
 use crate::db;
+use crate::eth_utils::eth_addr_from_x_only_pubkey;
 use crate::NETWORK;
 
 // Temporary prelude module to re-export the necessary types
@@ -377,8 +378,11 @@ impl IpcJoinSubnetMsg {
 
         self.validate_for_genesis_info(&genesis_info)?;
 
+        let eth_address = eth_addr_from_x_only_pubkey(self.pubkey);
+
         let new_validator = db::SubnetValidator {
             pubkey: self.pubkey,
+            eth_address,
             collateral: self.collateral,
             backup_address: self.backup_address.clone(),
             ip: self.ip,

--- a/src/ipc_lib.rs
+++ b/src/ipc_lib.rs
@@ -378,11 +378,11 @@ impl IpcJoinSubnetMsg {
 
         self.validate_for_genesis_info(&genesis_info)?;
 
-        let eth_address = eth_addr_from_x_only_pubkey(self.pubkey);
+        let subnet_address = eth_addr_from_x_only_pubkey(self.pubkey);
 
         let new_validator = db::SubnetValidator {
             pubkey: self.pubkey,
-            eth_address,
+            subnet_address,
             collateral: self.collateral,
             backup_address: self.backup_address.clone(),
             ip: self.ip,

--- a/src/ipc_lib.rs
+++ b/src/ipc_lib.rs
@@ -1,3 +1,4 @@
+use bitcoin::address::NetworkUnchecked;
 use bitcoin::Amount;
 use bitcoin::Txid;
 use bitcoin::XOnlyPublicKey;
@@ -15,7 +16,7 @@ pub mod prelude {
     pub use super::{
         IpcCreateSubnetMsg, IpcMessage, IpcSerialize, IpcTag, IPC_CHECKPOINT_TAG,
         IPC_CREATE_SUBNET_TAG, IPC_DELETE_SUBNET_TAG, IPC_DEPOSIT_TAG, IPC_JOIN_SUBNET_TAG,
-        IPC_TAG_DELIMITER, IPC_TRANSFER_TAG, IPC_WITHDRAW_TAG,
+        IPC_PREFUND_SUBNET_TAG, IPC_TAG_DELIMITER, IPC_TRANSFER_TAG, IPC_WITHDRAW_TAG,
     };
 }
 
@@ -23,6 +24,7 @@ pub mod prelude {
 
 pub const IPC_TAG_DELIMITER: &str = "#";
 pub const IPC_CREATE_SUBNET_TAG: &str = "IPC:CREATE";
+pub const IPC_PREFUND_SUBNET_TAG: &str = "IPC:PREFUND";
 pub const IPC_JOIN_SUBNET_TAG: &str = "IPC:JOIN";
 pub const IPC_DEPOSIT_TAG: &str = "IPC:DEPOSIT";
 pub const IPC_CHECKPOINT_TAG: &str = "IPC:CHECKPOINT";
@@ -34,12 +36,14 @@ pub const IPC_DELETE_SUBNET_TAG: &str = "IPC:DELETE";
 #[derive(Debug, PartialEq)]
 pub enum IpcTag {
     CreateSubnet,
+    PrefundSubnet,
 }
 
 impl IpcTag {
     pub fn as_str(&self) -> &'static str {
         match self {
             Self::CreateSubnet => IPC_CREATE_SUBNET_TAG,
+            Self::PrefundSubnet => IPC_PREFUND_SUBNET_TAG,
         }
     }
 }
@@ -50,6 +54,7 @@ impl std::str::FromStr for IpcTag {
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         match s {
             IPC_CREATE_SUBNET_TAG => Ok(Self::CreateSubnet),
+            IPC_PREFUND_SUBNET_TAG => Ok(Self::PrefundSubnet),
             _ => Err(IpcSerializeError::UnknownTag(s.to_string())),
         }
     }
@@ -205,10 +210,33 @@ impl IpcValidate for IpcCreateSubnetMsg {
     }
 }
 
+#[derive(Serialize, Deserialize, IpcSerialize, Debug, Clone)]
+#[tag(IPC_PREFUND_SUBNET_TAG)]
+pub struct IpcPrefundSubnetMsg {
+    /// The subnet id of the subnet to pre-fund
+    subnet_id: SubnetId,
+    /// The amount to collateral to lock in the subnet
+    #[serde(with = "bitcoin::amount::serde::as_sat")]
+    collateral: bitcoin::Amount,
+    /// The amount to receive in the subnet
+    #[serde(with = "bitcoin::amount::serde::as_sat")]
+    initial_funding: bitcoin::Amount,
+    /// The IP address of the validator, as
+    /// advertised in the subnet's join/pre-fund message
+    pub ip: std::net::SocketAddr,
+    /// The bitcoin address of the validator
+    /// to receive back the collateral in case of
+    /// subnet termination.
+    btc_address: bitcoin::Address<NetworkUnchecked>,
+    /// The username of the validator
+    username: String,
+}
+
 // Define the IPCMessage enum
 #[derive(Debug)]
 pub enum IpcMessage {
     CreateSubnet(IpcCreateSubnetMsg),
+    PrefundSubnet(IpcPrefundSubnetMsg),
 }
 
 impl IpcMessage {
@@ -223,6 +251,9 @@ impl IpcMessage {
         match IpcTag::from_str(tag)? {
             IpcTag::CreateSubnet => Ok(IpcMessage::CreateSubnet(
                 IpcCreateSubnetMsg::ipc_deserialize(s)?,
+            )),
+            IpcTag::PrefundSubnet => Ok(IpcMessage::PrefundSubnet(
+                IpcPrefundSubnetMsg::ipc_deserialize(s)?,
             )),
         }
     }

--- a/src/ipc_lib.rs
+++ b/src/ipc_lib.rs
@@ -4,12 +4,14 @@ use bitcoin::Amount;
 use bitcoin::Txid;
 use bitcoin::XOnlyPublicKey;
 use ipc_serde::IpcSerialize;
+use log::trace;
 use log::{debug, info};
 use serde::{Deserialize, Serialize};
 use std::str::FromStr;
 use thiserror::Error;
 
 use crate::bitcoin_utils::{self, create_multisig_address, submit_to_mempool};
+use crate::db;
 use crate::NETWORK;
 
 // Temporary prelude module to re-export the necessary types
@@ -172,6 +174,29 @@ impl IpcCreateSubnetMsg {
             Err(e) => Err(IpcLibError::BitcoinUtilsError(e)),
         }
     }
+
+    pub fn save_to_db<D: db::Database>(
+        &self,
+        db: &D,
+        subnet_id: SubnetId,
+        genesis_block_height: u64,
+    ) -> Result<(), IpcLibError> {
+        let genesis_info = db::SubnetGenesisInfo {
+            create_subnet_msg: self.clone(),
+            bootstrapped: false,
+            genesis_block_height,
+            boostrap_block_height: None,
+            genesis_validators: Vec::with_capacity(0),
+        };
+
+        trace!("Saving {self:?} to DB, genesis_info={genesis_info:?}");
+
+        let mut wtxn = db.write_txn()?;
+        db.save_subnet_genesis_info(&mut wtxn, subnet_id, genesis_info)?;
+        wtxn.commit()?;
+
+        Ok(())
+    }
 }
 
 impl IpcValidate for IpcCreateSubnetMsg {
@@ -237,11 +262,54 @@ pub struct IpcJoinSubnetMsg {
 }
 
 impl IpcJoinSubnetMsg {
-    /// Submits the prefund subnet message to the Bitcoin network
+    /// Validates the join subnet message, for the given genesis info
+    pub fn validate_for_genesis_info(
+        &self,
+        genesis_info: &db::SubnetGenesisInfo,
+    ) -> Result<(), IpcLibError> {
+        // Check if the subnet is already bootstrapped
+        if genesis_info.bootstrapped {
+            // TODO handle when subnet already bootstrapped
+            return Err(IpcValidateError::InvalidMsg(format!(
+                "Subnet {} is already bootstrapped.",
+                self.subnet_id
+            ))
+            .into());
+        }
+
+        // Check if the collateral is at least the minimum validator stake
+        if self.collateral < genesis_info.create_subnet_msg.min_validator_stake {
+            return Err(IpcValidateError::InvalidField(
+                "collateral",
+                format!(
+                    "Collateral must be at least {}, supplied {}",
+                    genesis_info.create_subnet_msg.min_validator_stake, self.collateral,
+                ),
+            )
+            .into());
+        }
+
+        // Check if the validator with this public key is already registered
+        if genesis_info
+            .genesis_validators
+            .iter()
+            .any(|v| v.pubkey == self.pubkey)
+        {
+            return Err(IpcValidateError::InvalidField(
+                "pubkey",
+                "Validator with this public key already registered in subnet".to_string(),
+            )
+            .into());
+        }
+
+        Ok(())
+    }
+
+    /// Submits the join subnet message to the Bitcoin network
     /// Using commit-reveal scheme
     /// And sends the collateral to the subnet multisig address
     ///
-    /// Returns the prefund txid — the txid of the reveal transaction
+    /// Returns the join txid — the txid of the reveal transaction
     pub fn submit_to_bitcoin(
         &self,
         rpc: &bitcoincore_rpc::Client,
@@ -280,6 +348,35 @@ impl IpcJoinSubnetMsg {
             }
             Err(e) => Err(IpcLibError::BitcoinUtilsError(e)),
         }
+    }
+
+    /// Modifies the database to account for the join subnet message
+    pub fn save_to_db<D: db::Database>(&self, db: &D, join_txid: Txid) -> Result<(), IpcLibError> {
+        let mut genesis_info =
+            db.get_subnet_genesis_info(self.subnet_id)?
+                .ok_or(IpcValidateError::InvalidMsg(format!(
+                    "subnet id={} does not exist",
+                    self.subnet_id
+                )))?;
+
+        self.validate_for_genesis_info(&genesis_info)?;
+
+        let new_validator = db::SubnetValidator {
+            pubkey: self.pubkey,
+            collateral: self.collateral,
+            ip: self.ip,
+            join_txid,
+        };
+
+        trace!("Processing {self:?}, adding new validator {new_validator:?}");
+
+        genesis_info.genesis_validators.push(new_validator);
+
+        let mut wtxn = db.write_txn()?;
+        db.save_subnet_genesis_info(&mut wtxn, self.subnet_id, genesis_info)?;
+        wtxn.commit()?;
+
+        Ok(())
     }
 }
 
@@ -418,18 +515,16 @@ impl<'de> serde::Deserialize<'de> for SubnetId {
 #[derive(Error, Debug)]
 pub enum IpcLibError {
     #[error(transparent)]
-    BitcoinUtilsError(#[from] crate::bitcoin_utils::BitcoinUtilsError),
-}
+    IpcValidateError(#[from] IpcValidateError),
 
-#[derive(PartialEq, Eq)]
-pub enum IpcTransactionType {
-    CreateChild,
-    JoinChild,
-    Deposit,
-    Checkpoint,
-    Transfer,
-    Withdraw,
-    Delete,
+    #[error(transparent)]
+    DbError(#[from] crate::db::DbError),
+
+    #[error(transparent)]
+    HeedError(#[from] heed::Error),
+
+    #[error(transparent)]
+    BitcoinUtilsError(#[from] crate::bitcoin_utils::BitcoinUtilsError),
 }
 
 #[cfg(test)]
@@ -603,7 +698,7 @@ mod tests {
         println!("{}", serialized);
 
         // Check serialization
-        assert!(serialized.starts_with(IPC_PREFUND_SUBNET_TAG));
+        assert!(serialized.starts_with(IPC_JOIN_SUBNET_TAG));
         // collateral should not be in serialized, it's included in the output
         assert!(!serialized.contains("collateral"));
 

--- a/src/ipc_lib.rs
+++ b/src/ipc_lib.rs
@@ -154,7 +154,7 @@ impl IpcCreateSubnetMsg {
 
         match submit_to_mempool(rpc, vec![commit_tx.clone(), reveal_tx.clone()]) {
             Ok(_) => {
-                let subnet_id = SubnetId::from_txid(&commit_txid);
+                let subnet_id = SubnetId::from_txid(&reveal_txid);
                 info!("Submitted create subnet msg for subnet_id={}", subnet_id);
                 Ok(subnet_id)
             }
@@ -233,7 +233,7 @@ impl IpcMessage {
 //
 
 /// Create Subnet IPC message is sent as a commit-reveal transaction pair.
-/// Subnet ID is derived from the transaction ID of the commit transaction.
+/// Subnet ID is derived from the transaction ID of the reveal transaction.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct SubnetId(Txid);
 

--- a/src/ipc_lib.rs
+++ b/src/ipc_lib.rs
@@ -275,8 +275,7 @@ impl IpcJoinSubnetMsg {
             return Err(IpcValidateError::InvalidMsg(format!(
                 "Subnet {} is already bootstrapped.",
                 self.subnet_id
-            ))
-            .into());
+            )));
         }
 
         // Check if the collateral is at least the minimum validator stake
@@ -287,8 +286,7 @@ impl IpcJoinSubnetMsg {
                     "Collateral must be at least {}, supplied {}",
                     genesis_info.create_subnet_msg.min_validator_stake, self.collateral,
                 ),
-            )
-            .into());
+            ));
         }
 
         // Check if the validator with this public key is already registered
@@ -300,8 +298,7 @@ impl IpcJoinSubnetMsg {
             return Err(IpcValidateError::InvalidField(
                 "pubkey",
                 "Validator with this public key already registered in subnet".to_string(),
-            )
-            .into());
+            ));
         }
 
         Ok(())
@@ -387,6 +384,8 @@ impl IpcJoinSubnetMsg {
             trace!("Subnet {} bootstrapped", self.subnet_id);
             genesis_info.bootstrapped = true;
             genesis_info.boostrap_block_height = Some(block_height);
+
+            // TODO create subnet in db
         }
 
         let mut wtxn = db.write_txn()?;

--- a/src/ipc_lib.rs
+++ b/src/ipc_lib.rs
@@ -178,13 +178,15 @@ impl IpcCreateSubnetMsg {
     pub fn save_to_db<D: db::Database>(
         &self,
         db: &D,
-        subnet_id: SubnetId,
-        genesis_block_height: u64,
+        block_height: u64,
+        txid: bitcoin::Txid,
     ) -> Result<(), IpcLibError> {
+        let subnet_id = SubnetId::from_txid(&txid);
+
         let genesis_info = db::SubnetGenesisInfo {
             create_subnet_msg: self.clone(),
             bootstrapped: false,
-            genesis_block_height,
+            genesis_block_height: block_height,
             boostrap_block_height: None,
             genesis_validators: Vec::with_capacity(0),
         };
@@ -266,7 +268,7 @@ impl IpcJoinSubnetMsg {
     pub fn validate_for_genesis_info(
         &self,
         genesis_info: &db::SubnetGenesisInfo,
-    ) -> Result<(), IpcLibError> {
+    ) -> Result<(), IpcValidateError> {
         // Check if the subnet is already bootstrapped
         if genesis_info.bootstrapped {
             // TODO handle when subnet already bootstrapped

--- a/src/ipc_lib.rs
+++ b/src/ipc_lib.rs
@@ -1,4 +1,5 @@
 use bitcoin::Amount;
+use bitcoin::Txid;
 use bitcoin::XOnlyPublicKey;
 use ipc_serde::IpcSerialize;
 use log::{debug, info};
@@ -124,7 +125,10 @@ impl IpcCreateSubnetMsg {
     /// Submits the create subnet message to the Bitcoin network
     /// Using commit-reveal scheme
     /// Returns the subnet id — derived from the commit txid
-    pub fn submit_to_bitcoin(&self, rpc: &bitcoincore_rpc::Client) -> Result<String, IpcLibError> {
+    pub fn submit_to_bitcoin(
+        &self,
+        rpc: &bitcoincore_rpc::Client,
+    ) -> Result<SubnetId, IpcLibError> {
         let multisig_address = self.multisig_address_from_whitelist()?;
         let subnet_data = self.ipc_serialize();
 
@@ -150,7 +154,7 @@ impl IpcCreateSubnetMsg {
 
         match submit_to_mempool(rpc, vec![commit_tx.clone(), reveal_tx.clone()]) {
             Ok(_) => {
-                let subnet_id = subnet_id_from_txid(&commit_txid);
+                let subnet_id = SubnetId::from_txid(&commit_txid);
                 info!("Submitted create subnet msg for subnet_id={}", subnet_id);
                 Ok(subnet_id)
             }
@@ -224,13 +228,73 @@ impl IpcMessage {
     }
 }
 
+//
+// Subnet ID
+//
+
 /// Create Subnet IPC message is sent as a commit-reveal transaction pair.
 /// Subnet ID is derived from the transaction ID of the commit transaction.
-///
-/// Creates a subnet ID from the commit txid
-// TODO make a new type for SubnetId
-pub fn subnet_id_from_txid(txid: &bitcoin::Txid) -> String {
-    format!("{}/{}", crate::L1_NAME, txid)
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct SubnetId(Txid);
+
+#[derive(Debug, Error)]
+pub enum SubnetIdError {
+    #[error("Invalid Subnet Id format. Expected '{0}/<txid>', got '{1}'")]
+    InvalidFormat(&'static str, String),
+    #[error("Invalid transaction ID: {0}")]
+    InvalidTxid(#[from] bitcoin::hashes::hex::HexToArrayError),
+}
+
+impl SubnetId {
+    /// Creates a new SubnetId from a transaction ID
+    pub fn from_txid(txid: &Txid) -> Self {
+        Self(*txid)
+    }
+
+    /// Returns the transaction ID
+    pub fn txid(&self) -> &Txid {
+        &self.0
+    }
+}
+
+impl FromStr for SubnetId {
+    type Err = SubnetIdError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let parts: Vec<&str> = s.split('/').collect();
+        if parts.len() != 2 || parts[0] != crate::L1_NAME {
+            return Err(SubnetIdError::InvalidFormat(crate::L1_NAME, s.to_string()));
+        }
+
+        let txid = Txid::from_str(parts[1])?;
+        Ok(SubnetId(txid))
+    }
+}
+
+impl std::fmt::Display for SubnetId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}/{}", crate::L1_NAME, self.0)
+    }
+}
+
+impl serde::Serialize for SubnetId {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        // Serialize as string in the format "L1_NAME/txid"
+        self.to_string().serialize(serializer)
+    }
+}
+
+impl<'de> serde::Deserialize<'de> for SubnetId {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let s = String::deserialize(deserializer)?;
+        SubnetId::from_str(&s).map_err(serde::de::Error::custom)
+    }
 }
 
 #[derive(Error, Debug)]
@@ -336,5 +400,87 @@ mod tests {
         assert_eq!(params.active_validators_limit, 20);
         assert_eq!(params.min_cross_msg_fee, Amount::from_sat(50));
         assert_eq!(params.whitelist, vec![validator1, validator2]);
+    }
+
+    //
+    // SubnetId
+    //
+
+    #[test]
+    fn test_subnet_id_creation() {
+        let txid =
+            Txid::from_str("4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b")
+                .unwrap();
+        let subnet_id = SubnetId::from_txid(&txid);
+
+        assert_eq!(subnet_id.txid(), &txid);
+    }
+
+    #[test]
+    fn test_subnet_id_from_str() {
+        let subnet_id_str = format!(
+            "{}/4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b",
+            crate::L1_NAME
+        );
+        let subnet_id = SubnetId::from_str(&subnet_id_str).unwrap();
+
+        assert_eq!(
+            subnet_id.txid().to_string(),
+            "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"
+        );
+    }
+
+    #[test]
+    fn test_subnet_id_display() {
+        let txid =
+            Txid::from_str("4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b")
+                .unwrap();
+        let subnet_id = SubnetId::from_txid(&txid);
+
+        assert_eq!(
+            subnet_id.to_string(),
+            format!(
+                "{}/4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b",
+                crate::L1_NAME
+            )
+        );
+    }
+
+    #[test]
+    fn test_invalid_subnet_id() {
+        // Test invalid txid
+        let result = SubnetId::from_str(&format!("{}/invalid-txid", crate::L1_NAME));
+        assert!(matches!(result, Err(SubnetIdError::InvalidTxid(_))));
+
+        // Test missing prefix
+        let result =
+            SubnetId::from_str("4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b");
+        assert!(matches!(result, Err(SubnetIdError::InvalidFormat(_, _))));
+
+        // Test wrong prefix
+        let result = SubnetId::from_str(
+            "wrongchain/4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b",
+        );
+        assert!(matches!(result, Err(SubnetIdError::InvalidFormat(_, _))));
+    }
+
+    #[test]
+    fn test_subnet_id_serde() {
+        let txid =
+            Txid::from_str("4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b")
+                .unwrap();
+        let subnet_id = SubnetId::from_txid(&txid);
+
+        // Test JSON serialization
+        let serialized = serde_json::to_string(&subnet_id).unwrap();
+        let expected = format!(
+            "\"{}/4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b\"",
+            crate::L1_NAME
+        );
+        assert_eq!(serialized, expected);
+
+        // Test JSON deserialization
+        let deserialized: SubnetId = serde_json::from_str(&serialized).unwrap();
+        assert_eq!(deserialized, subnet_id);
     }
 }

--- a/src/ipc_lib.rs
+++ b/src/ipc_lib.rs
@@ -1,4 +1,5 @@
 use bitcoin::address::NetworkUnchecked;
+use bitcoin::hashes::Hash;
 use bitcoin::Amount;
 use bitcoin::Txid;
 use bitcoin::XOnlyPublicKey;
@@ -36,14 +37,14 @@ pub const IPC_DELETE_SUBNET_TAG: &str = "IPC:DELETE";
 #[derive(Debug, PartialEq)]
 pub enum IpcTag {
     CreateSubnet,
-    PrefundSubnet,
+    JoinSubnet,
 }
 
 impl IpcTag {
     pub fn as_str(&self) -> &'static str {
         match self {
             Self::CreateSubnet => IPC_CREATE_SUBNET_TAG,
-            Self::PrefundSubnet => IPC_PREFUND_SUBNET_TAG,
+            Self::JoinSubnet => IPC_JOIN_SUBNET_TAG,
         }
     }
 }
@@ -54,7 +55,7 @@ impl std::str::FromStr for IpcTag {
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         match s {
             IPC_CREATE_SUBNET_TAG => Ok(Self::CreateSubnet),
-            IPC_PREFUND_SUBNET_TAG => Ok(Self::PrefundSubnet),
+            IPC_JOIN_SUBNET_TAG => Ok(Self::JoinSubnet),
             _ => Err(IpcSerializeError::UnknownTag(s.to_string())),
         }
     }
@@ -85,6 +86,9 @@ pub trait IpcSerialize {
 
 #[derive(Debug, Error)]
 pub enum IpcValidateError {
+    #[error("Invalid message: {0}")]
+    InvalidMsg(String),
+
     #[error("Invalid field {0}: {1}")]
     InvalidField(&'static str, String),
 }
@@ -99,7 +103,8 @@ pub trait IpcValidate {
 #[tag(IPC_CREATE_SUBNET_TAG)]
 pub struct IpcCreateSubnetMsg {
     /// The minimum number of collateral required for validators in Satoshis
-    pub min_validator_stake: u64,
+    #[serde(with = "bitcoin::amount::serde::as_sat")]
+    pub min_validator_stake: Amount,
     /// Minimum number of validators required to bootstrap the subnet
     pub min_validators: u16,
     /// The bottom up checkpoint period in number of blocks
@@ -148,6 +153,7 @@ impl IpcCreateSubnetMsg {
             &secp,
             &multisig_address,
             subnet_data.as_bytes(),
+            None,
         )?;
 
         let commit_txid = commit_tx.compute_txid();
@@ -211,32 +217,107 @@ impl IpcValidate for IpcCreateSubnetMsg {
 }
 
 #[derive(Serialize, Deserialize, IpcSerialize, Debug, Clone)]
-#[tag(IPC_PREFUND_SUBNET_TAG)]
-pub struct IpcPrefundSubnetMsg {
-    /// The subnet id of the subnet to pre-fund
-    subnet_id: SubnetId,
+#[tag(IPC_JOIN_SUBNET_TAG)]
+pub struct IpcJoinSubnetMsg {
+    /// The subnet id of the subnet to join
+    pub subnet_id: SubnetId,
     /// The amount to collateral to lock in the subnet
+    #[ipc_serde(skip)]
     #[serde(with = "bitcoin::amount::serde::as_sat")]
-    collateral: bitcoin::Amount,
-    /// The amount to receive in the subnet
-    #[serde(with = "bitcoin::amount::serde::as_sat")]
-    initial_funding: bitcoin::Amount,
+    pub collateral: bitcoin::Amount,
     /// The IP address of the validator, as
-    /// advertised in the subnet's join/pre-fund message
+    /// advertised in the subnet's join message
     pub ip: std::net::SocketAddr,
     /// The bitcoin address of the validator
     /// to receive back the collateral in case of
     /// subnet termination.
-    btc_address: bitcoin::Address<NetworkUnchecked>,
-    /// The username of the validator
-    username: String,
+    pub backup_address: bitcoin::Address<NetworkUnchecked>,
+    /// The pubkey of the validator
+    pub pubkey: bitcoin::XOnlyPublicKey,
+}
+
+impl IpcJoinSubnetMsg {
+    /// Submits the prefund subnet message to the Bitcoin network
+    /// Using commit-reveal scheme
+    /// And sends the collateral to the subnet multisig address
+    ///
+    /// Returns the prefund txid — the txid of the reveal transaction
+    pub fn submit_to_bitcoin(
+        &self,
+        rpc: &bitcoincore_rpc::Client,
+        multisig_address: &bitcoin::Address,
+    ) -> Result<Txid, IpcLibError> {
+        let subnet_data = self.ipc_serialize();
+
+        info!(
+            "Submitting join subnet msg to bitcoin. Multisig address = {}. Data={}",
+            multisig_address, subnet_data
+        );
+
+        let secp = bitcoin::secp256k1::Secp256k1::new();
+        let (commit_tx, reveal_tx) = bitcoin_utils::create_commit_reveal_txs(
+            rpc,
+            &secp,
+            multisig_address,
+            subnet_data.as_bytes(),
+            Some(self.collateral),
+        )?;
+
+        let commit_txid = commit_tx.compute_txid();
+        let reveal_txid = reveal_tx.compute_txid();
+        debug!(
+            "Join subnet commit_txid={} reveal_txid={}",
+            commit_txid, reveal_txid
+        );
+
+        match submit_to_mempool(rpc, vec![commit_tx.clone(), reveal_tx.clone()]) {
+            Ok(_) => {
+                info!(
+                    "Submitted join subnet msg for subnet_id={} join_txid={}",
+                    self.subnet_id, reveal_txid,
+                );
+                Ok(reveal_txid)
+            }
+            Err(e) => Err(IpcLibError::BitcoinUtilsError(e)),
+        }
+    }
+}
+
+impl IpcValidate for IpcJoinSubnetMsg {
+    fn validate(&self) -> Result<(), IpcValidateError> {
+        // Check subnet_id is not all zeros
+        if self.subnet_id == SubnetId::default() {
+            return Err(IpcValidateError::InvalidField(
+                "subnet_id",
+                "Subnet ID cannot be all zeros".to_string(),
+            ));
+        }
+
+        // Check collateral is not zero
+        if self.collateral == Amount::ZERO {
+            return Err(IpcValidateError::InvalidField(
+                "collateral",
+                "Collateral amount must be greater than zero".to_string(),
+            ));
+        }
+
+        // Check backup address
+        if !self.backup_address.is_valid_for_network(NETWORK) {
+            return Err(IpcValidateError::InvalidField(
+                "backup_address",
+                format!("Bitcoin address must be for {}", NETWORK),
+            ));
+        }
+
+        Ok(())
+    }
 }
 
 // Define the IPCMessage enum
 #[derive(Debug)]
 pub enum IpcMessage {
     CreateSubnet(IpcCreateSubnetMsg),
-    PrefundSubnet(IpcPrefundSubnetMsg),
+    JoinSubnet(IpcJoinSubnetMsg),
 }
 
 impl IpcMessage {
@@ -252,9 +333,9 @@ impl IpcMessage {
             IpcTag::CreateSubnet => Ok(IpcMessage::CreateSubnet(
                 IpcCreateSubnetMsg::ipc_deserialize(s)?,
             )),
-            IpcTag::PrefundSubnet => Ok(IpcMessage::PrefundSubnet(
-                IpcPrefundSubnetMsg::ipc_deserialize(s)?,
-            )),
+            IpcTag::JoinSubnet => Ok(IpcMessage::JoinSubnet(IpcJoinSubnetMsg::ipc_deserialize(
+                s,
+            )?)),
         }
     }
 }
@@ -285,6 +366,12 @@ impl SubnetId {
     /// Returns the transaction ID
     pub fn txid(&self) -> &Txid {
         &self.0
+    }
+}
+
+impl Default for SubnetId {
+    fn default() -> Self {
+        Self(Txid::all_zeros())
     }
 }
 
@@ -363,6 +450,10 @@ mod tests {
         assert!(IpcTag::from_str("INVALID_TAG").is_err());
     }
 
+    //
+    // Create subnet
+    //
+
     #[test]
     fn test_ipc_create_subnet_msg_serialize() {
         let validator1 = XOnlyPublicKey::from_str(
@@ -375,7 +466,7 @@ mod tests {
         .unwrap();
 
         let params = IpcCreateSubnetMsg {
-            min_validator_stake: 1000,
+            min_validator_stake: Amount::from_sat(1000),
             min_validators: 2,
             bottomup_check_period: 10,
             active_validators_limit: 20,
@@ -425,12 +516,124 @@ mod tests {
         println!("{}", serialized);
 
         let params = IpcCreateSubnetMsg::ipc_deserialize(&serialized).unwrap();
-        assert_eq!(params.min_validator_stake, 1000);
+        assert_eq!(params.min_validator_stake, Amount::from_sat(1000));
         assert_eq!(params.min_validators, 2);
         assert_eq!(params.bottomup_check_period, 10);
         assert_eq!(params.active_validators_limit, 20);
         assert_eq!(params.min_cross_msg_fee, Amount::from_sat(50));
         assert_eq!(params.whitelist, vec![validator1, validator2]);
+    }
+
+    //
+    // Join subnet
+    //
+
+    #[test]
+    fn test_ipc_join_subnet_msg_validate() {
+        let pubkey = XOnlyPublicKey::from_str(
+            "18845781f631c48f1c9709e23092067d06837f30aa0cd0544ac887fe91ddd166",
+        )
+        .unwrap();
+
+        let valid_msg = IpcJoinSubnetMsg {
+            subnet_id: SubnetId::from_txid(
+                &Txid::from_str("4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b")
+                    .unwrap(),
+            ),
+            collateral: Amount::from_sat(1000),
+            ip: "127.0.0.1:8080".parse().unwrap(),
+            backup_address: bitcoin::Address::from_str(
+                "bcrt1q3fznspr3e02artm9df7tk827a2xhny2m4zzr6n",
+            )
+            .unwrap(),
+            pubkey,
+        };
+        assert!(valid_msg.validate().is_ok());
+
+        // Test invalid subnet_id
+        let mut invalid_msg = valid_msg.clone();
+        invalid_msg.subnet_id = SubnetId::default();
+        assert!(matches!(
+            invalid_msg.validate(),
+            Err(IpcValidateError::InvalidField("subnet_id", _))
+        ));
+
+        // Test zero collateral
+        let mut invalid_msg = valid_msg.clone();
+        invalid_msg.collateral = Amount::ZERO;
+        assert!(matches!(
+            invalid_msg.validate(),
+            Err(IpcValidateError::InvalidField("collateral", _))
+        ));
+
+        // Test wrong network address
+        let mut invalid_msg = valid_msg.clone();
+        invalid_msg.backup_address =
+            bitcoin::Address::from_str("tb1qw508d6qejxtdg4y5r3zarvary0c5xw7kxpjzsx").unwrap();
+        assert!(matches!(
+            invalid_msg.validate(),
+            Err(IpcValidateError::InvalidField("backup_address", _))
+        ));
+    }
+
+    #[test]
+    fn test_ipc_join_subnet_msg_serialize_deserialize() {
+        let pubkey = XOnlyPublicKey::from_str(
+            "18845781f631c48f1c9709e23092067d06837f30aa0cd0544ac887fe91ddd166",
+        )
+        .unwrap();
+
+        let create_txid =
+            &Txid::from_str("4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b")
+                .unwrap();
+
+        let msg = IpcJoinSubnetMsg {
+            subnet_id: SubnetId::from_txid(create_txid),
+            collateral: Amount::from_sat(1000),
+            ip: "127.0.0.1:8080".parse().unwrap(),
+            backup_address: bitcoin::Address::from_str(
+                "bcrt1q3fznspr3e02artm9df7tk827a2xhny2m4zzr6n",
+            )
+            .unwrap(),
+            pubkey,
+        };
+
+        let serialized = msg.ipc_serialize();
+
+        println!("{}", serialized);
+
+        // Check serialization
+        assert!(serialized.starts_with(IPC_PREFUND_SUBNET_TAG));
+        // collateral should not be in serialized, it's included in the output
+        assert!(!serialized.contains("collateral"));
+
+        assert!(serialized.contains(&format!("{}ip=127.0.0.1:8080", IPC_TAG_DELIMITER)));
+        assert!(serialized.contains(&format!(
+            "{}backup_address=bcrt1q3fznspr3e02artm9df7tk827a2xhny2m4zzr6n",
+            IPC_TAG_DELIMITER
+        )));
+        assert!(serialized.contains(&format!(
+            "{}pubkey=18845781f631c48f1c9709e23092067d06837f30aa0cd0544ac887fe91ddd166",
+            IPC_TAG_DELIMITER
+        )));
+        assert!(serialized.contains(&format!(
+            "{}subnet_id=BTC/4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b",
+            IPC_TAG_DELIMITER
+        )));
+
+        // Test deserialization
+        let deserialized = IpcJoinSubnetMsg::ipc_deserialize(&serialized).unwrap();
+
+        // Skipped fields should be default values
+        assert_eq!(deserialized.subnet_id, SubnetId::from_txid(create_txid));
+        assert_eq!(deserialized.collateral, Amount::from_sat(0));
+        // Other fields should match
+        assert_eq!(deserialized.ip, msg.ip);
+        assert_eq!(deserialized.backup_address, msg.backup_address);
+        assert_eq!(deserialized.pubkey, msg.pubkey);
+
+        // It should be invalid because it's missing collateral and subnet_id
+        assert!(deserialized.validate().is_err());
     }
 
     //

--- a/src/ipc_lib.rs
+++ b/src/ipc_lib.rs
@@ -289,6 +289,18 @@ impl IpcJoinSubnetMsg {
             ));
         }
 
+        // Check if the validator's public key is whitelisted
+        if !genesis_info
+            .create_subnet_msg
+            .whitelist
+            .contains(&self.pubkey)
+        {
+            return Err(IpcValidateError::InvalidField(
+                "pubkey",
+                "Validator public key not whitelisted".to_string(),
+            ));
+        }
+
         // Check if the validator with this public key is already registered
         if genesis_info
             .genesis_validators

--- a/src/ipc_lib.rs
+++ b/src/ipc_lib.rs
@@ -353,7 +353,12 @@ impl IpcJoinSubnetMsg {
     }
 
     /// Modifies the database to account for the join subnet message
-    pub fn save_to_db<D: db::Database>(&self, db: &D, join_txid: Txid) -> Result<(), IpcLibError> {
+    pub fn save_to_db<D: db::Database>(
+        &self,
+        db: &D,
+        block_height: u64,
+        txid: Txid,
+    ) -> Result<(), IpcLibError> {
         let mut genesis_info =
             db.get_subnet_genesis_info(self.subnet_id)?
                 .ok_or(IpcValidateError::InvalidMsg(format!(
@@ -366,13 +371,23 @@ impl IpcJoinSubnetMsg {
         let new_validator = db::SubnetValidator {
             pubkey: self.pubkey,
             collateral: self.collateral,
+            backup_address: self.backup_address.clone(),
             ip: self.ip,
-            join_txid,
+            join_txid: txid,
         };
-
         trace!("Processing {self:?}, adding new validator {new_validator:?}");
-
         genesis_info.genesis_validators.push(new_validator);
+
+        //
+        // Check if the subnet is bootstrapped
+        //
+        if genesis_info.genesis_validators.len() as u16
+            >= genesis_info.create_subnet_msg.min_validators
+        {
+            trace!("Subnet {} bootstrapped", self.subnet_id);
+            genesis_info.bootstrapped = true;
+            genesis_info.boostrap_block_height = Some(block_height);
+        }
 
         let mut wtxn = db.write_txn()?;
         db.save_subnet_genesis_info(&mut wtxn, self.subnet_id, genesis_info)?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,6 +2,7 @@ use bitcoin::{FeeRate, Network};
 
 pub mod bitcoin_utils;
 pub mod db;
+pub mod eth_utils;
 pub mod ipc_lib;
 pub mod provider;
 pub mod wallet;

--- a/src/provider/rpc.rs
+++ b/src/provider/rpc.rs
@@ -196,6 +196,30 @@ pub async fn join_subnet(
     Ok(JoinSubnetResponse { join_txid })
 }
 
+#[derive(Serialize, Deserialize)]
+pub struct GetGenesisInfoParams {
+    subnet_id: SubnetId,
+}
+
+pub async fn get_genesis_info(
+    data: Data<Arc<ServerData>>,
+    Params(msg): Params<GetGenesisInfoParams>,
+) -> Result<db::SubnetGenesisInfo, JsonRpcError> {
+    let genesis_info = data
+        .db
+        .get_subnet_genesis_info(msg.subnet_id)
+        .map_err(|e| {
+            error!("Error getting subnet info from Db: {}", e);
+            RpcError::DbError(e)
+        })?
+        .ok_or(RpcError::InvalidParams(format!(
+            "Subnet {} not found.",
+            msg.subnet_id
+        )))?;
+
+    Ok(genesis_info)
+}
+
 pub fn make_rpc_server(server_data: Arc<ServerData>) -> RpcServer {
     jsonrpc_v2::Server::new()
         .with_data(Data::new(server_data))
@@ -205,5 +229,6 @@ pub fn make_rpc_server(server_data: Arc<ServerData>) -> RpcServer {
         .with_method("getbalance", get_balance)
         .with_method("createsubnet", create_subnet)
         .with_method("joinsubnet", join_subnet)
+        .with_method("getgenesisinfo", get_genesis_info)
         .finish()
 }

--- a/src/provider/rpc.rs
+++ b/src/provider/rpc.rs
@@ -175,7 +175,7 @@ pub async fn pre_fund(
 ) -> Result<PreFundSubnetResponse, JsonRpcError> {
     let subnet_info = data
         .db
-        .get_subnet_info(params.subnet_id)
+        .get_subnet_genesis_info(params.subnet_id)
         .await
         .map_err(|e| {
             error!("Error getting subnet info from Db: {}", e);
@@ -188,7 +188,7 @@ pub async fn pre_fund(
 
     // TODO this check should be done in the Db
     let multisig_address = &subnet_info
-        .multisig_address
+        .multisig_address()
         .require_network(NETWORK)
         .map_err(|_| {
             RpcError::InvalidParams(format!("Multisig address must be for {} network", NETWORK))

--- a/src/provider/rpc.rs
+++ b/src/provider/rpc.rs
@@ -1,9 +1,8 @@
 use crate::{
     db::{self, Database, HeedDb},
-    ipc_lib::{IpcValidate, SubnetId},
+    ipc_lib::{IpcJoinSubnetMsg, IpcValidate, SubnetId},
     IpcCreateSubnetMsg, BTC_CONFIRMATIONS, NETWORK,
 };
-use bitcoin::TxOut;
 use bitcoincore_rpc::{Client, RpcApi};
 use jsonrpc_v2::{Data, Error as JsonRpcError, ErrorLike, MapRouter, Params};
 use log::error;
@@ -158,24 +157,21 @@ pub async fn create_subnet(
 }
 
 #[derive(Serialize, Deserialize)]
-pub struct PreFundSubnetParams {
-    subnet_id: SubnetId,
-    #[serde(with = "bitcoin::amount::serde::as_sat")]
-    amount: bitcoin::Amount,
+pub struct JoinSubnetResponse {
+    join_txid: bitcoin::Txid,
 }
 
-#[derive(Serialize, Deserialize)]
-pub struct PreFundSubnetResponse {
-    tx_id: bitcoin::Txid,
-}
-
-pub async fn pre_fund(
+pub async fn join_subnet(
     data: Data<Arc<ServerData>>,
-    Params(params): Params<PreFundSubnetParams>,
-) -> Result<PreFundSubnetResponse, JsonRpcError> {
+    Params(msg): Params<IpcJoinSubnetMsg>,
+) -> Result<JoinSubnetResponse, JsonRpcError> {
+    if let Err(err) = msg.validate() {
+        return Err(RpcError::InvalidParams(err.to_string()).into());
+    }
+
     let subnet_info = data
         .db
-        .get_subnet_genesis_info(params.subnet_id)
+        .get_subnet_genesis_info(msg.subnet_id)
         .await
         .map_err(|e| {
             error!("Error getting subnet info from Db: {}", e);
@@ -183,8 +179,27 @@ pub async fn pre_fund(
         })?
         .ok_or(RpcError::InvalidParams(format!(
             "Subnet {} not found.",
-            params.subnet_id
+            msg.subnet_id
         )))?;
+
+    // Check if the subnet is already bootstrapped
+    if subnet_info.bootstrapped {
+        return Err(RpcError::InvalidParams(format!(
+            "Subnet {} is already bootstrapped.",
+            msg.subnet_id
+        ))
+        .into());
+    }
+
+    if subnet_info.create_subnet_msg.min_validator_stake < msg.collateral {
+        return Err(RpcError::InvalidParams(format!(
+            "Collateral must be at least {}",
+            subnet_info.create_subnet_msg.min_validator_stake
+        ))
+        .into());
+    }
+
+    // check already prefunded
 
     // TODO this check should be done in the Db
     let multisig_address = &subnet_info
@@ -194,23 +209,11 @@ pub async fn pre_fund(
             RpcError::InvalidParams(format!("Multisig address must be for {} network", NETWORK))
         })?;
 
-    let outputs = vec![TxOut {
-        value: params.amount,
-        script_pubkey: multisig_address.script_pubkey(),
-    }];
+    let join_txid = msg
+        .submit_to_bitcoin(&data.btc_rpc, multisig_address)
+        .map_err(|e| JsonRpcError::internal(e.to_string()))?;
 
-    let tx = crate::wallet::fund_outputs(&data.btc_rpc, outputs, None)
-        .map_err(|e| RpcError::InternalError(format!("Error creating transaction: {}", e)))?;
-
-    let tx = crate::wallet::sign_tx(&data.btc_rpc, tx)
-        .map_err(|e| RpcError::InternalError(format!("Error creating transaction: {}", e)))?;
-
-    let tx_id = tx.compute_txid();
-
-    crate::bitcoin_utils::submit_to_mempool(&data.btc_rpc, vec![tx])
-        .map_err(|e| RpcError::InternalError(format!("Error creating transaction: {}", e)))?;
-
-    Ok(PreFundSubnetResponse { tx_id })
+    Ok(JoinSubnetResponse { join_txid })
 }
 
 pub fn make_rpc_server(server_data: Arc<ServerData>) -> RpcServer {
@@ -221,6 +224,6 @@ pub fn make_rpc_server(server_data: Arc<ServerData>) -> RpcServer {
         .with_method("getconfirmedblock", get_confirmed_block)
         .with_method("getbalance", get_balance)
         .with_method("createsubnet", create_subnet)
-        .with_method("prefundsubnet", pre_fund)
+        .with_method("joinsubnet", join_subnet)
         .finish()
 }

--- a/src/provider/rpc.rs
+++ b/src/provider/rpc.rs
@@ -1,8 +1,9 @@
 use crate::{
+    db::{self, Database, HeedDb},
     ipc_lib::{IpcValidate, SubnetId},
     IpcCreateSubnetMsg, BTC_CONFIRMATIONS, NETWORK,
 };
-use bitcoin::{address::NetworkUnchecked, TxOut};
+use bitcoin::TxOut;
 use bitcoincore_rpc::{Client, RpcApi};
 use jsonrpc_v2::{Data, Error as JsonRpcError, ErrorLike, MapRouter, Params};
 use log::error;
@@ -21,6 +22,9 @@ pub enum RpcError {
     #[error("Invalid params: {0}")]
     InvalidParams(String),
 
+    #[error("Database error occurred: {0}")]
+    DbError(#[from] db::DbError),
+
     #[error("Internal server error: {0}")]
     InternalError(String),
 }
@@ -30,7 +34,7 @@ impl ErrorLike for RpcError {
         match self {
             RpcError::Unauthorized => -32001,
             RpcError::InvalidParams(_) => -32602,
-            RpcError::InternalError(_) => -32603,
+            RpcError::InternalError(_) | RpcError::DbError(_) => -32603,
         }
     }
 
@@ -56,8 +60,10 @@ impl actix_web::error::ResponseError for RpcError {
     }
 }
 
+// TODO use generics
 #[derive(Clone)]
 pub struct ServerData {
+    pub db: Arc<HeedDb>,
     pub btc_rpc: Arc<Client>,
 }
 
@@ -153,7 +159,7 @@ pub async fn create_subnet(
 
 #[derive(Serialize, Deserialize)]
 pub struct PreFundSubnetParams {
-    multisig_address: bitcoin::Address<NetworkUnchecked>,
+    subnet_id: SubnetId,
     #[serde(with = "bitcoin::amount::serde::as_sat")]
     amount: bitcoin::Amount,
 }
@@ -167,11 +173,26 @@ pub async fn pre_fund(
     data: Data<Arc<ServerData>>,
     Params(params): Params<PreFundSubnetParams>,
 ) -> Result<PreFundSubnetResponse, JsonRpcError> {
-    let multisig_address = &params
+    let subnet_info = data
+        .db
+        .get_subnet_info(params.subnet_id)
+        .await
+        .map_err(|e| {
+            error!("Error getting subnet info from Db: {}", e);
+            RpcError::DbError(e)
+        })?
+        .ok_or(RpcError::InvalidParams(format!(
+            "Subnet {} not found.",
+            params.subnet_id
+        )))?;
+
+    // TODO this check should be done in the Db
+    let multisig_address = &subnet_info
         .multisig_address
         .require_network(NETWORK)
-        // TODO better error
-        .map_err(|e| RpcError::InvalidParams(format!("Multisig address network: {}", e)))?;
+        .map_err(|_| {
+            RpcError::InvalidParams(format!("Multisig address must be for {} network", NETWORK))
+        })?;
 
     let outputs = vec![TxOut {
         value: params.amount,
@@ -200,5 +221,6 @@ pub fn make_rpc_server(server_data: Arc<ServerData>) -> RpcServer {
         .with_method("getconfirmedblock", get_confirmed_block)
         .with_method("getbalance", get_balance)
         .with_method("createsubnet", create_subnet)
+        .with_method("prefundsubnet", pre_fund)
         .finish()
 }

--- a/src/provider/rpc.rs
+++ b/src/provider/rpc.rs
@@ -1,4 +1,8 @@
-use crate::{ipc_lib::IpcValidate, IpcCreateSubnetMsg, BTC_CONFIRMATIONS};
+use crate::{
+    ipc_lib::{IpcValidate, SubnetId},
+    IpcCreateSubnetMsg, BTC_CONFIRMATIONS, NETWORK,
+};
+use bitcoin::{address::NetworkUnchecked, TxOut};
 use bitcoincore_rpc::{Client, RpcApi};
 use jsonrpc_v2::{Data, Error as JsonRpcError, ErrorLike, MapRouter, Params};
 use log::error;
@@ -128,7 +132,7 @@ pub async fn get_balance(data: Data<Arc<ServerData>>) -> Result<u64, JsonRpcErro
 
 #[derive(Serialize, Deserialize)]
 pub struct CreateSubnetResponse {
-    subnet_id: String,
+    subnet_id: SubnetId,
 }
 
 pub async fn create_subnet(
@@ -145,6 +149,47 @@ pub async fn create_subnet(
 
     // Return the response
     Ok(CreateSubnetResponse { subnet_id })
+}
+
+#[derive(Serialize, Deserialize)]
+pub struct PreFundSubnetParams {
+    multisig_address: bitcoin::Address<NetworkUnchecked>,
+    #[serde(with = "bitcoin::amount::serde::as_sat")]
+    amount: bitcoin::Amount,
+}
+
+#[derive(Serialize, Deserialize)]
+pub struct PreFundSubnetResponse {
+    tx_id: bitcoin::Txid,
+}
+
+pub async fn pre_fund(
+    data: Data<Arc<ServerData>>,
+    Params(params): Params<PreFundSubnetParams>,
+) -> Result<PreFundSubnetResponse, JsonRpcError> {
+    let multisig_address = &params
+        .multisig_address
+        .require_network(NETWORK)
+        // TODO better error
+        .map_err(|e| RpcError::InvalidParams(format!("Multisig address network: {}", e)))?;
+
+    let outputs = vec![TxOut {
+        value: params.amount,
+        script_pubkey: multisig_address.script_pubkey(),
+    }];
+
+    let tx = crate::wallet::fund_outputs(&data.btc_rpc, outputs, None)
+        .map_err(|e| RpcError::InternalError(format!("Error creating transaction: {}", e)))?;
+
+    let tx = crate::wallet::sign_tx(&data.btc_rpc, tx)
+        .map_err(|e| RpcError::InternalError(format!("Error creating transaction: {}", e)))?;
+
+    let tx_id = tx.compute_txid();
+
+    crate::bitcoin_utils::submit_to_mempool(&data.btc_rpc, vec![tx])
+        .map_err(|e| RpcError::InternalError(format!("Error creating transaction: {}", e)))?;
+
+    Ok(PreFundSubnetResponse { tx_id })
 }
 
 pub fn make_rpc_server(server_data: Arc<ServerData>) -> RpcServer {

--- a/src/provider/rpc.rs
+++ b/src/provider/rpc.rs
@@ -1,7 +1,7 @@
 use crate::{
     db::{self, Database, HeedDb},
     ipc_lib::{IpcJoinSubnetMsg, IpcValidate, SubnetId},
-    IpcCreateSubnetMsg, BTC_CONFIRMATIONS, NETWORK,
+    IpcCreateSubnetMsg, BTC_CONFIRMATIONS,
 };
 use bitcoincore_rpc::{Client, RpcApi};
 use jsonrpc_v2::{Data, Error as JsonRpcError, ErrorLike, MapRouter, Params};
@@ -169,10 +169,9 @@ pub async fn join_subnet(
         return Err(RpcError::InvalidParams(err.to_string()).into());
     }
 
-    let subnet_info = data
+    let genesis_info = data
         .db
         .get_subnet_genesis_info(msg.subnet_id)
-        .await
         .map_err(|e| {
             error!("Error getting subnet info from Db: {}", e);
             RpcError::DbError(e)
@@ -182,32 +181,13 @@ pub async fn join_subnet(
             msg.subnet_id
         )))?;
 
-    // Check if the subnet is already bootstrapped
-    if subnet_info.bootstrapped {
-        return Err(RpcError::InvalidParams(format!(
-            "Subnet {} is already bootstrapped.",
-            msg.subnet_id
-        ))
-        .into());
-    }
-
-    if subnet_info.create_subnet_msg.min_validator_stake < msg.collateral {
-        return Err(RpcError::InvalidParams(format!(
-            "Collateral must be at least {}",
-            subnet_info.create_subnet_msg.min_validator_stake
-        ))
-        .into());
-    }
-
-    // check already prefunded
+    msg.validate_for_genesis_info(&genesis_info).map_err(|e| {
+        error!("Error validating join msg for subnet info: {}", e);
+        RpcError::InvalidParams(e.to_string())
+    })?;
 
     // TODO this check should be done in the Db
-    let multisig_address = &subnet_info
-        .multisig_address()
-        .require_network(NETWORK)
-        .map_err(|_| {
-            RpcError::InvalidParams(format!("Multisig address must be for {} network", NETWORK))
-        })?;
+    let multisig_address = &genesis_info.multisig_address();
 
     let join_txid = msg
         .submit_to_bitcoin(&data.btc_rpc, multisig_address)


### PR DESCRIPTION
A PR that introduces a new IPC message type, `JoinSubnet`. It lets validators stake some collateral and join as validators.

It also opens a new Provider RPC method `getgenesisinfo` which returns the current subnet genesis information, like the list of validators that have joined, and if the subnet has been bootstrapped or not.

Currently it marks a subnet as bootstrapped if enough validators joined, but doesn't create any of the corresponding state in DB.

> I added a provisional `create_join.md` file for sharing the commands to test this. It's not meant to be kept as documentation.

This PR also improves Monitor error handling significantly, treating some fatal errors as panics, ignoring and logging others.
