### PR TITLE
Fund Subnet Msg + fetch rootnet messages

### DIFF
--- a/docs/internal/curl_reqs.md
+++ b/docs/internal/curl_reqs.md
@@ -124,4 +124,17 @@ curl -X POST http://localhost:3030/api \
     },
     "id": 1
 }' | jq
+
+curl -X POST http://localhost:3030/api \
+-H "Content-Type: application/json" \
+-H "Authorization: Bearer asda123123jhaskjdhgbjsjhdj" \
+-d '{
+    "jsonrpc": "2.0",
+    "method": "getrootnetmessages",
+    "params": {
+			"subnet_id": "/b4/t420f7gmk32wp44h5kxcc2sbonm6iysmmkvfscmxr74kx4cqrofc4len4quzaha",
+			"block_height": 229
+    },
+    "id": 1
+}' | jq
 ```

--- a/docs/internal/curl_reqs.md
+++ b/docs/internal/curl_reqs.md
@@ -92,12 +92,10 @@ curl -X POST http://localhost:3030/api \
 	"jsonrpc": "2.0",
 	"method": "getgenesisinfo",
 	"params": {
-		"subnet_id": "/b4/t420feejlnrllx3nr4tqfl5iuvwllwnazdiwehluntld6lc2z6w6ypffau6qppq"
+		"subnet_id": "/b4/t420f7gmk32wp44h5kxcc2sbonm6iysmmkvfscmxr74kx4cqrofc4len4quzaha"
 	},
 	"id": 1
 }' | jq
-
-
 
 curl -X POST http://localhost:3030/api \
 -H "Content-Type: application/json" \
@@ -107,6 +105,20 @@ curl -X POST http://localhost:3030/api \
     "method": "prefundsubnet",
     "params": {
 			"subnet_id": "/b4/t420feejlnrllx3nr4tqfl5iuvwllwnazdiwehluntld6lc2z6w6ypffau6qppq",
+			"amount": 40000000,
+			"address": "0xbce2f194e9628e6ae06fa0d85dd57cd5579213bf"
+    },
+    "id": 1
+}' | jq
+
+curl -X POST http://localhost:3030/api \
+-H "Content-Type: application/json" \
+-H "Authorization: Bearer asda123123jhaskjdhgbjsjhdj" \
+-d '{
+    "jsonrpc": "2.0",
+    "method": "fundsubnet",
+    "params": {
+			"subnet_id": "/b4/t420f7gmk32wp44h5kxcc2sbonm6iysmmkvfscmxr74kx4cqrofc4len4quzaha",
 			"amount": 40000000,
 			"address": "0xbce2f194e9628e6ae06fa0d85dd57cd5579213bf"
     },

--- a/src/bin/monitor.rs
+++ b/src/bin/monitor.rs
@@ -1,6 +1,7 @@
 use std::env;
 use std::path::PathBuf;
 
+use bitcoin::BlockHash;
 use bitcoin_ipc::bitcoin_utils::{concatenate_op_push_data, make_rpc_client_from_env};
 use bitcoin_ipc::db::{self, Database, HeedDb};
 use bitcoin_ipc::ipc_lib::{self, IpcLibError, IpcValidate};
@@ -273,7 +274,8 @@ where
         let block = self.rpc.get_block(&block_hash)?;
 
         for tx in block.txdata {
-            self.process_transaction(&tx, block_height).await?;
+            self.process_transaction(&tx, block_height, block_hash)
+                .await?;
         }
 
         Ok(())
@@ -283,6 +285,7 @@ where
         &self,
         tx: &bitcoin::Transaction,
         block_height: u64,
+        block_hash: BlockHash,
     ) -> Result<(), MonitorError> {
         let txid = tx.compute_txid();
         debug!("Processing transaction {}", txid);
@@ -312,7 +315,7 @@ where
                 };
 
                 match self
-                    .process_ipc_msg(block_height, tx, txid, ipc_message)
+                    .process_ipc_msg(block_height, block_hash, tx, txid, ipc_message)
                     .await
                 {
                     Ok(_) => {}
@@ -328,7 +331,7 @@ where
             let ipc_message = IpcMessage::PrefundSubnet(prefund_msg);
 
             match self
-                .process_ipc_msg(block_height, tx, txid, ipc_message)
+                .process_ipc_msg(block_height, block_hash, tx, txid, ipc_message)
                 .await
             {
                 Ok(_) => {}
@@ -338,7 +341,7 @@ where
             let ipc_message = IpcMessage::FundSubnet(fund_msg);
 
             match self
-                .process_ipc_msg(block_height, tx, txid, ipc_message)
+                .process_ipc_msg(block_height, block_hash, tx, txid, ipc_message)
                 .await
             {
                 Ok(_) => {}
@@ -352,6 +355,7 @@ where
     async fn process_ipc_msg(
         &self,
         block_height: u64,
+        block_hash: BlockHash,
         tx: &bitcoin::Transaction,
         txid: bitcoin::Txid,
         msg: IpcMessage,
@@ -397,7 +401,7 @@ where
             IpcMessage::FundSubnet(msg) => {
                 debug!("Found IPC message: {:?}", msg);
                 msg.validate()?;
-                msg.save_to_db(&self.db, block_height, txid)?;
+                msg.save_to_db(&self.db, block_height, block_hash, txid)?;
                 info!("Processed FundSubnet for Subnet ID: {}", msg.subnet_id);
                 Ok(())
             }

--- a/src/bin/monitor.rs
+++ b/src/bin/monitor.rs
@@ -334,6 +334,16 @@ where
                 Ok(_) => {}
                 Err(e) => self.handle_ipc_msg_error(e)?,
             }
+        } else if let Ok(fund_msg) = ipc_lib::IpcFundSubnetMsg::from_tx(tx) {
+            let ipc_message = IpcMessage::FundSubnet(fund_msg);
+
+            match self
+                .process_ipc_msg(block_height, tx, txid, ipc_message)
+                .await
+            {
+                Ok(_) => {}
+                Err(e) => self.handle_ipc_msg_error(e)?,
+            }
         }
 
         Ok(())
@@ -381,6 +391,14 @@ where
                 msg.validate()?;
                 msg.save_to_db(&self.db, block_height, txid)?;
                 info!("Processed PrefundSubnet for Subnet ID: {}", msg.subnet_id);
+                Ok(())
+            }
+
+            IpcMessage::FundSubnet(msg) => {
+                debug!("Found IPC message: {:?}", msg);
+                msg.validate()?;
+                msg.save_to_db(&self.db, block_height, txid)?;
+                info!("Processed FundSubnet for Subnet ID: {}", msg.subnet_id);
                 Ok(())
             }
         }

--- a/src/db.rs
+++ b/src/db.rs
@@ -11,14 +11,14 @@ use std::{io, path::Path};
 use thiserror::Error;
 
 const LAST_PROCESSED_BLOCK_KEY: &str = "monitor:last_processed_block";
-const SUBNET_INFO_PREFIX: &str = "subnet_info:";
+const SUBNET_STATE_KEY: &str = "subnet_state:";
 const SUBNET_GENESIS_INFO_PREFIX: &str = "subnet_genesis_info:";
 
 pub type Wtxn<'a> = &'a mut heed::RwTxn<'a>;
 
 #[allow(dead_code)]
-fn subnet_info_key(subnet_id: SubnetId) -> String {
-    format!("{SUBNET_INFO_PREFIX}:{}", subnet_id)
+fn subnet_state_key(subnet_id: SubnetId) -> String {
+    format!("{SUBNET_STATE_KEY}:{}", subnet_id)
 }
 
 fn subnet_genesis_info_key(subnet_id: SubnetId) -> String {
@@ -102,8 +102,18 @@ pub struct SubnetState {
 }
 
 impl SubnetState {
+    /// Returns the total stake of the current committee
     pub fn stake(&self) -> bitcoin::Amount {
         self.committee.validators.iter().map(|v| v.collateral).sum()
+    }
+
+    /// Returns the multisig address of the current committee
+    pub fn multisig_address(&self) -> Address {
+        self.committee
+            .multisig_address
+            .clone()
+            .require_network(NETWORK)
+            .expect("Multisig should be valid for saved subnet genesis info")
     }
 }
 
@@ -161,7 +171,7 @@ impl SubnetGenesisInfo {
             .expect("Multisig should be valid for saved subnet genesis info")
     }
 
-    pub fn into_subnet(self) -> SubnetState {
+    pub fn to_subnet(&self) -> SubnetState {
         SubnetState {
             id: self.subnet_id,
             committee_number: 1,
@@ -312,6 +322,15 @@ pub trait Database {
         subnet_id: SubnetId,
         genesis_info: SubnetGenesisInfo,
     ) -> Result<(), DbError>;
+
+    // Subnet State
+    fn get_subnet_state(&self, subnet_id: SubnetId) -> Result<Option<SubnetState>, DbError>;
+    fn save_subnet_state(
+        &self,
+        txn: &mut RwTxn,
+        subnet_id: SubnetId,
+        subnet_state: SubnetState,
+    ) -> Result<(), DbError>;
 }
 
 #[async_trait]
@@ -372,6 +391,26 @@ impl Database for HeedDb {
         let key = subnet_genesis_info_key(subnet_id);
         self.subnet_genesis_db
             .put(txn, &key, &subnet_genesis_info)?;
+        Ok(())
+    }
+
+    // Subnet State
+
+    fn get_subnet_state(&self, subnet_id: SubnetId) -> Result<Option<SubnetState>, DbError> {
+        let key = subnet_state_key(subnet_id);
+        let txn = self.env.read_txn()?;
+        let subnet = self.subnet_db.get(&txn, &key)?;
+        Ok(subnet)
+    }
+
+    fn save_subnet_state(
+        &self,
+        txn: &mut RwTxn,
+        subnet_id: SubnetId,
+        subnet_state: SubnetState,
+    ) -> Result<(), DbError> {
+        let key = subnet_state_key(subnet_id);
+        self.subnet_db.put(txn, &key, &subnet_state)?;
         Ok(())
     }
 }

--- a/src/db.rs
+++ b/src/db.rs
@@ -233,9 +233,9 @@ impl SubnetGenesisInfo {
     }
 }
 
-/// State of a validator in a subnet
+/// Message emmited on the Bitcoin chain
 #[derive(Serialize, Deserialize, Debug, Clone)]
-#[serde(tag = "type")]
+#[serde(tag = "kind")]
 pub enum RootnetMessage {
     #[serde(rename = "fund")]
     FundSubnet {
@@ -455,7 +455,6 @@ impl Database for HeedDb {
     }
 
     // Subnet State
-
     fn get_subnet_state(&self, subnet_id: SubnetId) -> Result<Option<SubnetState>, DbError> {
         let key = subnet_state_key(subnet_id);
         let txn = self.env.read_txn()?;

--- a/src/db.rs
+++ b/src/db.rs
@@ -4,7 +4,7 @@ use crate::{
     SubnetId, NETWORK,
 };
 use async_trait::async_trait;
-use bitcoin::{address::NetworkUnchecked, Address, XOnlyPublicKey};
+use bitcoin::{address::NetworkUnchecked, Address, BlockHash, Txid, XOnlyPublicKey};
 use heed::{types::*, Database as HeedDatabase, Env, EnvOpenOptions, RwTxn};
 use log::{debug, error, trace};
 use serde::{Deserialize, Serialize};
@@ -241,7 +241,9 @@ pub enum RootnetMessage {
     FundSubnet {
         msg: IpcFundSubnetMsg,
         block_height: u64,
+        block_hash: BlockHash,
         nonce: u64,
+        txid: Txid,
     },
 }
 

--- a/src/db.rs
+++ b/src/db.rs
@@ -37,6 +37,11 @@ fn rootnet_msgs_key(subnet_id: SubnetId, nonce: u64) -> String {
     format!("{ROOTNET_MSGS_KEY}:{}:{}", subnet_id, nonce)
 }
 
+#[derive(Serialize, Deserialize)]
+struct MonitorInfo {
+    pub last_processed_block: u64,
+}
+
 /// State of a validator in a subnet
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct SubnetValidator {
@@ -230,7 +235,9 @@ impl SubnetGenesisInfo {
 
 /// State of a validator in a subnet
 #[derive(Serialize, Deserialize, Debug, Clone)]
+#[serde(tag = "type")]
 pub enum RootnetMessage {
+    #[serde(rename = "fund")]
     FundSubnet {
         msg: IpcFundSubnetMsg,
         block_height: u64,
@@ -246,17 +253,14 @@ impl RootnetMessage {
     }
 }
 
-#[derive(Serialize, Deserialize)]
-struct MonitorInfo {
-    pub last_processed_block: u64,
-}
-
 pub struct HeedDb {
     env: Env,
     monitor_info: HeedDatabase<Str, SerdeBincode<MonitorInfo>>,
     subnet_db: HeedDatabase<Str, SerdeBincode<SubnetState>>,
     subnet_genesis_db: HeedDatabase<Str, SerdeBincode<SubnetGenesisInfo>>,
-    rootnet_msgs_db: HeedDatabase<Str, SerdeBincode<RootnetMessage>>,
+    // TODO use SerdeBincode for this as well
+    // There's a conflict of bincode and `serde(tag = "type")` for RootnetMessage
+    rootnet_msgs_db: HeedDatabase<Str, SerdeJson<RootnetMessage>>,
 }
 
 impl HeedDb {
@@ -375,7 +379,7 @@ pub trait Database {
         subnet_id: SubnetId,
         block_height: u64,
     ) -> Result<Vec<RootnetMessage>, DbError>;
-    fn get_last_msg_nonce(&self, subnet_id: SubnetId) -> Result<u64, DbError>;
+    fn get_last_rootnet_msg_nonce(&self, subnet_id: SubnetId) -> Result<u64, DbError>;
     fn get_rootnet_msg(
         &self,
         subnet_id: SubnetId,
@@ -518,15 +522,15 @@ impl Database for HeedDb {
         Ok(msgs)
     }
 
-    fn get_last_msg_nonce(&self, subnet_id: SubnetId) -> Result<u64, DbError> {
+    fn get_last_rootnet_msg_nonce(&self, subnet_id: SubnetId) -> Result<u64, DbError> {
         let prefix = rootnet_msgs_prefix(subnet_id);
         let txn = self.env.read_txn()?;
         let msgs_iter = self.rootnet_msgs_db.prefix_iter(&txn, &prefix)?;
-        let last_msg = msgs_iter.last();
-        match last_msg {
-            Some(Ok((_, msg))) => Ok(msg.nonce()),
-            _ => Ok(0),
-        }
+        let count: u64 = msgs_iter
+            .count()
+            .try_into()
+            .map_err(|_| DbError::TypeConversionError("max roonet messages reached".to_string()))?;
+        Ok(count)
     }
 
     fn get_rootnet_msg(

--- a/src/db.rs
+++ b/src/db.rs
@@ -1,6 +1,7 @@
 use crate::{
+    ipc_lib::{IpcCreateSubnetMsg, IpcFundSubnetMsg},
     multisig::{create_subnet_multisig_address, multisig_threshold},
-    IpcCreateSubnetMsg, SubnetId, NETWORK,
+    SubnetId, NETWORK,
 };
 use async_trait::async_trait;
 use bitcoin::{address::NetworkUnchecked, Address, XOnlyPublicKey};
@@ -11,18 +12,29 @@ use std::{io, path::Path};
 use thiserror::Error;
 
 const LAST_PROCESSED_BLOCK_KEY: &str = "monitor:last_processed_block";
+// subnet_genesis_info:<subnet_id>
+const SUBNET_GENESIS_INFO_KEY: &str = "subnet_genesis_info:";
+// subnet_state:<subnet_id>
 const SUBNET_STATE_KEY: &str = "subnet_state:";
-const SUBNET_GENESIS_INFO_PREFIX: &str = "subnet_genesis_info:";
+// rootnet_msgs:<subnet_id>:<nonce>
+const ROOTNET_MSGS_KEY: &str = "rootnet_msgs:";
 
 pub type Wtxn<'a> = &'a mut heed::RwTxn<'a>;
 
-#[allow(dead_code)]
 fn subnet_state_key(subnet_id: SubnetId) -> String {
     format!("{SUBNET_STATE_KEY}:{}", subnet_id)
 }
 
 fn subnet_genesis_info_key(subnet_id: SubnetId) -> String {
-    format!("{SUBNET_GENESIS_INFO_PREFIX}:{}", subnet_id)
+    format!("{SUBNET_GENESIS_INFO_KEY}:{}", subnet_id)
+}
+
+fn rootnet_msgs_prefix(subnet_id: SubnetId) -> String {
+    format!("{ROOTNET_MSGS_KEY}:{}", subnet_id)
+}
+
+fn rootnet_msgs_key(subnet_id: SubnetId, nonce: u64) -> String {
+    format!("{ROOTNET_MSGS_KEY}:{}:{}", subnet_id, nonce)
 }
 
 /// State of a validator in a subnet
@@ -216,6 +228,24 @@ impl SubnetGenesisInfo {
     }
 }
 
+/// State of a validator in a subnet
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub enum RootnetMessage {
+    FundSubnet {
+        msg: IpcFundSubnetMsg,
+        block_height: u64,
+        nonce: u64,
+    },
+}
+
+impl RootnetMessage {
+    pub fn nonce(&self) -> u64 {
+        match self {
+            RootnetMessage::FundSubnet { nonce, .. } => *nonce,
+        }
+    }
+}
+
 #[derive(Serialize, Deserialize)]
 struct MonitorInfo {
     pub last_processed_block: u64,
@@ -224,9 +254,9 @@ struct MonitorInfo {
 pub struct HeedDb {
     env: Env,
     monitor_info: HeedDatabase<Str, SerdeBincode<MonitorInfo>>,
-    #[allow(dead_code)]
     subnet_db: HeedDatabase<Str, SerdeBincode<SubnetState>>,
     subnet_genesis_db: HeedDatabase<Str, SerdeBincode<SubnetGenesisInfo>>,
+    rootnet_msgs_db: HeedDatabase<Str, SerdeBincode<RootnetMessage>>,
 }
 
 impl HeedDb {
@@ -278,6 +308,9 @@ impl HeedDb {
             let subnet_genesis_db = env
                 .open_database(&rtxn, Some("subnet_genesis_db"))?
                 .ok_or(DbError::DbNotFound("subnet_genesis_db".to_string()))?;
+            let rootnet_msgs_db = env
+                .open_database(&rtxn, Some("rootnet_msgs_db"))?
+                .ok_or(DbError::DbNotFound("rootnet_msgs_db".to_string()))?;
             rtxn.commit()?;
 
             Ok(Self {
@@ -285,6 +318,7 @@ impl HeedDb {
                 monitor_info,
                 subnet_db,
                 subnet_genesis_db,
+                rootnet_msgs_db,
             })
         } else {
             // In write mode, we can create the databases if they don't exist
@@ -292,6 +326,7 @@ impl HeedDb {
             let monitor_info = env.create_database(&mut txn, Some("monitor_info"))?;
             let subnet_db = env.create_database(&mut txn, Some("subnet_db"))?;
             let subnet_genesis_db = env.create_database(&mut txn, Some("subnet_genesis_db"))?;
+            let rootnet_msgs_db = env.create_database(&mut txn, Some("rootnet_msgs_db"))?;
             txn.commit()?;
 
             Ok(Self {
@@ -299,6 +334,7 @@ impl HeedDb {
                 monitor_info,
                 subnet_db,
                 subnet_genesis_db,
+                rootnet_msgs_db,
             })
         }
     }
@@ -330,6 +366,26 @@ pub trait Database {
         txn: &mut RwTxn,
         subnet_id: SubnetId,
         subnet_state: SubnetState,
+    ) -> Result<(), DbError>;
+
+    // Rootnet Messages
+    fn get_all_rootnet_msgs(&self, subnet_id: SubnetId) -> Result<Vec<RootnetMessage>, DbError>;
+    fn get_rootnet_msgs_by_height(
+        &self,
+        subnet_id: SubnetId,
+        block_height: u64,
+    ) -> Result<Vec<RootnetMessage>, DbError>;
+    fn get_last_msg_nonce(&self, subnet_id: SubnetId) -> Result<u64, DbError>;
+    fn get_rootnet_msg(
+        &self,
+        subnet_id: SubnetId,
+        nonce: u64,
+    ) -> Result<Option<RootnetMessage>, DbError>;
+    fn add_rootnet_msg(
+        &self,
+        txn: &mut RwTxn,
+        subnet_id: SubnetId,
+        msg: RootnetMessage,
     ) -> Result<(), DbError>;
 }
 
@@ -411,6 +467,88 @@ impl Database for HeedDb {
     ) -> Result<(), DbError> {
         let key = subnet_state_key(subnet_id);
         self.subnet_db.put(txn, &key, &subnet_state)?;
+        Ok(())
+    }
+
+    // Rootnet Messages
+
+    /// Note: Potentially returns a large number of messages,
+    /// see `get_rootnet_msgs_by_height` for a more efficient way to get messages
+    fn get_all_rootnet_msgs(&self, subnet_id: SubnetId) -> Result<Vec<RootnetMessage>, DbError> {
+        let prefix = rootnet_msgs_prefix(subnet_id);
+        let txn = self.env.read_txn()?;
+
+        let msgs_iter = self.rootnet_msgs_db.prefix_iter(&txn, &prefix)?;
+
+        let msgs = msgs_iter
+            .map(|res| res.map(|(_, msg)| msg))
+            .collect::<Result<Vec<_>, _>>()?;
+
+        Ok(msgs)
+    }
+
+    fn get_rootnet_msgs_by_height(
+        &self,
+        subnet_id: SubnetId,
+        block_height: u64,
+    ) -> Result<Vec<RootnetMessage>, DbError> {
+        let prefix = rootnet_msgs_prefix(subnet_id);
+        let txn = self.env.read_txn()?;
+
+        let msgs_iter = self.rootnet_msgs_db.prefix_iter(&txn, &prefix)?;
+
+        let msgs = msgs_iter
+            .map(|res| res.map(|(_, msg)| msg))
+            .filter_map(|res| match res {
+                Ok(msg) => {
+                    let height = match &msg {
+                        RootnetMessage::FundSubnet { block_height, .. } => *block_height,
+                    };
+                    // Only include messages within the specified height range
+                    if height == block_height {
+                        Some(Ok(msg))
+                    } else {
+                        None
+                    }
+                }
+                Err(e) => Some(Err(e)),
+            })
+            .collect::<Result<Vec<_>, _>>()?;
+
+        Ok(msgs)
+    }
+
+    fn get_last_msg_nonce(&self, subnet_id: SubnetId) -> Result<u64, DbError> {
+        let prefix = rootnet_msgs_prefix(subnet_id);
+        let txn = self.env.read_txn()?;
+        let msgs_iter = self.rootnet_msgs_db.prefix_iter(&txn, &prefix)?;
+        let last_msg = msgs_iter.last();
+        match last_msg {
+            Some(Ok((_, msg))) => Ok(msg.nonce()),
+            _ => Ok(0),
+        }
+    }
+
+    fn get_rootnet_msg(
+        &self,
+        subnet_id: SubnetId,
+        nonce: u64,
+    ) -> Result<Option<RootnetMessage>, DbError> {
+        let key = rootnet_msgs_key(subnet_id, nonce);
+        let txn = self.env.read_txn()?;
+        let msg = self.rootnet_msgs_db.get(&txn, &key)?;
+        Ok(msg)
+    }
+
+    fn add_rootnet_msg(
+        &self,
+        txn: &mut RwTxn,
+        subnet_id: SubnetId,
+        msg: RootnetMessage,
+    ) -> Result<(), DbError> {
+        let key = rootnet_msgs_key(subnet_id, msg.nonce());
+        trace!("Add rootnet msg: {msg:#?}");
+        self.rootnet_msgs_db.put(txn, &key, &msg)?;
         Ok(())
     }
 }

--- a/src/eth_utils.rs
+++ b/src/eth_utils.rs
@@ -1,3 +1,6 @@
+// The length of the ethereum address - helper
+pub const ETH_ADDR_LEN: usize = alloy_primitives::Address::len_bytes();
+
 // fvm_shared rellies on this global current_network variable
 // to format the address correctly
 //

--- a/src/ipc_lib.rs
+++ b/src/ipc_lib.rs
@@ -14,6 +14,7 @@ use thiserror::Error;
 use crate::bitcoin_utils::{self, submit_to_mempool};
 use crate::db;
 use crate::eth_utils::eth_addr_from_x_only_pubkey;
+use crate::eth_utils::ETH_ADDR_LEN;
 use crate::multisig::create_subnet_multisig_address;
 use crate::wallet;
 use crate::NETWORK;
@@ -22,7 +23,7 @@ use crate::NETWORK;
 pub mod prelude {
     pub use super::{
         IpcCreateSubnetMsg, IpcJoinSubnetMsg, IpcMessage, IpcSerialize, IpcTag, SubnetId,
-        IPC_CHECKPOINT_TAG, IPC_CREATE_SUBNET_TAG, IPC_DELETE_SUBNET_TAG, IPC_DEPOSIT_TAG,
+        IPC_CHECKPOINT_TAG, IPC_CREATE_SUBNET_TAG, IPC_DELETE_SUBNET_TAG, IPC_FUND_SUBNET_TAG,
         IPC_JOIN_SUBNET_TAG, IPC_PREFUND_SUBNET_TAG, IPC_TAG_DELIMITER, IPC_TRANSFER_TAG,
         IPC_WITHDRAW_TAG,
     };
@@ -36,7 +37,7 @@ pub const IPC_TAG_DELIMITER: &str = "#";
 pub const IPC_CREATE_SUBNET_TAG: &str = "IPC:CREATE";
 pub const IPC_PREFUND_SUBNET_TAG: &str = "IPC:PREFUND";
 pub const IPC_JOIN_SUBNET_TAG: &str = "IPC:JOIN";
-pub const IPC_DEPOSIT_TAG: &str = "IPC:DEPOSIT";
+pub const IPC_FUND_SUBNET_TAG: &str = "IPC:FUND";
 pub const IPC_CHECKPOINT_TAG: &str = "IPC:CHECKPOINT";
 pub const IPC_TRANSFER_TAG: &str = "IPC:TRANSFER";
 pub const IPC_WITHDRAW_TAG: &str = "IPC:WITHDRAW";
@@ -48,6 +49,7 @@ pub enum IpcTag {
     CreateSubnet,
     JoinSubnet,
     PrefundSubnet,
+    FundSubnet,
 }
 
 impl IpcTag {
@@ -56,6 +58,7 @@ impl IpcTag {
             Self::CreateSubnet => IPC_CREATE_SUBNET_TAG,
             Self::JoinSubnet => IPC_JOIN_SUBNET_TAG,
             Self::PrefundSubnet => IPC_PREFUND_SUBNET_TAG,
+            Self::FundSubnet => IPC_FUND_SUBNET_TAG,
         }
     }
 }
@@ -68,6 +71,7 @@ impl std::str::FromStr for IpcTag {
             IPC_CREATE_SUBNET_TAG => Ok(Self::CreateSubnet),
             IPC_JOIN_SUBNET_TAG => Ok(Self::JoinSubnet),
             IPC_PREFUND_SUBNET_TAG => Ok(Self::PrefundSubnet),
+            IPC_FUND_SUBNET_TAG => Ok(Self::FundSubnet),
             _ => Err(IpcSerializeError::UnknownTag(s.to_string())),
         }
     }
@@ -408,6 +412,9 @@ impl IpcJoinSubnetMsg {
         trace!("Processing {self:?}, adding new validator {new_validator:?}");
         genesis_info.genesis_validators.push(new_validator);
 
+        // Write to DB
+        let mut wtxn = db.write_txn()?;
+
         //
         // Check if the subnet is bootstrapped
         //
@@ -418,10 +425,10 @@ impl IpcJoinSubnetMsg {
             genesis_info.bootstrapped = true;
             genesis_info.genesis_block_height = Some(block_height);
 
-            // TODO create subnet in db
+            // Save the newly create subnet state
+            let subnet_state = genesis_info.to_subnet();
+            db.save_subnet_state(&mut wtxn, self.subnet_id, subnet_state)?;
         }
-
-        let mut wtxn = db.write_txn()?;
         db.save_subnet_genesis_info(&mut wtxn, self.subnet_id, genesis_info)?;
         wtxn.commit()?;
 
@@ -459,16 +466,13 @@ impl IpcValidate for IpcJoinSubnetMsg {
     }
 }
 
-#[derive(Serialize, Deserialize, IpcSerialize, Debug, Clone)]
-#[tag(IPC_PREFUND_SUBNET_TAG)]
+#[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct IpcPrefundSubnetMsg {
     /// The subnet id of the subnet to prefund
     /// This is derived from 2nd output
     /// that is sent to the subnet multisig address
-    #[ipc_serde(skip)]
     pub subnet_id: SubnetId,
     /// The amount to deposit in the subnet
-    #[ipc_serde(skip)]
     #[serde(with = "bitcoin::amount::serde::as_sat")]
     pub amount: bitcoin::Amount,
     /// The address to prefund in the subnet
@@ -492,10 +496,8 @@ impl IpcPrefundSubnetMsg {
     const RELEASE_LOCKTIME: u32 = 6;
     // The length of the subnet tag - helper
     const PREFUND_TAG_LEN: usize = IPC_PREFUND_SUBNET_TAG.len();
-    // The length of the ethereum address - helper
-    const ETH_ADDR_LEN: usize = alloy_primitives::Address::len_bytes();
     // The total length of the op_return data - helper
-    const DATA_LEN: usize = Self::PREFUND_TAG_LEN + Txid::LEN + Self::ETH_ADDR_LEN;
+    const DATA_LEN: usize = Self::PREFUND_TAG_LEN + Txid::LEN + ETH_ADDR_LEN;
 
     /// Validates the join subnet message, for the given genesis info
     pub fn validate_for_genesis_info(
@@ -599,10 +601,10 @@ impl IpcPrefundSubnetMsg {
             .try_into()
             .expect("IPC_PREFUND_SUBNET_TAG has incorrect length");
         let subnet_id_txid: [u8; Txid::LEN] = self.subnet_id.txid().as_raw_hash().to_byte_array();
-        let subnet_addr: [u8; Self::ETH_ADDR_LEN] = self.address.into_array();
+        let subnet_addr: [u8; ETH_ADDR_LEN] = self.address.into_array();
 
         // Construct op_return data
-        let mut op_return_data = [0u8; Self::PREFUND_TAG_LEN + Txid::LEN + Self::ETH_ADDR_LEN];
+        let mut op_return_data = [0u8; Self::PREFUND_TAG_LEN + Txid::LEN + ETH_ADDR_LEN];
 
         op_return_data[0..Self::PREFUND_TAG_LEN].copy_from_slice(&prefund_tag);
         op_return_data[Self::PREFUND_TAG_LEN..(Self::PREFUND_TAG_LEN + Txid::LEN)]
@@ -704,12 +706,126 @@ impl IpcPrefundSubnetMsg {
     }
 }
 
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct IpcFundSubnetMsg {
+    /// The subnet id of the subnet to prefund
+    /// This is derived from 2nd output
+    /// that is sent to the subnet multisig address
+    pub subnet_id: SubnetId,
+    /// The amount to deposit in the subnet
+    #[serde(with = "bitcoin::amount::serde::as_sat")]
+    pub amount: bitcoin::Amount,
+    /// The address to prefund in the subnet
+    pub address: alloy_primitives::Address,
+}
+
+impl IpcValidate for IpcFundSubnetMsg {
+    fn validate(&self) -> Result<(), IpcValidateError> {
+        if self.amount == bitcoin::Amount::MIN {
+            return Err(IpcValidateError::InvalidField(
+                "value",
+                "Value must be greater than 0".to_string(),
+            ));
+        }
+        Ok(())
+    }
+}
+
+impl IpcFundSubnetMsg {
+    // The length of the subnet tag - helper
+    const FUND_TAG_LEN: usize = IPC_FUND_SUBNET_TAG.len();
+
+    pub fn to_tx(&self, multisig_address: &bitcoin::Address) -> Result<Transaction, IpcLibError> {
+        //
+        // Create the first output: op_return with
+        // ipc tag, subnet_id (txid) and user's subnet address to fund
+        //
+        let fund_tag: [u8; Self::FUND_TAG_LEN] = IPC_FUND_SUBNET_TAG
+            .as_bytes()
+            .try_into()
+            .expect("IPC_FUND_SUBNET_TAG has incorrect length");
+        let subnet_id_txid: [u8; Txid::LEN] = self.subnet_id.txid().as_raw_hash().to_byte_array();
+        let subnet_addr: [u8; ETH_ADDR_LEN] = self.address.into_array();
+
+        // Construct op_return data
+        let mut op_return_data = [0u8; Self::FUND_TAG_LEN + Txid::LEN + ETH_ADDR_LEN];
+
+        op_return_data[0..Self::FUND_TAG_LEN].copy_from_slice(&fund_tag);
+        op_return_data[Self::FUND_TAG_LEN..(Self::FUND_TAG_LEN + Txid::LEN)]
+            .copy_from_slice(&subnet_id_txid);
+        op_return_data[(Self::FUND_TAG_LEN + Txid::LEN)..].copy_from_slice(&subnet_addr);
+
+        // Make op_return script and txout
+        let op_return_script = bitcoin_utils::make_op_return_script(op_return_data);
+        let data_tx_out = bitcoin::TxOut {
+            value: bitcoin::Amount::ZERO,
+            script_pubkey: op_return_script,
+        };
+
+        //
+        // Create second output: pre-fund + pre-release script
+        //
+
+        let fund_tx_out = bitcoin::TxOut {
+            value: self.amount,
+            script_pubkey: multisig_address.script_pubkey(),
+        };
+
+        // Construct transaction
+
+        let tx_outs = vec![data_tx_out, fund_tx_out];
+        let fund_tx = bitcoin_utils::create_tx_from_txouts(tx_outs);
+        debug!("Fund TX: {fund_tx:?}");
+
+        Ok(fund_tx)
+    }
+
+    pub fn submit_to_bitcoin(
+        &self,
+        rpc: &bitcoincore_rpc::Client,
+        multisig_address: &bitcoin::Address,
+    ) -> Result<Txid, IpcLibError> {
+        info!(
+            "Submitting fund subnet msg to bitcoin. Multisig address = {}. Amount={}",
+            multisig_address, self.amount
+        );
+
+        // Construct, fund and sign the prefund transaction
+
+        let fund_tx = self.to_tx(multisig_address)?;
+
+        let fund_tx = crate::wallet::fund_tx(rpc, fund_tx, None)?;
+        trace!("Fund msg funded TX: {fund_tx:?}");
+        let fund_tx = crate::wallet::sign_tx(rpc, fund_tx)?;
+        trace!("Fund msg signed TX: {fund_tx:?}");
+
+        // Submit the prefund transaction to the mempool
+
+        let fund_txid = fund_tx.compute_txid();
+        match submit_to_mempool(rpc, vec![fund_tx]) {
+            Ok(_) => {
+                info!(
+                    "Submitted fund subnet msg for subnet_id={} fund_txid={}",
+                    self.subnet_id, fund_txid,
+                );
+                Ok(fund_txid)
+            }
+            Err(e) => Err(IpcLibError::BitcoinUtilsError(e)),
+        }
+    }
+}
+
+//
+// IPC Messages
+//
+
 // Define the IPCMessage enum
 #[derive(Debug)]
 pub enum IpcMessage {
     CreateSubnet(IpcCreateSubnetMsg),
     JoinSubnet(IpcJoinSubnetMsg),
     PrefundSubnet(IpcPrefundSubnetMsg),
+    FundSubnet(IpcFundSubnetMsg),
 }
 
 impl IpcMessage {
@@ -728,8 +844,14 @@ impl IpcMessage {
             IpcTag::JoinSubnet => Ok(IpcMessage::JoinSubnet(IpcJoinSubnetMsg::ipc_deserialize(
                 s,
             )?)),
-            IpcTag::PrefundSubnet => Ok(IpcMessage::PrefundSubnet(
-                IpcPrefundSubnetMsg::ipc_deserialize(s)?,
+            //
+            // The bellow messages aren't using serialization in witness
+            //
+            IpcTag::PrefundSubnet => Err(IpcSerializeError::DeserializationError(
+                "Invalid tag".to_string(),
+            )),
+            IpcTag::FundSubnet => Err(IpcSerializeError::DeserializationError(
+                "Invalid tag".to_string(),
             )),
         }
     }

--- a/src/ipc_lib.rs
+++ b/src/ipc_lib.rs
@@ -774,9 +774,10 @@ impl IpcFundSubnetMsg {
 
         trace!("Processing {self:?}, adding new rootnet message");
 
-        let mut wtxn = db.write_txn()?;
         // Get next nonce
-        let nonce = db.get_last_msg_nonce(self.subnet_id)? + 1;
+
+        let nonce = db.get_last_rootnet_msg_nonce(self.subnet_id)? + 1;
+        let mut wtxn = db.write_txn()?;
         // Construct rootnet message
         let rootnet_msg = self.to_rootnet_message(nonce, block_height);
         debug!("New rootnet message: {rootnet_msg:?}");

--- a/src/ipc_lib.rs
+++ b/src/ipc_lib.rs
@@ -748,11 +748,19 @@ impl IpcFundSubnetMsg {
     }
 
     // Create a rootnet message from the fund subnet message
-    pub fn to_rootnet_message(&self, nonce: u64, block_height: u64) -> db::RootnetMessage {
+    pub fn to_rootnet_message(
+        &self,
+        nonce: u64,
+        block_height: u64,
+        block_hash: bitcoin::BlockHash,
+        txid: Txid,
+    ) -> db::RootnetMessage {
         db::RootnetMessage::FundSubnet {
             msg: self.clone(),
             nonce,
             block_height,
+            block_hash,
+            txid,
         }
     }
 
@@ -761,7 +769,8 @@ impl IpcFundSubnetMsg {
         &self,
         db: &D,
         block_height: u64,
-        _txid: Txid,
+        block_hash: bitcoin::BlockHash,
+        txid: Txid,
     ) -> Result<(), IpcLibError> {
         let subnet_state =
             db.get_subnet_state(self.subnet_id)?
@@ -779,7 +788,7 @@ impl IpcFundSubnetMsg {
         let nonce = db.get_last_rootnet_msg_nonce(self.subnet_id)? + 1;
         let mut wtxn = db.write_txn()?;
         // Construct rootnet message
-        let rootnet_msg = self.to_rootnet_message(nonce, block_height);
+        let rootnet_msg = self.to_rootnet_message(nonce, block_height, block_hash, txid);
         debug!("New rootnet message: {rootnet_msg:?}");
         // save message
         db.add_rootnet_msg(&mut wtxn, self.subnet_id, rootnet_msg)?;

--- a/src/ipc_lib.rs
+++ b/src/ipc_lib.rs
@@ -734,6 +734,127 @@ impl IpcValidate for IpcFundSubnetMsg {
 impl IpcFundSubnetMsg {
     // The length of the subnet tag - helper
     const FUND_TAG_LEN: usize = IPC_FUND_SUBNET_TAG.len();
+    // The total length of the op_return data - helper
+    const DATA_LEN: usize = Self::FUND_TAG_LEN + Txid::LEN + ETH_ADDR_LEN;
+
+    /// Validates the fund msg for the given subnet
+    pub fn validate_for_subnet(
+        &self,
+        _subnet_state: &db::SubnetState,
+    ) -> Result<(), IpcValidateError> {
+        // For now no need to validate anything, the subnet must exist
+
+        Ok(())
+    }
+
+    // Create a rootnet message from the fund subnet message
+    pub fn to_rootnet_message(&self, nonce: u64, block_height: u64) -> db::RootnetMessage {
+        db::RootnetMessage::FundSubnet {
+            msg: self.clone(),
+            nonce,
+            block_height,
+        }
+    }
+
+    /// Modifies the database to account for the join subnet message
+    pub fn save_to_db<D: db::Database>(
+        &self,
+        db: &D,
+        block_height: u64,
+        _txid: Txid,
+    ) -> Result<(), IpcLibError> {
+        let subnet_state =
+            db.get_subnet_state(self.subnet_id)?
+                .ok_or(IpcValidateError::InvalidMsg(format!(
+                    "subnet id={} does not exist",
+                    self.subnet_id
+                )))?;
+
+        self.validate_for_subnet(&subnet_state)?;
+
+        trace!("Processing {self:?}, adding new rootnet message");
+
+        let mut wtxn = db.write_txn()?;
+        // Get next nonce
+        let nonce = db.get_last_msg_nonce(self.subnet_id)? + 1;
+        // Construct rootnet message
+        let rootnet_msg = self.to_rootnet_message(nonce, block_height);
+        debug!("New rootnet message: {rootnet_msg:?}");
+        // save message
+        db.add_rootnet_msg(&mut wtxn, self.subnet_id, rootnet_msg)?;
+        wtxn.commit()?;
+
+        Ok(())
+    }
+
+    /// Reconstructs an IpcFundSubnetMsg from a bitcoin::Transaction.
+    ///
+    /// Given that:
+    ///   • The first output is an OP_RETURN containing our custom pushdata,
+    ///     whose layout is:
+    ///         [fund tag | 32-byte txid | 20-byte alloy address]
+    ///   • The second output is the funding output with nonzero value.
+    ///
+    /// Returns an error if any expected data is missing or malformed.
+    pub fn from_tx(tx: &Transaction) -> Result<Self, IpcLibError> {
+        use bitcoin::blockdata::script::Instruction;
+
+        // Helper closure for error creation
+        let err = |msg: String| IpcLibError::MsgParseError(IPC_FUND_SUBNET_TAG, msg);
+
+        // Verify we have both required outputs
+        if tx.output.len() < 2 {
+            return Err(err("Transaction must have at least 2 outputs".into()));
+        }
+        // Get OP_RETURN data from first output
+        let op_return_data = tx.output[0]
+            .script_pubkey
+            .instructions_minimal()
+            .find_map(|ins| match ins {
+                Ok(Instruction::PushBytes(data)) => Some(data.as_bytes()),
+                _ => None,
+            })
+            .ok_or_else(|| err("First output must be OP_RETURN with pushdata".into()))?;
+
+        // Check total length matches our expected format
+        if op_return_data.len() != Self::DATA_LEN {
+            return Err(err(format!(
+                "OP_RETURN data length mismatch: got {}, expected {}",
+                op_return_data.len(),
+                Self::DATA_LEN
+            )));
+        }
+
+        // Split data into its components
+        let (tag, rest) = op_return_data.split_at(Self::FUND_TAG_LEN);
+        let (txid_bytes, addr_bytes) = rest.split_at(Txid::LEN);
+
+        // Verify tag
+        if tag != IPC_FUND_SUBNET_TAG.as_bytes() {
+            return Err(err(format!(
+                "Invalid tag: got '{}', expected '{}'",
+                String::from_utf8_lossy(tag),
+                IPC_FUND_SUBNET_TAG
+            )));
+        }
+
+        // Convert txid bytes to Txid
+        let txid =
+            Txid::from_slice(txid_bytes).map_err(|e| err(format!("Invalid txid bytes: {}", e)))?;
+        let subnet_id = SubnetId::from_txid(&txid);
+
+        // Convert address bytes to alloy Address
+        let address = alloy_primitives::Address::from_slice(addr_bytes);
+
+        // Get value from second output
+        let amount = tx.output[1].value;
+
+        Ok(Self {
+            subnet_id,
+            amount,
+            address,
+        })
+    }
 
     pub fn to_tx(&self, multisig_address: &bitcoin::Address) -> Result<Transaction, IpcLibError> {
         //

--- a/src/provider/rpc.rs
+++ b/src/provider/rpc.rs
@@ -310,6 +310,18 @@ pub async fn get_rootnet_messages(
     data: Data<Arc<ServerData>>,
     Params(params): Params<GetRootnetMessagesParams>,
 ) -> Result<Vec<db::RootnetMessage>, JsonRpcError> {
+    // Check subnet exists
+    data.db
+        .get_subnet_state(params.subnet_id)
+        .map_err(|e| {
+            error!("Error getting subnet info from Db: {}", e);
+            RpcError::DbError(e)
+        })?
+        .ok_or(RpcError::InvalidParams(format!(
+            "Subnet {} not found.",
+            params.subnet_id
+        )))?;
+
     return data
         .db
         .get_rootnet_msgs_by_height(params.subnet_id, params.block_height)

--- a/src/provider/rpc.rs
+++ b/src/provider/rpc.rs
@@ -1,6 +1,6 @@
 use crate::{
     db::{self, Database, HeedDb},
-    ipc_lib::{IpcJoinSubnetMsg, IpcPrefundSubnetMsg, IpcValidate, SubnetId},
+    ipc_lib::{IpcFundSubnetMsg, IpcJoinSubnetMsg, IpcPrefundSubnetMsg, IpcValidate, SubnetId},
     IpcCreateSubnetMsg, BTC_CONFIRMATIONS,
 };
 use bitcoincore_rpc::{Client, RpcApi};
@@ -254,13 +254,50 @@ pub async fn prefund_subnet(
     })?;
 
     // TODO this check should be done in the Db
-    let multisig_address = &genesis_info.multisig_address();
+    let multisig_address = genesis_info.multisig_address();
 
     let prefund_txid = msg
-        .submit_to_bitcoin(&data.btc_rpc, multisig_address)
+        .submit_to_bitcoin(&data.btc_rpc, &multisig_address)
         .map_err(|e| JsonRpcError::internal(e.to_string()))?;
 
     Ok(PrefundSubnetResponse { prefund_txid })
+}
+
+#[derive(Serialize, Deserialize)]
+pub struct FundSubnetResponse {
+    fund_txid: bitcoin::Txid,
+}
+
+pub async fn fund_subnet(
+    data: Data<Arc<ServerData>>,
+    Params(msg): Params<IpcFundSubnetMsg>,
+) -> Result<FundSubnetResponse, JsonRpcError> {
+    if let Err(err) = msg.validate() {
+        error!("Invalid prefund message={msg:?}: {err}");
+        return Err(RpcError::InvalidParams(err.to_string()).into());
+    }
+
+    let subnet_state = data
+        .db
+        .get_subnet_state(msg.subnet_id)
+        .map_err(|e| {
+            error!("Error getting subnet info from Db: {}", e);
+            RpcError::DbError(e)
+        })?
+        .ok_or(RpcError::InvalidParams(format!(
+            "Subnet {} not found.",
+            msg.subnet_id
+        )))?;
+
+    let multisig_address = subnet_state.multisig_address();
+
+    println!("subnet multisig = {multisig_address:?}");
+
+    let fund_txid = msg
+        .submit_to_bitcoin(&data.btc_rpc, &multisig_address)
+        .map_err(|e| JsonRpcError::internal(e.to_string()))?;
+
+    Ok(FundSubnetResponse { fund_txid })
 }
 
 pub fn make_rpc_server(server_data: Arc<ServerData>) -> RpcServer {
@@ -274,5 +311,6 @@ pub fn make_rpc_server(server_data: Arc<ServerData>) -> RpcServer {
         .with_method("joinsubnet", join_subnet)
         .with_method("getgenesisinfo", get_genesis_info)
         .with_method("prefundsubnet", prefund_subnet)
+        .with_method("fundsubnet", fund_subnet)
         .finish()
 }

--- a/src/provider/rpc.rs
+++ b/src/provider/rpc.rs
@@ -300,17 +300,40 @@ pub async fn fund_subnet(
     Ok(FundSubnetResponse { fund_txid })
 }
 
+#[derive(Serialize, Deserialize)]
+pub struct GetRootnetMessagesParams {
+    subnet_id: SubnetId,
+    block_height: u64,
+}
+
+pub async fn get_rootnet_messages(
+    data: Data<Arc<ServerData>>,
+    Params(params): Params<GetRootnetMessagesParams>,
+) -> Result<Vec<db::RootnetMessage>, JsonRpcError> {
+    return data
+        .db
+        .get_rootnet_msgs_by_height(params.subnet_id, params.block_height)
+        .map_err(|e| {
+            error!("Error getting rootnet messages from Db: {}", e);
+            RpcError::DbError(e).into()
+        });
+}
+
 pub fn make_rpc_server(server_data: Arc<ServerData>) -> RpcServer {
     jsonrpc_v2::Server::new()
         .with_data(Data::new(server_data))
+        // btc info
         .with_method("getblockhash", get_block_hash)
         .with_method("getblockcount", get_block_count)
         .with_method("getconfirmedblock", get_confirmed_block)
         .with_method("getbalance", get_balance)
+        // subnet
         .with_method("createsubnet", create_subnet)
         .with_method("joinsubnet", join_subnet)
         .with_method("getgenesisinfo", get_genesis_info)
         .with_method("prefundsubnet", prefund_subnet)
         .with_method("fundsubnet", fund_subnet)
+        // rootnet messages
+        .with_method("getrootnetmessages", get_rootnet_messages)
         .finish()
 }


### PR DESCRIPTION
Saves fund subnet messages in the database, and allows fetching events/messages that happened at a certain block height.

> Delete the database and re-run monitor before testing.

First efforts at top down messages. See `curl_reqs.md` for example requests. The rootnet messages structure currently looks like this:

```json
{
  "jsonrpc": "2.0",
  "result": [
    {
      "type": "fund",
      "msg": {
        "subnet_id": "/b4/t420f7gmk32wp44h5kxcc2sbonm6iysmmkvfscmxr74kx4cqrofc4len4quzaha",
        "amount": 80000000,
        "address": "0xbce2f194e9628e6ae06fa0d85dd57cd5579213bf"
      },
      "block_height": 234,
      "nonce": 15
    },
    {
      "type": "fund",
      "msg": {
        "subnet_id": "/b4/t420f7gmk32wp44h5kxcc2sbonm6iysmmkvfscmxr74kx4cqrofc4len4quzaha",
        "amount": 50000000,
        "address": "0xbce2f194e9628e6ae06fa0d85dd57cd5579213bf"
      },
      "block_height": 234,
      "nonce": 16
    }
  ],
  "id": 1
}
```

Closes #68 