### PR TITLE
Add `getsubnet` and `getconfirmedcount` rpc methods

### DIFF
--- a/docs/internal/curl_reqs.md
+++ b/docs/internal/curl_reqs.md
@@ -28,7 +28,7 @@ curl -X POST http://localhost:3030/api \
     "jsonrpc": "2.0",
     "method": "joinsubnet",
     "params": {
-			"subnet_id": "/b4/t420fepbcc2ait3aclq2exb3nmwmi4wmd5gfixnktv36mxmax5lmhpdr6qge5su",
+			"subnet_id": "/b4/t420fmsv2gwpnksrxob6yij4wi6iuu2pg4vowy6xopfembcl6axt5ocqtymspsm",
 			"collateral": 200000000,
 			"ip": "66.222.44.55:8080",
 			"backup_address": "bcrt1q3fznspr3e02artm9df7tk827a2xhny2m4zzr6n",
@@ -44,7 +44,7 @@ curl -X POST http://localhost:3030/api \
     "jsonrpc": "2.0",
     "method": "joinsubnet",
     "params": {
-			"subnet_id": "/b4/t420fepbcc2ait3aclq2exb3nmwmi4wmd5gfixnktv36mxmax5lmhpdr6qge5su",
+			"subnet_id": "/b4/t420fmsv2gwpnksrxob6yij4wi6iuu2pg4vowy6xopfembcl6axt5ocqtymspsm",
 			"collateral": 110000000,
 			"ip": "66.222.44.55:8081",
 			"backup_address": "bcrt1q3fznspr3e02artm9df7tk827a2xhny2m4zzr6n",
@@ -60,7 +60,7 @@ curl -X POST http://localhost:3030/api \
     "jsonrpc": "2.0",
     "method": "joinsubnet",
     "params": {
-			"subnet_id": "/b4/t420fepbcc2ait3aclq2exb3nmwmi4wmd5gfixnktv36mxmax5lmhpdr6qge5su",
+			"subnet_id": "/b4/t420fmsv2gwpnksrxob6yij4wi6iuu2pg4vowy6xopfembcl6axt5ocqtymspsm",
 			"collateral": 150000000,
 			"ip": "66.222.44.55:8082",
 			"backup_address": "bcrt1q3fznspr3e02artm9df7tk827a2xhny2m4zzr6n",
@@ -76,7 +76,7 @@ curl -X POST http://localhost:3030/api \
     "jsonrpc": "2.0",
     "method": "joinsubnet",
     "params": {
-			"subnet_id": "/b4/t420fepbcc2ait3aclq2exb3nmwmi4wmd5gfixnktv36mxmax5lmhpdr6qge5su",
+			"subnet_id": "/b4/t420fmsv2gwpnksrxob6yij4wi6iuu2pg4vowy6xopfembcl6axt5ocqtymspsm",
 			"collateral": 180000000,
 			"ip": "66.222.44.55:8083",
 			"backup_address": "bcrt1q3fznspr3e02artm9df7tk827a2xhny2m4zzr6n",
@@ -92,9 +92,21 @@ curl -X POST http://localhost:3030/api \
 	"jsonrpc": "2.0",
 	"method": "getgenesisinfo",
 	"params": {
-		"subnet_id": "/b4/t420f7gmk32wp44h5kxcc2sbonm6iysmmkvfscmxr74kx4cqrofc4len4quzaha"
+		"subnet_id": "/b4/t420fmsv2gwpnksrxob6yij4wi6iuu2pg4vowy6xopfembcl6axt5ocqtymspsm"
 	},
 	"id": 1
+}' | jq
+
+curl -X POST http://localhost:3030/api \
+-H "Content-Type: application/json" \
+-H "Authorization: Bearer asda123123jhaskjdhgbjsjhdj" \
+-d '{
+    "jsonrpc": "2.0",
+    "method": "getsubnet",
+    "params": {
+			"subnet_id": "/b4/t420fmsv2gwpnksrxob6yij4wi6iuu2pg4vowy6xopfembcl6axt5ocqtymspsm"
+    },
+    "id": 1
 }' | jq
 
 curl -X POST http://localhost:3030/api \
@@ -118,7 +130,7 @@ curl -X POST http://localhost:3030/api \
     "jsonrpc": "2.0",
     "method": "fundsubnet",
     "params": {
-			"subnet_id": "/b4/t420f7gmk32wp44h5kxcc2sbonm6iysmmkvfscmxr74kx4cqrofc4len4quzaha",
+			"subnet_id": "/b4/t420fmsv2gwpnksrxob6yij4wi6iuu2pg4vowy6xopfembcl6axt5ocqtymspsm",
 			"amount": 40000000,
 			"address": "0xbce2f194e9628e6ae06fa0d85dd57cd5579213bf"
     },
@@ -132,8 +144,8 @@ curl -X POST http://localhost:3030/api \
     "jsonrpc": "2.0",
     "method": "getrootnetmessages",
     "params": {
-			"subnet_id": "/b4/t420f7gmk32wp44h5kxcc2sbonm6iysmmkvfscmxr74kx4cqrofc4len4quzaha",
-			"block_height": 229
+			"subnet_id": "/b4/t420fmsv2gwpnksrxob6yij4wi6iuu2pg4vowy6xopfembcl6axt5ocqtymspsm",
+			"block_height": 235
     },
     "id": 1
 }' | jq

--- a/src/bitcoin_utils.rs
+++ b/src/bitcoin_utils.rs
@@ -28,7 +28,7 @@ use bitcoin::{
 use bitcoincore_rpc::json::{EstimateMode, EstimateSmartFeeResult};
 use bitcoincore_rpc::{Auth, Client, RawTx, RpcApi};
 
-use crate::{DEFAULT_BTC_FEE_RATE, MAXIMUM_BTC_FEE_RATE, MINIMUM_BTC_FEE_RATE};
+use crate::{BTC_CONFIRMATIONS, DEFAULT_BTC_FEE_RATE, MAXIMUM_BTC_FEE_RATE, MINIMUM_BTC_FEE_RATE};
 
 /// Returns the number of blocks to wait for before considering a
 /// confirmed in a given network.
@@ -40,8 +40,19 @@ pub const fn confirmations(network: Network) -> u64 {
     }
 }
 
+pub fn get_confirmed_from_height(height: u64) -> Option<u64> {
+    // Since BTC_CONFIRMATIONS is 0 in regtest and sigtest
+    // Clippy will complain about absurd comparisons
+    #[allow(clippy::absurd_extreme_comparisons)]
+    if height < BTC_CONFIRMATIONS {
+        return None;
+    }
+    Some(height - BTC_CONFIRMATIONS)
+}
+
 //
 // BitcoinCore RPC
+//
 
 pub fn make_rpc_client_from_env() -> Client {
     let rpc_user = std::env::var("RPC_USER").expect("RPC_USER env var not defined");

--- a/src/provider/rpc.rs
+++ b/src/provider/rpc.rs
@@ -1,7 +1,8 @@
 use crate::{
+    bitcoin_utils::get_confirmed_from_height,
     db::{self, Database, HeedDb},
     ipc_lib::{IpcFundSubnetMsg, IpcJoinSubnetMsg, IpcPrefundSubnetMsg, IpcValidate, SubnetId},
-    IpcCreateSubnetMsg, BTC_CONFIRMATIONS,
+    IpcCreateSubnetMsg,
 };
 use bitcoincore_rpc::{Client, RpcApi};
 use jsonrpc_v2::{Data, Error as JsonRpcError, ErrorLike, MapRouter, Params};
@@ -96,37 +97,21 @@ pub async fn get_block_count(data: Data<Arc<ServerData>>) -> Result<u64, JsonRpc
     }
 }
 
