### PR TITLE
Pre-fund subnet message

### DIFF
--- a/docs/internal/curl_reqs.md
+++ b/docs/internal/curl_reqs.md
@@ -92,7 +92,7 @@ curl -X POST http://localhost:3030/api \
 	"jsonrpc": "2.0",
 	"method": "getgenesisinfo",
 	"params": {
-		"subnet_id": "/b4/t420f7gmk32wp44h5kxcc2sbonm6iysmmkvfscmxr74kx4cqrofc4len4quzaha"
+		"subnet_id": "/b4/t420feejlnrllx3nr4tqfl5iuvwllwnazdiwehluntld6lc2z6w6ypffau6qppq"
 	},
 	"id": 1
 }' | jq
@@ -107,7 +107,7 @@ curl -X POST http://localhost:3030/api \
     "method": "prefundsubnet",
     "params": {
 			"subnet_id": "/b4/t420feejlnrllx3nr4tqfl5iuvwllwnazdiwehluntld6lc2z6w6ypffau6qppq",
-			"value": 40000000,
+			"amount": 40000000,
 			"address": "0xbce2f194e9628e6ae06fa0d85dd57cd5579213bf"
     },
     "id": 1

--- a/docs/internal/curl_reqs.md
+++ b/docs/internal/curl_reqs.md
@@ -107,7 +107,7 @@ curl -X POST http://localhost:3030/api \
     "method": "prefundsubnet",
     "params": {
 			"subnet_id": "/b4/t420feejlnrllx3nr4tqfl5iuvwllwnazdiwehluntld6lc2z6w6ypffau6qppq",
-			"value": 200000000,
+			"value": 40000000,
 			"address": "0xbce2f194e9628e6ae06fa0d85dd57cd5579213bf"
     },
     "id": 1

--- a/docs/internal/curl_reqs.md
+++ b/docs/internal/curl_reqs.md
@@ -92,8 +92,24 @@ curl -X POST http://localhost:3030/api \
 	"jsonrpc": "2.0",
 	"method": "getgenesisinfo",
 	"params": {
-		"subnet_id": "/b4/t420fepbcc2ait3aclq2exb3nmwmi4wmd5gfixnktv36mxmax5lmhpdr6qge5su"
+		"subnet_id": "/b4/t420f7gmk32wp44h5kxcc2sbonm6iysmmkvfscmxr74kx4cqrofc4len4quzaha"
 	},
 	"id": 1
+}' | jq
+
+
+
+curl -X POST http://localhost:3030/api \
+-H "Content-Type: application/json" \
+-H "Authorization: Bearer asda123123jhaskjdhgbjsjhdj" \
+-d '{
+    "jsonrpc": "2.0",
+    "method": "prefundsubnet",
+    "params": {
+			"subnet_id": "/b4/t420feejlnrllx3nr4tqfl5iuvwllwnazdiwehluntld6lc2z6w6ypffau6qppq",
+			"value": 200000000,
+			"address": "0xbce2f194e9628e6ae06fa0d85dd57cd5579213bf"
+    },
+    "id": 1
 }' | jq
 ```

--- a/src/bin/monitor.rs
+++ b/src/bin/monitor.rs
@@ -316,24 +316,23 @@ where
                     .await
                 {
                     Ok(_) => {}
-                    // Ignorable
-                    Err(MonitorError::IpcMsgInvalid(e)) => {
-                        error!("Invalid IPC message: {:?}", e);
-                    }
-                    // Ignorable
-                    Err(MonitorError::IpcTxInvalid(e)) => {
-                        error!("Invalid IPC message transaction: {:?}", e);
-                    }
-                    // Ignorable
-                    Err(MonitorError::IpcMsgProcessingError(IpcLibError::IpcValidateError(e))) => {
-                        error!("Invalid IPC message: {:?}", e);
-                    }
-                    // Panicable, all other errors
-                    Err(e) => {
-                        error!("Fatal error processing IPC message: {:?}", e);
-                        return Err(e);
-                    }
+                    Err(e) => self.handle_ipc_msg_error(e)?,
                 }
+            }
+        }
+
+        // Process outputs
+
+        // TODO make a general way to find messages in outputs or from entire tx
+        if let Ok(prefund_msg) = ipc_lib::IpcPrefundSubnetMsg::from_tx(tx) {
+            let ipc_message = IpcMessage::PrefundSubnet(prefund_msg);
+
+            match self
+                .process_ipc_msg(block_height, tx, txid, ipc_message)
+                .await
+            {
+                Ok(_) => {}
+                Err(e) => self.handle_ipc_msg_error(e)?,
             }
         }
 
@@ -381,11 +380,32 @@ where
                 debug!("Found IPC message: {:?}", msg);
                 msg.validate()?;
                 // msg.save_to_db(&self.db, block_height, txid)?;
-                info!(
-                    "TODO Processed PrefundSubnet for Subnet ID: {}",
-                    msg.subnet_id
-                );
+                info!("Processed PrefundSubnet for Subnet ID: {}", msg.subnet_id);
                 Ok(())
+            }
+        }
+    }
+
+    /// Helper function to handle IPC message processing errors
+    fn handle_ipc_msg_error(&self, error: MonitorError) -> Result<(), MonitorError> {
+        match error {
+            // Ignorable errors
+            MonitorError::IpcMsgInvalid(e) => {
+                error!("Invalid IPC message: {:?}", e);
+                Ok(())
+            }
+            MonitorError::IpcTxInvalid(e) => {
+                error!("Invalid IPC message transaction: {:?}", e);
+                Ok(())
+            }
+            MonitorError::IpcMsgProcessingError(IpcLibError::IpcValidateError(e)) => {
+                error!("Invalid IPC message: {:?}", e);
+                Ok(())
+            }
+            // Propagate all other errors
+            e => {
+                error!("Fatal error processing IPC message: {:?}", e);
+                Err(e)
             }
         }
     }

--- a/src/bin/monitor.rs
+++ b/src/bin/monitor.rs
@@ -379,7 +379,7 @@ where
             IpcMessage::PrefundSubnet(msg) => {
                 debug!("Found IPC message: {:?}", msg);
                 msg.validate()?;
-                // msg.save_to_db(&self.db, block_height, txid)?;
+                msg.save_to_db(&self.db, block_height, txid)?;
                 info!("Processed PrefundSubnet for Subnet ID: {}", msg.subnet_id);
                 Ok(())
             }

--- a/src/bin/monitor.rs
+++ b/src/bin/monitor.rs
@@ -376,6 +376,17 @@ where
                 );
                 Ok(())
             }
+
+            IpcMessage::PrefundSubnet(msg) => {
+                debug!("Found IPC message: {:?}", msg);
+                msg.validate()?;
+                // msg.save_to_db(&self.db, block_height, txid)?;
+                info!(
+                    "TODO Processed PrefundSubnet for Subnet ID: {}",
+                    msg.subnet_id
+                );
+                Ok(())
+            }
         }
     }
 }

--- a/src/bitcoin_utils.rs
+++ b/src/bitcoin_utils.rs
@@ -15,7 +15,10 @@ use bitcoin::{
     },
     hashes::Hash,
     key::UntweakedPublicKey,
-    opcodes::{all::OP_DROP, OP_TRUE},
+    opcodes::{
+        all::{OP_CSV, OP_DROP},
+        OP_TRUE,
+    },
     script::{Instruction, PushBytes},
     secp256k1::Secp256k1,
     taproot::{LeafVersion, TaprootBuilder},
@@ -153,6 +156,14 @@ pub fn make_push_data_script(data: &[u8]) -> ScriptBuf {
     builder = builder.push_opcode(OP_TRUE);
 
     builder.into_script()
+}
+
+/// Makes a simple OP_RETURN script
+pub fn make_op_return_script<T: AsRef<PushBytes>>(data: T) -> ScriptBuf {
+    Builder::new()
+        .push_opcode(bitcoin::opcodes::all::OP_RETURN)
+        .push_slice(data)
+        .into_script()
 }
 
 /// Creates and submits two transactions to the Bitcoin network:
@@ -381,6 +392,55 @@ pub fn concatenate_op_push_data(witness: &[u8]) -> Result<Vec<u8>, BitcoinUtilsE
     }
 
     Ok(concatenated_data)
+}
+
+pub fn create_send_with_timelock_release_tx_script(
+    secp: &Secp256k1<bitcoin::secp256k1::All>,
+    receive_address: &Address,
+    release_address: &Address,
+    release_blocks: u32,
+) -> Result<ScriptBuf, BitcoinUtilsError> {
+    // Script 1. Send to the receive address
+    let send_script = receive_address.script_pubkey();
+
+    // Script 2. Release after n blocks
+    let release_timelock_script = Builder::new()
+        .push_int(release_blocks.into()) // Push the relative timelock value
+        .push_opcode(OP_CSV) // Enforce relative timelock
+        .push_opcode(OP_DROP) // Drop the timelock value
+        .into_script();
+
+    // Merge the release address with a timelock
+    let mut release_script_bytes = release_timelock_script.into_bytes();
+    release_script_bytes.extend(release_address.script_pubkey().to_bytes());
+    let release_script = ScriptBuf::from_bytes(release_script_bytes);
+
+    // Create the taproot output
+
+    let taproot_builder = TaprootBuilder::new()
+        .add_leaf(1, send_script)?
+        .add_leaf(1, release_script)?;
+
+    let unspendable_pubkey = create_unspendable_internal_key();
+
+    let spend_info = taproot_builder
+        .finalize(secp, unspendable_pubkey)
+        .map_err(|_| BitcoinUtilsError::TaprootBuilderNotFinalizable)?;
+
+    let script_pubkey =
+        ScriptBuf::new_p2tr(secp, spend_info.internal_key(), spend_info.merkle_root());
+
+    // TODO return both scripts and their control blocks
+    Ok(script_pubkey)
+}
+
+pub fn create_tx_from_txouts(txouts: Vec<TxOut>) -> Transaction {
+    Transaction {
+        version: transaction::Version::TWO,
+        lock_time: LockTime::ZERO,
+        input: Vec::with_capacity(0),
+        output: txouts,
+    }
 }
 
 #[derive(Error, Debug)]

--- a/src/db.rs
+++ b/src/db.rs
@@ -177,7 +177,7 @@ impl SubnetGenesisInfo {
         for entry in &self.genesis_balance_entries {
             balance
                 .entry(entry.subnet_address)
-                .and_modify(|amount| *amount = *amount + entry.amount)
+                .and_modify(|amount| *amount += entry.amount)
                 .or_insert(entry.amount);
         }
         balance

--- a/src/db.rs
+++ b/src/db.rs
@@ -107,6 +107,26 @@ impl SubnetState {
     }
 }
 
+/// An entry in the subnet genesis balance
+///
+/// This balance is added to user addresses in genesis, and becomes part of the genesis
+/// circulating supply. Users (including validators) can add genesis balance
+/// via pre-fund messages.
+///
+/// One entry is added per pre-fund message.
+/// There could be multiple entries for a single subnet address.
+#[derive(Serialize, Deserialize, Debug)]
+pub struct GenesisBalanceEntry {
+    /// The subnet address
+    pub subnet_address: alloy_primitives::Address,
+    /// The balance
+    pub amount: bitcoin::Amount,
+    /// The transaction ID of the pre-fund message
+    pub prefund_txid: bitcoin::Txid,
+    /// The block height of the pre-fund message
+    pub block_height: u64,
+}
+
 /// Genesis info for a subnet
 #[derive(Serialize, Deserialize, Debug)]
 pub struct SubnetGenesisInfo {
@@ -127,6 +147,11 @@ pub struct SubnetGenesisInfo {
     pub genesis_block_height: Option<u64>,
     /// The list of validators that boostrapped the subnet
     pub genesis_validators: Vec<SubnetValidator>,
+    /// The initial balance of the subnet at genesis
+    /// Filled with pre-fund messages
+    ///
+    /// use `.genesis_balance()` to get a hashmap
+    pub genesis_balance_entries: Vec<GenesisBalanceEntry>,
 }
 
 impl SubnetGenesisInfo {
@@ -142,6 +167,42 @@ impl SubnetGenesisInfo {
             committee_number: 1,
             committee: self.genesis_validators.to_committee(&self.subnet_id),
         }
+    }
+
+    /// Returns the genesis balance for the subnet
+    pub fn genesis_balance(
+        &self,
+    ) -> std::collections::HashMap<alloy_primitives::Address, bitcoin::Amount> {
+        let mut balance = std::collections::HashMap::new();
+        for entry in &self.genesis_balance_entries {
+            balance
+                .entry(entry.subnet_address)
+                .and_modify(|amount| *amount = *amount + entry.amount)
+                .or_insert(entry.amount);
+        }
+        balance
+    }
+
+    /// Adds a genesis balance entry to the genesis info
+    pub fn add_genesis_balance_entry(
+        &mut self,
+        subnet_address: alloy_primitives::Address,
+        amount: bitcoin::Amount,
+        prefund_txid: bitcoin::Txid,
+        block_height: u64,
+    ) {
+        self.genesis_balance_entries.push(GenesisBalanceEntry {
+            subnet_address,
+            amount,
+            prefund_txid,
+            block_height,
+        });
+    }
+
+    /// Removes a genesis balance entry from the genesis info, for a given prefund_txid
+    pub fn remove_genesis_balance_entry(&mut self, txid: &bitcoin::Txid) {
+        self.genesis_balance_entries
+            .retain(|entry| &entry.prefund_txid != txid);
     }
 }
 

--- a/src/ipc_lib.rs
+++ b/src/ipc_lib.rs
@@ -206,6 +206,7 @@ impl IpcCreateSubnetMsg {
             create_msg_block_height: block_height,
             genesis_block_height: None,
             genesis_validators: Vec::with_capacity(0),
+            genesis_balance_entries: Vec::with_capacity(0),
         };
 
         trace!("Saving {self:?} to DB, genesis_info={genesis_info:?}");
@@ -469,14 +470,14 @@ pub struct IpcPrefundSubnetMsg {
     /// The amount to deposit in the subnet
     #[ipc_serde(skip)]
     #[serde(with = "bitcoin::amount::serde::as_sat")]
-    pub value: bitcoin::Amount,
+    pub amount: bitcoin::Amount,
     /// The address to prefund in the subnet
     pub address: alloy_primitives::Address,
 }
 
 impl IpcValidate for IpcPrefundSubnetMsg {
     fn validate(&self) -> Result<(), IpcValidateError> {
-        if self.value == bitcoin::Amount::MIN {
+        if self.amount == bitcoin::Amount::MIN {
             return Err(IpcValidateError::InvalidField(
                 "value",
                 "Value must be greater than 0".to_string(),
@@ -572,11 +573,11 @@ impl IpcPrefundSubnetMsg {
         let address = alloy_primitives::Address::from_slice(addr_bytes);
 
         // Get value from second output
-        let value = tx.output[1].value;
+        let amount = tx.output[1].value;
 
         Ok(Self {
             subnet_id,
-            value,
+            amount,
             address,
         })
     }
@@ -626,7 +627,7 @@ impl IpcPrefundSubnetMsg {
             Self::RELEASE_LOCKTIME,
         )?;
         let prefund_tx_out = bitcoin::TxOut {
-            value: self.value,
+            value: self.amount,
             script_pubkey: prefund_script,
         };
 
@@ -646,7 +647,7 @@ impl IpcPrefundSubnetMsg {
     ) -> Result<Txid, IpcLibError> {
         info!(
             "Submitting pre-fund subnet msg to bitcoin. Multisig address = {}. Amount={}",
-            multisig_address, self.value
+            multisig_address, self.amount
         );
 
         let release_address = wallet::get_new_address(rpc)?;
@@ -673,6 +674,33 @@ impl IpcPrefundSubnetMsg {
             }
             Err(e) => Err(IpcLibError::BitcoinUtilsError(e)),
         }
+    }
+
+    /// Modifies the database to account for the join subnet message
+    pub fn save_to_db<D: db::Database>(
+        &self,
+        db: &D,
+        block_height: u64,
+        txid: Txid,
+    ) -> Result<(), IpcLibError> {
+        let mut genesis_info =
+            db.get_subnet_genesis_info(self.subnet_id)?
+                .ok_or(IpcValidateError::InvalidMsg(format!(
+                    "subnet id={} does not exist",
+                    self.subnet_id
+                )))?;
+
+        self.validate_for_genesis_info(&genesis_info)?;
+
+        trace!("Processing {self:?}, adding new genesis_balance entry");
+
+        genesis_info.add_genesis_balance_entry(self.address, self.amount, txid, block_height);
+
+        let mut wtxn = db.write_txn()?;
+        db.save_subnet_genesis_info(&mut wtxn, self.subnet_id, genesis_info)?;
+        wtxn.commit()?;
+
+        Ok(())
     }
 }
 
@@ -1141,7 +1169,7 @@ mod prefund_msg_tests {
 
         IpcPrefundSubnetMsg {
             subnet_id,
-            value: Amount::from_sat(1000),
+            amount: Amount::from_sat(1000),
             address: eth_addr,
         }
     }
@@ -1213,7 +1241,7 @@ mod prefund_msg_tests {
 
         // Verify all fields match
         assert_eq!(parsed_msg.subnet_id, original_msg.subnet_id);
-        assert_eq!(parsed_msg.value, original_msg.value);
+        assert_eq!(parsed_msg.amount, original_msg.amount);
         assert_eq!(parsed_msg.address, original_msg.address);
     }
 

--- a/src/ipc_lib.rs
+++ b/src/ipc_lib.rs
@@ -1,6 +1,7 @@
 use bitcoin::address::NetworkUnchecked;
 use bitcoin::hashes::Hash;
 use bitcoin::Amount;
+use bitcoin::Transaction;
 use bitcoin::Txid;
 use bitcoin::XOnlyPublicKey;
 use ipc_serde::IpcSerialize;
@@ -487,7 +488,13 @@ impl IpcValidate for IpcPrefundSubnetMsg {
 
 impl IpcPrefundSubnetMsg {
     // Locktime for the pre-release script
-    const PREFUND_LOCKTIME: u32 = 6;
+    const RELEASE_LOCKTIME: u32 = 6;
+    // The length of the subnet tag - helper
+    const PREFUND_TAG_LEN: usize = IPC_PREFUND_SUBNET_TAG.len();
+    // The length of the ethereum address - helper
+    const ETH_ADDR_LEN: usize = alloy_primitives::Address::len_bytes();
+    // The total length of the op_return data - helper
+    const DATA_LEN: usize = Self::PREFUND_TAG_LEN + Txid::LEN + Self::ETH_ADDR_LEN;
 
     /// Validates the join subnet message, for the given genesis info
     pub fn validate_for_genesis_info(
@@ -505,6 +512,133 @@ impl IpcPrefundSubnetMsg {
         Ok(())
     }
 
+    /// Reconstructs an IpcPrefundSubnetMsg from a bitcoin::Transaction.
+    ///
+    /// Given that:
+    ///   • The first output is an OP_RETURN containing our custom pushdata,
+    ///     whose layout is:
+    ///         [prefund tag | 32-byte txid | 20-byte alloy address]
+    ///   • The second output is the funding output with nonzero value.
+    ///
+    /// Returns an error if any expected data is missing or malformed.
+    pub fn from_tx(tx: &Transaction) -> Result<Self, IpcLibError> {
+        use bitcoin::blockdata::script::Instruction;
+
+        // Helper closure for error creation
+        let err = |msg: String| IpcLibError::MsgParseError(IPC_PREFUND_SUBNET_TAG, msg);
+
+        // Verify we have both required outputs
+        if tx.output.len() < 2 {
+            return Err(err("Transaction must have at least 2 outputs".into()));
+        }
+        // Get OP_RETURN data from first output
+        let op_return_data = tx.output[0]
+            .script_pubkey
+            .instructions_minimal()
+            .find_map(|ins| match ins {
+                Ok(Instruction::PushBytes(data)) => Some(data.as_bytes()),
+                _ => None,
+            })
+            .ok_or_else(|| err("First output must be OP_RETURN with pushdata".into()))?;
+
+        // Check total length matches our expected format
+        if op_return_data.len() != Self::DATA_LEN {
+            return Err(err(format!(
+                "OP_RETURN data length mismatch: got {}, expected {}",
+                op_return_data.len(),
+                Self::DATA_LEN
+            )));
+        }
+
+        // Split data into its components
+        let (tag, rest) = op_return_data.split_at(Self::PREFUND_TAG_LEN);
+        let (txid_bytes, addr_bytes) = rest.split_at(Txid::LEN);
+
+        // Verify tag
+        if tag != IPC_PREFUND_SUBNET_TAG.as_bytes() {
+            return Err(err(format!(
+                "Invalid tag: got '{}', expected '{}'",
+                String::from_utf8_lossy(tag),
+                IPC_PREFUND_SUBNET_TAG
+            )));
+        }
+
+        // Convert txid bytes to Txid
+        let txid =
+            Txid::from_slice(txid_bytes).map_err(|e| err(format!("Invalid txid bytes: {}", e)))?;
+        let subnet_id = SubnetId::from_txid(&txid);
+
+        // Convert address bytes to alloy Address
+        let address = alloy_primitives::Address::from_slice(addr_bytes);
+
+        // Get value from second output
+        let value = tx.output[1].value;
+
+        Ok(Self {
+            subnet_id,
+            value,
+            address,
+        })
+    }
+
+    pub fn to_tx(
+        &self,
+        multisig_address: &bitcoin::Address,
+        release_address: &bitcoin::Address,
+    ) -> Result<Transaction, IpcLibError> {
+        let secp = bitcoin::secp256k1::Secp256k1::new();
+
+        //
+        // Create the first output: op_return with
+        // ipc tag, subnet_id (txid) and user's subnet address to fund
+        //
+
+        let prefund_tag: [u8; Self::PREFUND_TAG_LEN] = IPC_PREFUND_SUBNET_TAG
+            .as_bytes()
+            .try_into()
+            .expect("IPC_PREFUND_SUBNET_TAG has incorrect length");
+        let subnet_id_txid: [u8; Txid::LEN] = self.subnet_id.txid().as_raw_hash().to_byte_array();
+        let subnet_addr: [u8; Self::ETH_ADDR_LEN] = self.address.into_array();
+
+        // Construct op_return data
+        let mut op_return_data = [0u8; Self::PREFUND_TAG_LEN + Txid::LEN + Self::ETH_ADDR_LEN];
+
+        op_return_data[0..Self::PREFUND_TAG_LEN].copy_from_slice(&prefund_tag);
+        op_return_data[Self::PREFUND_TAG_LEN..(Self::PREFUND_TAG_LEN + Txid::LEN)]
+            .copy_from_slice(&subnet_id_txid);
+        op_return_data[(Self::PREFUND_TAG_LEN + Txid::LEN)..].copy_from_slice(&subnet_addr);
+
+        // Make op_return script and txout
+        let op_return_script = bitcoin_utils::make_op_return_script(op_return_data);
+        let data_tx_out = bitcoin::TxOut {
+            value: bitcoin::Amount::ZERO,
+            script_pubkey: op_return_script,
+        };
+
+        //
+        // Create second output: pre-fund + pre-release script
+        //
+
+        let prefund_script = bitcoin_utils::create_send_with_timelock_release_tx_script(
+            &secp,
+            multisig_address,
+            release_address,
+            Self::RELEASE_LOCKTIME,
+        )?;
+        let prefund_tx_out = bitcoin::TxOut {
+            value: self.value,
+            script_pubkey: prefund_script,
+        };
+
+        // Construct transaction
+
+        let tx_outs = vec![data_tx_out, prefund_tx_out];
+        let prefund_tx = bitcoin_utils::create_tx_from_txouts(tx_outs);
+        debug!("Prefund TX: {prefund_tx:?}");
+
+        Ok(prefund_tx)
+    }
+
     pub fn submit_to_bitcoin(
         &self,
         rpc: &bitcoincore_rpc::Client,
@@ -515,51 +649,30 @@ impl IpcPrefundSubnetMsg {
             multisig_address, self.value
         );
 
-        let secp = bitcoin::secp256k1::Secp256k1::new();
+        let release_address = wallet::get_new_address(rpc)?;
 
-        //
-        // Create first output: pre-fund + pre-release script
-        //
+        // Construct, fund and sign the prefund transaction
 
-        let release_address = wallet::get_new_address(&rpc)?;
-        let prefund_script = bitcoin_utils::create_send_with_timelock_release_tx_script(
-            &secp,
-            &multisig_address,
-            &release_address,
-            Self::PREFUND_LOCKTIME,
-        )?;
-        let prefund_tx_out = bitcoin::TxOut {
-            value: self.value,
-            script_pubkey: prefund_script,
-        };
+        let prefund_tx = self.to_tx(multisig_address, &release_address)?;
 
-        //
-        // Create the second output: op_return with subnet_id and user's subnet address to fund
-        //
-
-        let subnet_id_txid: [u8; 32] = self.subnet_id.txid().as_raw_hash().to_byte_array();
-        let subnet_addr: [u8; 20] = self.address.into_array();
-
-        // Construct op_return data
-        let mut op_return_data = [0u8; 32 + 20];
-        op_return_data[..subnet_id_txid.len()].copy_from_slice(&subnet_id_txid);
-        op_return_data[subnet_id_txid.len()..].copy_from_slice(&subnet_addr);
-        // Make op_return script and txout
-        let op_return_script = bitcoin_utils::make_op_return_script(op_return_data);
-        let data_tx_out = bitcoin::TxOut {
-            value: bitcoin::Amount::ZERO,
-            script_pubkey: op_return_script,
-        };
-
-        let tx_outs = vec![prefund_tx_out, data_tx_out];
-        let prefund_tx = bitcoin_utils::create_tx_from_txouts(tx_outs);
-        println!("prefund_tx: {prefund_tx:#?}");
         let prefund_tx = crate::wallet::fund_tx(rpc, prefund_tx, None)?;
-        println!("prefund_tx: {prefund_tx:#?}");
+        trace!("Prefund funded TX: {prefund_tx:?}");
         let prefund_tx = crate::wallet::sign_tx(rpc, prefund_tx)?;
-        println!("prefund_tx: {prefund_tx:#?}");
+        trace!("Prefund signed TX: {prefund_tx:?}");
 
-        return Ok(prefund_tx.compute_txid());
+        // Submit the prefund transaction to the mempool
+
+        let prefund_txid = prefund_tx.compute_txid();
+        match submit_to_mempool(rpc, vec![prefund_tx]) {
+            Ok(_) => {
+                info!(
+                    "Submitted prefund subnet msg for subnet_id={} prefund_txid={}",
+                    self.subnet_id, prefund_txid,
+                );
+                Ok(prefund_txid)
+            }
+            Err(e) => Err(IpcLibError::BitcoinUtilsError(e)),
+        }
     }
 }
 
@@ -693,6 +806,9 @@ impl<'de> serde::Deserialize<'de> for SubnetId {
 
 #[derive(Error, Debug)]
 pub enum IpcLibError {
+    #[error("Error parsing {0}: {1}")]
+    MsgParseError(&'static str, String),
+
     #[error(transparent)]
     IpcValidateError(#[from] IpcValidateError),
 
@@ -1007,5 +1123,144 @@ mod tests {
         // Test JSON deserialization
         let deserialized: SubnetId = serde_json::from_str(&serialized).unwrap();
         assert_eq!(deserialized, subnet_id);
+    }
+}
+
+#[cfg(test)]
+mod prefund_msg_tests {
+    use super::*;
+
+    fn create_test_msg() -> IpcPrefundSubnetMsg {
+        let txid =
+            Txid::from_str("4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b")
+                .unwrap();
+        let subnet_id = SubnetId::from_txid(&txid);
+        let eth_addr =
+            alloy_primitives::Address::from_str("742d35Cc6634C0532925a3b844Bc454e4438f44e")
+                .unwrap();
+
+        IpcPrefundSubnetMsg {
+            subnet_id,
+            value: Amount::from_sat(1000),
+            address: eth_addr,
+        }
+    }
+
+    fn get_addresses() -> (bitcoin::Address, bitcoin::Address) {
+        let multisig_address = bitcoin::Address::from_str(
+            "bc1pzc5j0fyekrc9p63avup65y8h8rhp7m5ql5tg7590wuhhqdtlkfusng6er8",
+        )
+        .unwrap()
+        .assume_checked();
+        let release_address =
+            bitcoin::Address::from_str("bcrt1qvr3jycfxtrkk8u6hp5caxc25tueek5f90mpnsv")
+                .unwrap()
+                .assume_checked();
+
+        (multisig_address, release_address)
+    }
+
+    #[test]
+    fn test_to_tx_structure() {
+        let msg = create_test_msg();
+        let (multisig_address, release_address) = get_addresses();
+
+        // Generate transaction
+        let tx = msg.to_tx(&multisig_address, &release_address).unwrap();
+
+        // Check basic structure
+        assert_eq!(
+            tx.output.len(),
+            2,
+            "Transaction should have exactly 2 outputs"
+        );
+
+        // First output should be OP_RETURN
+        assert!(
+            tx.output[0].script_pubkey.is_op_return(),
+            "First output should be OP_RETURN"
+        );
+        assert_eq!(
+            tx.output[0].value,
+            Amount::ZERO,
+            "OP_RETURN output should have zero value"
+        );
+
+        // Second output should have the correct value and script
+        assert!(
+            tx.output[1].script_pubkey.is_p2tr(),
+            "Second output should be p2tr"
+        );
+        assert_eq!(
+            tx.output[1].value,
+            Amount::from_sat(1000),
+            "Second output should have correct value"
+        );
+    }
+
+    #[test]
+    fn test_from_tx_valid() {
+        let original_msg = create_test_msg();
+        let (multisig_address, release_address) = get_addresses();
+
+        // Create transaction using to_tx
+        let tx = original_msg
+            .to_tx(&multisig_address, &release_address)
+            .unwrap();
+
+        // Parse it back using from_tx
+        let parsed_msg = IpcPrefundSubnetMsg::from_tx(&tx).unwrap();
+
+        // Verify all fields match
+        assert_eq!(parsed_msg.subnet_id, original_msg.subnet_id);
+        assert_eq!(parsed_msg.value, original_msg.value);
+        assert_eq!(parsed_msg.address, original_msg.address);
+    }
+
+    #[test]
+    fn test_from_tx_invalid_cases() {
+        let (multisig_address, release_address) = get_addresses();
+
+        // Test case 1: Empty transaction
+        let empty_tx = Transaction {
+            version: bitcoin::transaction::Version::TWO,
+            lock_time: bitcoin::absolute::LockTime::ZERO,
+            input: vec![],
+            output: vec![],
+        };
+        assert!(matches!(
+            IpcPrefundSubnetMsg::from_tx(&empty_tx),
+            Err(IpcLibError::MsgParseError(IPC_PREFUND_SUBNET_TAG, _))
+        ));
+
+        // Test case 2: Transaction with only one output
+        let tx = create_test_msg()
+            .to_tx(&multisig_address, &release_address)
+            .unwrap();
+        let single_output_tx = Transaction {
+            version: tx.version,
+            lock_time: tx.lock_time,
+            input: tx.input.clone(),
+            output: vec![tx.output[0].clone()], // Only the OP_RETURN output
+        };
+        assert!(matches!(
+            IpcPrefundSubnetMsg::from_tx(&single_output_tx),
+            Err(IpcLibError::MsgParseError(IPC_PREFUND_SUBNET_TAG, _))
+        ));
+
+        // Test case 3: Wrong tag in OP_RETURN
+        let mut wrong_tag_tx = tx.clone();
+        let mut wrong_data = Vec::new();
+        // same length as "IPC:PREFUND"
+        let invalid_tag = "IPC:TEST123";
+        wrong_data.extend_from_slice(invalid_tag.as_bytes()); // Different tag
+        wrong_data.extend_from_slice(&[0u8; 32]); // txid
+        wrong_data.extend_from_slice(&[0u8; 20]); // address
+        let wrong_data: [u8; IpcPrefundSubnetMsg::DATA_LEN] = wrong_data.try_into().unwrap();
+        wrong_tag_tx.output[0].script_pubkey = bitcoin_utils::make_op_return_script(&wrong_data);
+        assert!(matches!(
+            IpcPrefundSubnetMsg::from_tx(&wrong_tag_tx),
+            Err(IpcLibError::MsgParseError(IPC_PREFUND_SUBNET_TAG, _))
+        ));
     }
 }

--- a/src/ipc_lib.rs
+++ b/src/ipc_lib.rs
@@ -1285,7 +1285,7 @@ mod prefund_msg_tests {
         wrong_data.extend_from_slice(&[0u8; 32]); // txid
         wrong_data.extend_from_slice(&[0u8; 20]); // address
         let wrong_data: [u8; IpcPrefundSubnetMsg::DATA_LEN] = wrong_data.try_into().unwrap();
-        wrong_tag_tx.output[0].script_pubkey = bitcoin_utils::make_op_return_script(&wrong_data);
+        wrong_tag_tx.output[0].script_pubkey = bitcoin_utils::make_op_return_script(wrong_data);
         assert!(matches!(
             IpcPrefundSubnetMsg::from_tx(&wrong_tag_tx),
             Err(IpcLibError::MsgParseError(IPC_PREFUND_SUBNET_TAG, _))

--- a/src/ipc_lib.rs
+++ b/src/ipc_lib.rs
@@ -46,6 +46,7 @@ pub const IPC_DELETE_SUBNET_TAG: &str = "IPC:DELETE";
 pub enum IpcTag {
     CreateSubnet,
     JoinSubnet,
+    PrefundSubnet,
 }
 
 impl IpcTag {
@@ -53,6 +54,7 @@ impl IpcTag {
         match self {
             Self::CreateSubnet => IPC_CREATE_SUBNET_TAG,
             Self::JoinSubnet => IPC_JOIN_SUBNET_TAG,
+            Self::PrefundSubnet => IPC_PREFUND_SUBNET_TAG,
         }
     }
 }
@@ -64,6 +66,7 @@ impl std::str::FromStr for IpcTag {
         match s {
             IPC_CREATE_SUBNET_TAG => Ok(Self::CreateSubnet),
             IPC_JOIN_SUBNET_TAG => Ok(Self::JoinSubnet),
+            IPC_PREFUND_SUBNET_TAG => Ok(Self::PrefundSubnet),
             _ => Err(IpcSerializeError::UnknownTag(s.to_string())),
         }
     }
@@ -454,11 +457,118 @@ impl IpcValidate for IpcJoinSubnetMsg {
     }
 }
 
+#[derive(Serialize, Deserialize, IpcSerialize, Debug, Clone)]
+#[tag(IPC_PREFUND_SUBNET_TAG)]
+pub struct IpcPrefundSubnetMsg {
+    /// The subnet id of the subnet to prefund
+    /// This is derived from 2nd output
+    /// that is sent to the subnet multisig address
+    #[ipc_serde(skip)]
+    pub subnet_id: SubnetId,
+    /// The amount to deposit in the subnet
+    #[ipc_serde(skip)]
+    #[serde(with = "bitcoin::amount::serde::as_sat")]
+    pub value: bitcoin::Amount,
+    /// The address to prefund in the subnet
+    pub address: alloy_primitives::Address,
+}
+
+impl IpcValidate for IpcPrefundSubnetMsg {
+    fn validate(&self) -> Result<(), IpcValidateError> {
+        if self.value == bitcoin::Amount::MIN {
+            return Err(IpcValidateError::InvalidField(
+                "value",
+                "Value must be greater than 0".to_string(),
+            ));
+        }
+        Ok(())
+    }
+}
+
+impl IpcPrefundSubnetMsg {
+    // Locktime for the pre-release script
+    const PREFUND_LOCKTIME: u32 = 6;
+
+    /// Validates the join subnet message, for the given genesis info
+    pub fn validate_for_genesis_info(
+        &self,
+        genesis_info: &db::SubnetGenesisInfo,
+    ) -> Result<(), IpcValidateError> {
+        // Check if the subnet is already bootstrapped
+        if genesis_info.bootstrapped {
+            return Err(IpcValidateError::InvalidMsg(format!(
+                "Subnet {} is already bootstrapped.",
+                self.subnet_id
+            )));
+        }
+
+        Ok(())
+    }
+
+    pub fn submit_to_bitcoin(
+        &self,
+        rpc: &bitcoincore_rpc::Client,
+        multisig_address: &bitcoin::Address,
+    ) -> Result<Txid, IpcLibError> {
+        info!(
+            "Submitting pre-fund subnet msg to bitcoin. Multisig address = {}. Amount={}",
+            multisig_address, self.value
+        );
+
+        let secp = bitcoin::secp256k1::Secp256k1::new();
+
+        //
+        // Create first output: pre-fund + pre-release script
+        //
+
+        let release_address = wallet::get_new_address(&rpc)?;
+        let prefund_script = bitcoin_utils::create_send_with_timelock_release_tx_script(
+            &secp,
+            &multisig_address,
+            &release_address,
+            Self::PREFUND_LOCKTIME,
+        )?;
+        let prefund_tx_out = bitcoin::TxOut {
+            value: self.value,
+            script_pubkey: prefund_script,
+        };
+
+        //
+        // Create the second output: op_return with subnet_id and user's subnet address to fund
+        //
+
+        let subnet_id_txid: [u8; 32] = self.subnet_id.txid().as_raw_hash().to_byte_array();
+        let subnet_addr: [u8; 20] = self.address.into_array();
+
+        // Construct op_return data
+        let mut op_return_data = [0u8; 32 + 20];
+        op_return_data[..subnet_id_txid.len()].copy_from_slice(&subnet_id_txid);
+        op_return_data[subnet_id_txid.len()..].copy_from_slice(&subnet_addr);
+        // Make op_return script and txout
+        let op_return_script = bitcoin_utils::make_op_return_script(op_return_data);
+        let data_tx_out = bitcoin::TxOut {
+            value: bitcoin::Amount::ZERO,
+            script_pubkey: op_return_script,
+        };
+
+        let tx_outs = vec![prefund_tx_out, data_tx_out];
+        let prefund_tx = bitcoin_utils::create_tx_from_txouts(tx_outs);
+        println!("prefund_tx: {prefund_tx:#?}");
+        let prefund_tx = crate::wallet::fund_tx(rpc, prefund_tx, None)?;
+        println!("prefund_tx: {prefund_tx:#?}");
+        let prefund_tx = crate::wallet::sign_tx(rpc, prefund_tx)?;
+        println!("prefund_tx: {prefund_tx:#?}");
+
+        return Ok(prefund_tx.compute_txid());
+    }
+}
+
 // Define the IPCMessage enum
 #[derive(Debug)]
 pub enum IpcMessage {
     CreateSubnet(IpcCreateSubnetMsg),
     JoinSubnet(IpcJoinSubnetMsg),
+    PrefundSubnet(IpcPrefundSubnetMsg),
 }
 
 impl IpcMessage {
@@ -477,6 +587,9 @@ impl IpcMessage {
             IpcTag::JoinSubnet => Ok(IpcMessage::JoinSubnet(IpcJoinSubnetMsg::ipc_deserialize(
                 s,
             )?)),
+            IpcTag::PrefundSubnet => Ok(IpcMessage::PrefundSubnet(
+                IpcPrefundSubnetMsg::ipc_deserialize(s)?,
+            )),
         }
     }
 }

--- a/src/multisig.rs
+++ b/src/multisig.rs
@@ -151,10 +151,10 @@ mod tests {
                 };
 
                 bitcoinconsensus::verify_with_flags(
-                    &output.script_pubkey.as_bytes(),
+                    output.script_pubkey.as_bytes(),
                     output.value.to_sat(),
                     serialized_tx.as_slice(),
-                    Some(&vec![spent_utxo]),
+                    Some(&[spent_utxo]),
                     idx,
                     bitcoinconsensus::VERIFY_ALL_PRE_TAPROOT | bitcoinconsensus::VERIFY_TAPROOT,
                 )?;
@@ -351,7 +351,7 @@ mod tests {
             }],
             output: vec![TxOut {
                 value: spending_amount,
-                script_pubkey: ScriptBuf::new_op_return(&[1]),
+                script_pubkey: ScriptBuf::new_op_return([1]),
             }],
         };
 
@@ -388,10 +388,10 @@ mod tests {
 
             // Push empty signatures for the remaining keys
             for _ in 2..keypairs.len() {
-                witness.push(&[]); // Empty signature slots for unused keys
+                witness.push([]); // Empty signature slots for unused keys
             }
 
-            witness.push(&script.to_bytes());
+            witness.push(script.to_bytes());
             witness.push(control_block.serialize());
 
             tx_insufficient.input[0].witness = witness;
@@ -418,7 +418,7 @@ mod tests {
             for (idx, keypair) in keypairs.iter().rev().enumerate() {
                 // Skip keys 4 and 5, pushing empty signatures
                 if idx > 2 {
-                    witness.push(&[]);
+                    witness.push([]);
                     continue;
                 }
                 let msg =
@@ -427,7 +427,7 @@ mod tests {
                 witness.push(sig.serialize());
             }
 
-            witness.push(&script.to_bytes());
+            witness.push(script.to_bytes());
             witness.push(control_block.serialize());
 
             tx_valid.input[0].witness = witness;
@@ -458,7 +458,7 @@ mod tests {
                 witness.push(sig.serialize());
             }
 
-            witness.push(&script.to_bytes());
+            witness.push(script.to_bytes());
             witness.push(control_block.serialize());
 
             tx_all.input[0].witness = witness;
@@ -491,10 +491,10 @@ mod tests {
 
             // Push empty signatures for the remaining keys
             for _ in 3..keypairs.len() {
-                witness.push(&[]); // Empty signature slots for unused keys
+                witness.push([]); // Empty signature slots for unused keys
             }
 
-            witness.push(&script.to_bytes());
+            witness.push(script.to_bytes());
             witness.push(
                 spend_info
                     .control_block(&(script.clone(), LeafVersion::TapScript))

--- a/src/provider/rpc.rs
+++ b/src/provider/rpc.rs
@@ -1,6 +1,6 @@
 use crate::{
     db::{self, Database, HeedDb},
-    ipc_lib::{IpcJoinSubnetMsg, IpcValidate, SubnetId},
+    ipc_lib::{IpcJoinSubnetMsg, IpcPrefundSubnetMsg, IpcValidate, SubnetId},
     IpcCreateSubnetMsg, BTC_CONFIRMATIONS,
 };
 use bitcoincore_rpc::{Client, RpcApi};
@@ -145,6 +145,7 @@ pub async fn create_subnet(
     Params(msg): Params<IpcCreateSubnetMsg>,
 ) -> Result<CreateSubnetResponse, JsonRpcError> {
     if let Err(err) = msg.validate() {
+        error!("Invalid create message={msg:?}: {err}");
         return Err(RpcError::InvalidParams(err.to_string()).into());
     }
 
@@ -166,6 +167,7 @@ pub async fn join_subnet(
     Params(msg): Params<IpcJoinSubnetMsg>,
 ) -> Result<JoinSubnetResponse, JsonRpcError> {
     if let Err(err) = msg.validate() {
+        error!("Invalid join message={msg:?}: {err}");
         return Err(RpcError::InvalidParams(err.to_string()).into());
     }
 
@@ -220,6 +222,47 @@ pub async fn get_genesis_info(
     Ok(genesis_info)
 }
 
+#[derive(Serialize, Deserialize)]
+pub struct PrefundSubnetResponse {
+    prefund_txid: bitcoin::Txid,
+}
+
+pub async fn prefund_subnet(
+    data: Data<Arc<ServerData>>,
+    Params(msg): Params<IpcPrefundSubnetMsg>,
+) -> Result<PrefundSubnetResponse, JsonRpcError> {
+    if let Err(err) = msg.validate() {
+        error!("Invalid prefund message={msg:?}: {err}");
+        return Err(RpcError::InvalidParams(err.to_string()).into());
+    }
+
+    let genesis_info = data
+        .db
+        .get_subnet_genesis_info(msg.subnet_id)
+        .map_err(|e| {
+            error!("Error getting subnet info from Db: {}", e);
+            RpcError::DbError(e)
+        })?
+        .ok_or(RpcError::InvalidParams(format!(
+            "Subnet {} not found.",
+            msg.subnet_id
+        )))?;
+
+    msg.validate_for_genesis_info(&genesis_info).map_err(|e| {
+        error!("Error validating prefund msg for subnet info: {}", e);
+        RpcError::InvalidParams(e.to_string())
+    })?;
+
+    // TODO this check should be done in the Db
+    let multisig_address = &genesis_info.multisig_address();
+
+    let prefund_txid = msg
+        .submit_to_bitcoin(&data.btc_rpc, multisig_address)
+        .map_err(|e| JsonRpcError::internal(e.to_string()))?;
+
+    Ok(PrefundSubnetResponse { prefund_txid })
+}
+
 pub fn make_rpc_server(server_data: Arc<ServerData>) -> RpcServer {
     jsonrpc_v2::Server::new()
         .with_data(Data::new(server_data))
@@ -230,5 +273,6 @@ pub fn make_rpc_server(server_data: Arc<ServerData>) -> RpcServer {
         .with_method("createsubnet", create_subnet)
         .with_method("joinsubnet", join_subnet)
         .with_method("getgenesisinfo", get_genesis_info)
+        .with_method("prefundsubnet", prefund_subnet)
         .finish()
 }


### PR DESCRIPTION
Opens a `prefundsubnet` RPC method. Example curl request:

```sh
curl -X POST http://localhost:3030/api \
-H "Content-Type: application/json" \
-H "Authorization: Bearer asda123123jhaskjdhgbjsjhdj" \
-d '{
    "jsonrpc": "2.0",
    "method": "prefundsubnet",
    "params": {
			"subnet_id": "/b4/t420feejlnrllx3nr4tqfl5iuvwllwnazdiwehluntld6lc2z6w6ypffau6qppq",
			"amount": 40000000,
			"address": "0xbce2f194e9628e6ae06fa0d85dd57cd5579213bf"
    },
    "id": 1
}' | jq
```

Once processed by monitor, it is saved in the database.

To get the genesis balances, query the genesis info:

```sh
curl -X POST http://localhost:3030/api \
-H "Content-Type: application/json" \
-H "Authorization: Bearer asda123123jhaskjdhgbjsjhdj" \
-d '{
	"jsonrpc": "2.0",
	"method": "getgenesisinfo",
	"params": {
		"subnet_id": "/b4/t420feejlnrllx3nr4tqfl5iuvwllwnazdiwehluntld6lc2z6w6ypffau6qppq"
	},
	"id": 1
}' | jq
```

You'll see there's a `genesis_balance_entries` looking like so:

```json
"genesis_balance_entries": [
    {
    "subnet_address": "0xbce2f194e9628e6ae06fa0d85dd57cd5579213bf",
    "amount": 200000000,
    "prefund_txid": "9dcbb66bfab259afeb940fa49d2b1bcb23f434805a31f241da27b95904ae6546",
    "block_height": 215
    },
    {
    "subnet_address": "0xbce2f194e9628e6ae06fa0d85dd57cd5579213bf",
    "amount": 40000000,
    "prefund_txid": "532a530c1c0b6c9e5e39527ca8a7b36eb944da472a4e2e53946c23cdb1321fa3",
    "block_height": 216
    },
    {
    "subnet_address": "0xbce2f194e9628e6ae06fa0d85dd57cd5579213bf",
    "amount": 40000000,
    "prefund_txid": "deaa2cf09d86c1bc38d0b8d95aef74e24ef3742beb2a26f8137407994b09abfa",
    "block_height": 218
    },
    {
    "subnet_address": "0xbce2f194e9628e6ae06fa0d85dd57cd5579213bf",
    "amount": 40000000,
    "prefund_txid": "613db9a1923f74b714f9a7ed3fea7b320bef049f73fa4981cb32567870268722",
    "block_height": 219
    }
] 
```

The `subnet_address` can be duplicated if a single user submitted multiple pre-fund messages. Every pre-fund however needs to be verified upon bootstrap to check if the funds have been released, which will be done in a follow-up task.

Closes #56 