-pub async fn get_confirmed_block(data: Data<Arc<ServerData>>) -> Result<String, JsonRpcError> {
+pub async fn get_confirmed_block_height(data: Data<Arc<ServerData>>) -> Result<u64, JsonRpcError> {
     let client = data.btc_rpc.as_ref();
 
     match client.get_block_count() {
         Ok(current_height) => {
-            // Since BTC_CONFIRMATIONS is 0 in regtest and sigtest
-            // Clippy will complain about absurd comparisons
-            #[allow(clippy::absurd_extreme_comparisons)]
-            if current_height < BTC_CONFIRMATIONS {
-                return Err(JsonRpcError::internal(
-                    "Not enough blocks to have a confirmed block",
-                ));
-            }
-
-            let confirmed_block_height = current_height - BTC_CONFIRMATIONS;
-            match client.get_block_hash(confirmed_block_height) {
-                Ok(block_hash) => Ok(block_hash.to_string()),
-                Err(e) => Err(JsonRpcError::internal(e)),
-            }
+            let confirmed_block_height = match get_confirmed_from_height(current_height) {
+                Some(height) => height,
+                None => {
+                    return Err(JsonRpcError::internal(
+                        "Not enough blocks to have a confirmed block",
+                    ))
+                }
+            };
+            Ok(confirmed_block_height)
         }
-        Err(e) => Err(JsonRpcError::internal(e)),
-    }
-}
-
-/// Get the balance of the wallet in Satoshis
-/// Note: Bitcoin Core RPC returns the balance in BTC (using f64)
-pub async fn get_balance(data: Data<Arc<ServerData>>) -> Result<u64, JsonRpcError> {
-    let client = data.btc_rpc.as_ref();
-
-    match client.get_balance(None, None) {
-        Ok(balance) => Ok(balance.to_sat()),
         Err(e) => Err(JsonRpcError::internal(e)),
     }
 }
@@ -363,8 +348,7 @@ pub fn make_rpc_server(server_data: Arc<ServerData>) -> RpcServer {
         // btc info
         .with_method("getblockhash", get_block_hash)
         .with_method("getblockcount", get_block_count)
-        .with_method("getconfirmedblock", get_confirmed_block)
-        .with_method("getbalance", get_balance)
+        .with_method("getconfirmedcount", get_confirmed_block_height)
         // subnet
         .with_method("createsubnet", create_subnet)
         .with_method("joinsubnet", join_subnet)

--- a/src/provider/rpc.rs
+++ b/src/provider/rpc.rs
@@ -5,7 +5,7 @@ use crate::{
 };
 use bitcoincore_rpc::{Client, RpcApi};
 use jsonrpc_v2::{Data, Error as JsonRpcError, ErrorLike, MapRouter, Params};
-use log::error;
+use log::{error, trace};
 use serde::{Deserialize, Serialize};
 use serde_json::json;
 use std::sync::Arc;
@@ -223,6 +223,33 @@ pub async fn get_genesis_info(
 }
 
 #[derive(Serialize, Deserialize)]
+pub struct GetSubnetParams {
+    subnet_id: SubnetId,
+}
+
+pub async fn get_subnet(
+    data: Data<Arc<ServerData>>,
+    Params(params): Params<GetSubnetParams>,
+) -> Result<db::SubnetState, JsonRpcError> {
+    trace!("getsubnet: {}", params.subnet_id);
+
+    // Check subnet exists
+    let subnet = data
+        .db
+        .get_subnet_state(params.subnet_id)
+        .map_err(|e| {
+            error!("Error getting subnet info from Db: {}", e);
+            RpcError::DbError(e)
+        })?
+        .ok_or_else(|| {
+            error!("Subnet {} not found.", params.subnet_id);
+            RpcError::InvalidParams(format!("Subnet {} not found.", params.subnet_id))
+        })?;
+
+    Ok(subnet)
+}
+
+#[derive(Serialize, Deserialize)]
 pub struct PrefundSubnetResponse {
     prefund_txid: bitcoin::Txid,
 }
@@ -322,13 +349,12 @@ pub async fn get_rootnet_messages(
             params.subnet_id
         )))?;
 
-    return data
-        .db
+    data.db
         .get_rootnet_msgs_by_height(params.subnet_id, params.block_height)
         .map_err(|e| {
             error!("Error getting rootnet messages from Db: {}", e);
             RpcError::DbError(e).into()
-        });
+        })
 }
 
 pub fn make_rpc_server(server_data: Arc<ServerData>) -> RpcServer {
@@ -342,6 +368,7 @@ pub fn make_rpc_server(server_data: Arc<ServerData>) -> RpcServer {
         // subnet
         .with_method("createsubnet", create_subnet)
         .with_method("joinsubnet", join_subnet)
+        .with_method("getsubnet", get_subnet)
         .with_method("getgenesisinfo", get_genesis_info)
         .with_method("prefundsubnet", prefund_subnet)
         .with_method("fundsubnet", fund_subnet)


### PR DESCRIPTION
```sh
curl -X POST http://localhost:3030/api \
	-H "Content-Type: application/json" \
	-H "Authorization: Bearer asda123123jhaskjdhgbjsjhdj" \
	-d '{
		"jsonrpc": "2.0",
		"method": "getconfirmedcount",
		"id": 1
	}' | jq
```

See `getsubnet` in `curl_reqs.md`. It returns the current validator committee.

Also removes `getbalance` as the actual bitcoin wallet balance is not relevant and could be confused with subnet getbalance.