### PR TITLE
Save subnet multisig addresses in bitcoincore watchonly wallet

### DIFF
--- a/src/bin/monitor.rs
+++ b/src/bin/monitor.rs
@@ -1,18 +1,18 @@
 use std::env;
 use std::path::PathBuf;
 
-use bitcoin::BlockHash;
-use bitcoin_ipc::bitcoin_utils::{concatenate_op_push_data, make_rpc_client_from_env};
-use bitcoin_ipc::db::{self, Database, HeedDb};
-use bitcoin_ipc::ipc_lib::{self, IpcLibError, IpcValidate};
-use bitcoin_ipc::{eth_utils, IpcMessage, BTC_CONFIRMATIONS};
-use bitcoincore_rpc::RpcApi;
 use clap::Parser;
 use log::{debug, error, info, trace};
 use thiserror::Error;
 use tokio::signal;
 use tokio::time::Duration;
 use tokio_util::sync::CancellationToken;
+
+use bitcoin::BlockHash;
+use bitcoin_ipc::db::{self, Database, HeedDb};
+use bitcoin_ipc::ipc_lib::{self, IpcLibError, IpcValidate};
+use bitcoin_ipc::{bitcoin_utils, eth_utils, IpcMessage, BTC_CONFIRMATIONS};
+use bitcoincore_rpc::RpcApi;
 
 // TODO make configurable
 const POLL_INTERVAL: Duration = Duration::from_secs(3);
@@ -56,7 +56,8 @@ async fn main() {
 
     // Init the bitcoincore_rpc client
 
-    let btc_rpc = make_rpc_client_from_env();
+    let btc_rpc = bitcoin_utils::make_rpc_client_from_env();
+    let btc_watchonly_rpc = bitcoin_utils::make_watchonly_rpc_client_from_env();
 
     // Set correct fvm network
 
@@ -66,7 +67,13 @@ async fn main() {
 
     let cancel_token = CancellationToken::new();
 
-    let mut monitor = Monitor::new(db, btc_rpc, POLL_INTERVAL, cancel_token.clone());
+    let mut monitor = Monitor::new(
+        db,
+        btc_rpc,
+        btc_watchonly_rpc,
+        POLL_INTERVAL,
+        cancel_token.clone(),
+    );
 
     // Spawn monitor task
 
@@ -102,6 +109,7 @@ async fn main() {
 struct Monitor<D: Database> {
     db: D,
     rpc: bitcoincore_rpc::Client,
+    watchonly_rpc: bitcoincore_rpc::Client,
     check_interval: Duration,
     current_height: u64,
     cancel_token: CancellationToken,
@@ -114,12 +122,14 @@ where
     fn new(
         db: D,
         rpc: bitcoincore_rpc::Client,
+        watchonly_rpc: bitcoincore_rpc::Client,
         check_interval: Duration,
         cancel_token: CancellationToken,
     ) -> Self {
         Self {
             db,
             rpc,
+            watchonly_rpc,
             check_interval,
             cancel_token,
             current_height: 0,
@@ -296,7 +306,7 @@ where
             // TODO check more efficiently if witness has IPC tag
             for witness in input.witness.iter().filter(|w| !w.is_empty()) {
                 // Reconstruct the witness data
-                let concatenated_data = match concatenate_op_push_data(witness) {
+                let concatenated_data = match bitcoin_utils::concatenate_op_push_data(witness) {
                     Ok(data) => data,
                     Err(_) => {
                         continue;
@@ -364,6 +374,7 @@ where
             IpcMessage::CreateSubnet(create_subnet_msg) => {
                 debug!("Found IPC message: {:?}", create_subnet_msg);
                 create_subnet_msg.validate()?;
+                // Save to db
                 let subnet_id = create_subnet_msg.save_to_db(&self.db, block_height, txid)?;
                 info!("Processed CreateSubnet for Subnet ID: {}", subnet_id);
                 Ok(())
@@ -382,7 +393,12 @@ where
                 debug!("Found IPC message: {:?}", join_subnet_msg);
 
                 join_subnet_msg.validate()?;
-                join_subnet_msg.save_to_db(&self.db, block_height, txid)?;
+                if let Some(subnet) = join_subnet_msg.save_to_db(&self.db, block_height, txid)? {
+                    // TODO think about how to handle side-effects in monitor
+                    // Subnet bootstrapped
+                    subnet.import_current_address_to_wallet(&self.watchonly_rpc)?;
+                }
+
                 info!(
                     "Processed JoinSubnet for Subnet ID: {}",
                     join_subnet_msg.subnet_id

--- a/src/bin/monitor.rs
+++ b/src/bin/monitor.rs
@@ -375,8 +375,17 @@ where
                 debug!("Found IPC message: {:?}", create_subnet_msg);
                 create_subnet_msg.validate()?;
                 // Save to db
-                let subnet_id = create_subnet_msg.save_to_db(&self.db, block_height, txid)?;
-                info!("Processed CreateSubnet for Subnet ID: {}", subnet_id);
+                let subnet_genesis_info =
+                    create_subnet_msg.save_to_db(&self.db, block_height, txid)?;
+
+                // TODO think about how to handle side-effects in monitor
+                subnet_genesis_info.import_whitelist_address_to_wallet(&self.watchonly_rpc)?;
+
+                info!(
+                    "Processed CreateSubnet for Subnet ID: {}",
+                    subnet_genesis_info.subnet_id
+                );
+
                 Ok(())
             }
 

--- a/src/bin/provider.rs
+++ b/src/bin/provider.rs
@@ -2,9 +2,8 @@ use std::env;
 use std::path::PathBuf;
 use std::sync::Arc;
 
-use bitcoin_ipc::bitcoin_utils::make_rpc_client_from_env;
 use bitcoin_ipc::db::HeedDb;
-use bitcoin_ipc::{eth_utils, provider};
+use bitcoin_ipc::{bitcoin_utils, eth_utils, provider};
 use clap::Parser;
 use log::error;
 
@@ -62,7 +61,8 @@ async fn main() -> std::io::Result<()> {
 
     // Init the bitcoincore_rpc client
 
-    let btc_rpc = Arc::new(make_rpc_client_from_env());
+    let btc_rpc = Arc::new(bitcoin_utils::make_rpc_client_from_env());
+    let btc_watchonly_rpc = Arc::new(bitcoin_utils::make_watchonly_rpc_client_from_env());
 
     // Set correct fvm network
 
@@ -72,7 +72,11 @@ async fn main() -> std::io::Result<()> {
 
     let port = std::env::var("PROVIDER_PORT").unwrap_or_else(|_| DEFAULT_PROVIDER_PORT.to_string());
 
-    let server_data = Arc::new(provider::ServerData { db, btc_rpc });
+    let server_data = Arc::new(provider::ServerData {
+        db,
+        btc_rpc,
+        btc_watchonly_rpc,
+    });
 
     provider::Server::new(token, port, server_data)
         .serve()

--- a/src/bitcoin_utils.rs
+++ b/src/bitcoin_utils.rs
@@ -28,7 +28,10 @@ use bitcoin::{
 use bitcoincore_rpc::json::{EstimateMode, EstimateSmartFeeResult};
 use bitcoincore_rpc::{Auth, Client, RawTx, RpcApi};
 
-use crate::{BTC_CONFIRMATIONS, DEFAULT_BTC_FEE_RATE, MAXIMUM_BTC_FEE_RATE, MINIMUM_BTC_FEE_RATE};
+use crate::{
+    BTC_CONFIRMATIONS, DEFAULT_BTC_FEE_RATE, MAXIMUM_BTC_FEE_RATE, MINIMUM_BTC_FEE_RATE,
+    WATCHONLY_WALLET_NAME,
+};
 
 /// Returns the number of blocks to wait for before considering a
 /// confirmed in a given network.
@@ -60,17 +63,37 @@ pub fn make_rpc_client_from_env() -> Client {
     let rpc_url = std::env::var("RPC_URL").expect("RPC_URL env var not defined");
     let wallet_name = std::env::var("WALLET_NAME").expect("WALLET_NAME env var not defined");
 
-    // Append the wallet name into the URL.
-    // Ensure there is no trailing slash, then add "/wallet/<wallet_name>".
-    let full_url = format!("{}/wallet/{}", rpc_url.trim_end_matches('/'), wallet_name);
-
-    let rpc = match init_rpc_client(rpc_user, rpc_pass, full_url) {
+    let rpc = match init_rpc_client(rpc_user, rpc_pass, rpc_url, wallet_name.clone()) {
         Ok(rpc) => rpc,
         Err(e) => {
-            panic!("Error: {}", e);
+            panic!("Error making bitcoincore rpc client: {}", e);
         }
     };
+    // Ignore any errors by loadwallet, as the wallet may already be loaded
     let _ = rpc.load_wallet(&wallet_name);
+    rpc
+}
+
+pub fn make_watchonly_rpc_client_from_env() -> Client {
+    let rpc_user = std::env::var("RPC_USER").expect("RPC_USER env var not defined");
+    let rpc_pass = std::env::var("RPC_PASS").expect("RPC_PASS env var not defined");
+    let rpc_url = std::env::var("RPC_URL").expect("RPC_URL env var not defined");
+
+    let rpc = match init_rpc_client(
+        rpc_user,
+        rpc_pass,
+        rpc_url,
+        WATCHONLY_WALLET_NAME.to_string(),
+    ) {
+        Ok(rpc) => rpc,
+        Err(e) => {
+            panic!("Error making bitcoincore rpc client: {}", e);
+        }
+    };
+
+    create_or_load_wallet(&rpc, WATCHONLY_WALLET_NAME, true)
+        .unwrap_or_else(|_| panic!("Error creating {}", WATCHONLY_WALLET_NAME));
+
     rpc
 }
 
@@ -78,8 +101,12 @@ pub fn init_rpc_client(
     rpc_user: String,
     rpc_pass: String,
     rpc_url: String,
+    wallet_name: String,
 ) -> Result<Client, BitcoinUtilsError> {
-    let rpc = Client::new(&rpc_url, Auth::UserPass(rpc_user, rpc_pass))?;
+    // Append the wallet name into the URL.
+    // Ensure there is no trailing slash, then add "/wallet/<wallet_name>".
+    let full_url = format!("{}/wallet/{}", rpc_url.trim_end_matches('/'), wallet_name);
+    let rpc = Client::new(&full_url, Auth::UserPass(rpc_user, rpc_pass))?;
     Ok(rpc)
 }
 
@@ -199,7 +226,7 @@ pub fn create_commit_reveal_txs(
     amount_to_send: Option<Amount>,
 ) -> Result<(Transaction, Transaction), BitcoinUtilsError> {
     trace!(
-        "Creating commit-reveal tx for addres={}, data={:02x?}",
+        "Creating commit-reveal tx for address={}, data={:02x?}",
         &final_address,
         &data
     );
@@ -370,6 +397,47 @@ pub fn get_current_fee_rate(
     trace!("Current fee rate is {}", fee_rate);
 
     FeeRate::clamp(fee_rate, MINIMUM_BTC_FEE_RATE, MAXIMUM_BTC_FEE_RATE)
+}
+
+pub fn create_or_load_wallet(
+    rpc: &Client,
+    wallet_name: &str,
+    disable_private_keys: bool,
+) -> Result<(), BitcoinUtilsError> {
+    let wallet = rpc.create_wallet(wallet_name, Some(disable_private_keys), None, None, None);
+    if wallet.is_ok() {
+        let wallet_info = wallet.unwrap();
+        trace!("Created wallet '{}': {:?}", wallet_name, wallet_info);
+        return Ok(());
+    }
+
+    let create_err = wallet.unwrap_err();
+    if !create_err.to_string().contains("already exists") {
+        error!("Error creating wallet '{}': {}", wallet_name, create_err);
+        return Err(BitcoinUtilsError::BitcoinRpcError(create_err));
+    }
+
+    trace!(
+        "Wallet '{}' already exists. Attempting to load it.",
+        wallet_name
+    );
+    let loaded = rpc.load_wallet(wallet_name);
+
+    match loaded {
+        Ok(_) => {
+            trace!("Loaded wallet '{}'", wallet_name);
+            Ok(())
+        }
+        Err(e) => {
+            if !e.to_string().contains("already loaded") {
+                error!("Error loading wallet '{}': {}", wallet_name, e);
+                Err(BitcoinUtilsError::BitcoinRpcError(e))
+            } else {
+                trace!("Wallet already loaded '{}'", wallet_name);
+                Ok(())
+            }
+        }
+    }
 }
 
 pub fn convert_bytes_to_push_bytes(data: &[u8]) -> &PushBytes {

--- a/src/db.rs
+++ b/src/db.rs
@@ -155,10 +155,6 @@ impl SubnetState {
     ) -> Result<(), bitcoincore_rpc::Error> {
         let address = self.multisig_address();
         let label = format!("{}-{}", self.id, self.committee_number);
-        debug!(
-            "Importing watch-only address {} to bitcoincore wallet with label {}",
-            address, label
-        );
         wallet::import_address(rpc, &address, label)?;
         Ok(())
     }
@@ -212,10 +208,37 @@ pub struct SubnetGenesisInfo {
 }
 
 impl SubnetGenesisInfo {
+    /// Returns if the subnet has enough validators to bootstrap
+    pub fn enough_to_bootstrap(&self) -> bool {
+        self.genesis_validators.len() as u16 >= self.create_subnet_msg.min_validators
+    }
+
     pub fn multisig_address(&self) -> Address {
-        self.create_subnet_msg
-            .multisig_address_from_whitelist(&self.subnet_id)
-            .expect("Multisig should be valid for saved subnet genesis info")
+        let secp = bitcoin::secp256k1::Secp256k1::new();
+
+        create_subnet_multisig_address(
+            &secp,
+            &self.subnet_id,
+            &self.create_subnet_msg.whitelist.clone(),
+            self.create_subnet_msg.min_validators.into(),
+            NETWORK,
+        )
+        // TODO think about this expect, maybe return a Result
+        .expect("Multisig should be valid for saved subnet genesis info")
+    }
+
+    /// Imports the whitelist multisig address to Bitcoin Core
+    /// as a watch-only address. Bitcoincore will monitor the UTXOs.
+    pub fn import_whitelist_address_to_wallet(
+        &self,
+        rpc: &bitcoincore_rpc::Client,
+    ) -> Result<(), bitcoincore_rpc::Error> {
+        let address = self.multisig_address();
+        // Import the subnet whitelist address to the wallet
+        // with a committee number 0
+        let label = format!("{}-{}", self.subnet_id, 0);
+        wallet::import_address(rpc, &address, label)?;
+        Ok(())
     }
 
     pub fn to_subnet(&self) -> SubnetState {
@@ -392,7 +415,7 @@ pub trait Database {
         &self,
         txn: &mut RwTxn,
         subnet_id: SubnetId,
-        genesis_info: SubnetGenesisInfo,
+        genesis_info: &SubnetGenesisInfo,
     ) -> Result<(), DbError>;
 
     // Subnet State
@@ -401,7 +424,7 @@ pub trait Database {
         &self,
         txn: &mut RwTxn,
         subnet_id: SubnetId,
-        subnet_state: SubnetState,
+        subnet_state: &SubnetState,
     ) -> Result<(), DbError>;
 
     // Rootnet Messages
@@ -478,11 +501,10 @@ impl Database for HeedDb {
         &self,
         txn: &mut RwTxn,
         subnet_id: SubnetId,
-        subnet_genesis_info: SubnetGenesisInfo,
+        subnet_genesis_info: &SubnetGenesisInfo,
     ) -> Result<(), DbError> {
         let key = subnet_genesis_info_key(subnet_id);
-        self.subnet_genesis_db
-            .put(txn, &key, &subnet_genesis_info)?;
+        self.subnet_genesis_db.put(txn, &key, subnet_genesis_info)?;
         Ok(())
     }
 
@@ -498,10 +520,10 @@ impl Database for HeedDb {
         &self,
         txn: &mut RwTxn,
         subnet_id: SubnetId,
-        subnet_state: SubnetState,
+        subnet_state: &SubnetState,
     ) -> Result<(), DbError> {
         let key = subnet_state_key(subnet_id);
-        self.subnet_db.put(txn, &key, &subnet_state)?;
+        self.subnet_db.put(txn, &key, subnet_state)?;
         Ok(())
     }
 

--- a/src/db.rs
+++ b/src/db.rs
@@ -1,7 +1,7 @@
 use crate::{
     ipc_lib::{IpcCreateSubnetMsg, IpcFundSubnetMsg},
     multisig::{create_subnet_multisig_address, multisig_threshold},
-    SubnetId, NETWORK,
+    wallet, SubnetId, NETWORK,
 };
 use async_trait::async_trait;
 use bitcoin::{address::NetworkUnchecked, Address, BlockHash, Txid, XOnlyPublicKey};
@@ -94,7 +94,7 @@ impl SubnetValidators for Vec<SubnetValidator> {
 }
 
 /// The committee of a subnet
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct SubnetCommittee {
     /// The threshold for the multisig
     pub threshold: u16,
@@ -104,11 +104,25 @@ pub struct SubnetCommittee {
     pub multisig_address: Address<NetworkUnchecked>,
 }
 
+impl SubnetCommittee {
+    pub fn get_unspent(
+        &self,
+        rpc: &bitcoincore_rpc::Client,
+    ) -> Result<Vec<bitcoincore_rpc::json::ListUnspentResultEntry>, wallet::WalletError> {
+        let address = self
+            .multisig_address
+            .clone()
+            .require_network(NETWORK)
+            .expect("Multisig should be valid for saved subnet genesis info");
+        wallet::get_unspent_for_address(rpc, &address)
+    }
+}
+
 /// The current state of a subnet
 /// Must only exist if the subnet is bootstrapped
 ///
 /// Note: many more fields will be added here
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct SubnetState {
     /// Duplicate of the subnet ID, for easy access
     pub id: SubnetId,
@@ -131,6 +145,22 @@ impl SubnetState {
             .clone()
             .require_network(NETWORK)
             .expect("Multisig should be valid for saved subnet genesis info")
+    }
+
+    /// Imports the subnet multisig address to Bitcoin Core
+    /// as a watch-only address. Bitcoincore will monitor the UTXOs.
+    pub fn import_current_address_to_wallet(
+        &self,
+        rpc: &bitcoincore_rpc::Client,
+    ) -> Result<(), bitcoincore_rpc::Error> {
+        let address = self.multisig_address();
+        let label = format!("{}-{}", self.id, self.committee_number);
+        debug!(
+            "Importing watch-only address {} to bitcoincore wallet with label {}",
+            address, label
+        );
+        wallet::import_address(rpc, &address, label)?;
+        Ok(())
     }
 }
 

--- a/src/ipc_lib.rs
+++ b/src/ipc_lib.rs
@@ -134,24 +134,49 @@ pub struct IpcCreateSubnetMsg {
     pub whitelist: Vec<XOnlyPublicKey>,
 }
 
-impl IpcCreateSubnetMsg {
-    /// Creates a multisig address from the whitelisted public keys
-    pub fn multisig_address_from_whitelist(
-        &self,
-        subnet_id: &SubnetId,
-    ) -> Result<bitcoin::Address, IpcLibError> {
-        let secp = bitcoin::secp256k1::Secp256k1::new();
-        let multisig_address = create_subnet_multisig_address(
-            &secp,
-            subnet_id,
-            &self.whitelist.clone(),
-            self.min_validators.into(),
-            NETWORK,
-        )?;
+impl IpcValidate for IpcCreateSubnetMsg {
+    fn validate(&self) -> Result<(), IpcValidateError> {
+        if self.min_validators == 0 {
+            return Err(IpcValidateError::InvalidField(
+                "min_validators",
+                "The minimum number of validators must be greater than 0".to_string(),
+            ));
+        }
 
-        Ok(multisig_address)
+        if self.whitelist.len() < self.min_validators as usize {
+            return Err(IpcValidateError::InvalidField(
+                "whitelist",
+                "Number of whitelisted validators is less than the minimum required validators"
+                    .to_string(),
+            ));
+        }
+
+        if self.bottomup_check_period == 0 {
+            return Err(IpcValidateError::InvalidField(
+                "bottomup_check_period",
+                "Must be greater than 0".to_string(),
+            ));
+        }
+
+        if self.active_validators_limit < self.min_validators {
+            return Err(IpcValidateError::InvalidField(
+                "active_validators_limit",
+                "Must be greater than or equal to min_validators".to_string(),
+            ));
+        }
+
+        if self.min_cross_msg_fee == Amount::ZERO {
+            return Err(IpcValidateError::InvalidField(
+                "min_cross_msg_fee",
+                "Must be greater than 0".to_string(),
+            ));
+        }
+
+        Ok(())
     }
+}
 
+impl IpcCreateSubnetMsg {
     /// Submits the create subnet message to the Bitcoin network
     /// Using commit-reveal scheme
     /// Returns the subnet id — derived from the commit txid
@@ -195,12 +220,16 @@ impl IpcCreateSubnetMsg {
         }
     }
 
+    /// Saves the create subnet message to the database
+    /// by creating a new subnet genesis info
+    ///
+    /// Returns the subnet id and the multisig address
     pub fn save_to_db<D: db::Database>(
         &self,
         db: &D,
         block_height: u64,
         txid: bitcoin::Txid,
-    ) -> Result<SubnetId, IpcLibError> {
+    ) -> Result<db::SubnetGenesisInfo, IpcLibError> {
         let subnet_id = SubnetId::from_txid(&txid);
 
         let genesis_info = db::SubnetGenesisInfo {
@@ -214,54 +243,29 @@ impl IpcCreateSubnetMsg {
         };
 
         trace!("Saving {self:?} to DB, genesis_info={genesis_info:?}");
-
         let mut wtxn = db.write_txn()?;
-        db.save_subnet_genesis_info(&mut wtxn, subnet_id, genesis_info)?;
+        db.save_subnet_genesis_info(&mut wtxn, subnet_id, &genesis_info)?;
         wtxn.commit()?;
 
-        Ok(subnet_id)
+        Ok(genesis_info)
     }
-}
 
-impl IpcValidate for IpcCreateSubnetMsg {
-    fn validate(&self) -> Result<(), IpcValidateError> {
-        if self.min_validators == 0 {
-            return Err(IpcValidateError::InvalidField(
-                "min_validators",
-                "The minimum number of validators must be greater than 0".to_string(),
-            ));
-        }
+    /// Creates a multisig address from the whitelisted public keys
+    /// and the subnet id
+    pub fn multisig_address_from_whitelist(
+        &self,
+        subnet_id: &SubnetId,
+    ) -> Result<bitcoin::Address, IpcLibError> {
+        let secp = bitcoin::secp256k1::Secp256k1::new();
+        let multisig_address = create_subnet_multisig_address(
+            &secp,
+            subnet_id,
+            &self.whitelist.clone(),
+            self.min_validators.into(),
+            NETWORK,
+        )?;
 
-        if self.whitelist.len() < self.min_validators as usize {
-            return Err(IpcValidateError::InvalidField(
-                "whitelist",
-                "Number of whitelisted validators is less than the minimum required validators"
-                    .to_string(),
-            ));
-        }
-
-        if self.bottomup_check_period == 0 {
-            return Err(IpcValidateError::InvalidField(
-                "bottomup_check_period",
-                "Must be greater than 0".to_string(),
-            ));
-        }
-
-        if self.active_validators_limit < self.min_validators {
-            return Err(IpcValidateError::InvalidField(
-                "active_validators_limit",
-                "Must be greater than or equal to min_validators".to_string(),
-            ));
-        }
-
-        if self.min_cross_msg_fee == Amount::ZERO {
-            return Err(IpcValidateError::InvalidField(
-                "min_cross_msg_fee",
-                "Must be greater than 0".to_string(),
-            ));
-        }
-
-        Ok(())
+        Ok(multisig_address)
     }
 }
 
@@ -419,21 +423,19 @@ impl IpcJoinSubnetMsg {
         //
         // Check if the subnet is bootstrapped
         //
-        if genesis_info.genesis_validators.len() as u16
-            >= genesis_info.create_subnet_msg.min_validators
-        {
+        if genesis_info.enough_to_bootstrap() {
             trace!("Subnet {} bootstrapped", self.subnet_id);
             genesis_info.bootstrapped = true;
             genesis_info.genesis_block_height = Some(block_height);
 
             // Save the newly create subnet state
             let subnet_state = genesis_info.to_subnet();
-            db.save_subnet_state(&mut wtxn, self.subnet_id, subnet_state.clone())?;
-            db.save_subnet_genesis_info(&mut wtxn, self.subnet_id, genesis_info)?;
+            db.save_subnet_state(&mut wtxn, self.subnet_id, &subnet_state)?;
+            db.save_subnet_genesis_info(&mut wtxn, self.subnet_id, &genesis_info)?;
             wtxn.commit()?;
             Ok(Some(subnet_state))
         } else {
-            db.save_subnet_genesis_info(&mut wtxn, self.subnet_id, genesis_info)?;
+            db.save_subnet_genesis_info(&mut wtxn, self.subnet_id, &genesis_info)?;
             wtxn.commit()?;
             Ok(None)
         }
@@ -703,7 +705,7 @@ impl IpcPrefundSubnetMsg {
         genesis_info.add_genesis_balance_entry(self.address, self.amount, txid, block_height);
 
         let mut wtxn = db.write_txn()?;
-        db.save_subnet_genesis_info(&mut wtxn, self.subnet_id, genesis_info)?;
+        db.save_subnet_genesis_info(&mut wtxn, self.subnet_id, &genesis_info)?;
         wtxn.commit()?;
 
         Ok(())

--- a/src/ipc_lib.rs
+++ b/src/ipc_lib.rs
@@ -384,12 +384,13 @@ impl IpcJoinSubnetMsg {
     }
 
     /// Modifies the database to account for the join subnet message
+    /// Returning SubnetState if the subnet is bootstrapped
     pub fn save_to_db<D: db::Database>(
         &self,
         db: &D,
         block_height: u64,
         txid: Txid,
-    ) -> Result<(), IpcLibError> {
+    ) -> Result<Option<db::SubnetState>, IpcLibError> {
         let mut genesis_info =
             db.get_subnet_genesis_info(self.subnet_id)?
                 .ok_or(IpcValidateError::InvalidMsg(format!(
@@ -427,12 +428,15 @@ impl IpcJoinSubnetMsg {
 
             // Save the newly create subnet state
             let subnet_state = genesis_info.to_subnet();
-            db.save_subnet_state(&mut wtxn, self.subnet_id, subnet_state)?;
+            db.save_subnet_state(&mut wtxn, self.subnet_id, subnet_state.clone())?;
+            db.save_subnet_genesis_info(&mut wtxn, self.subnet_id, genesis_info)?;
+            wtxn.commit()?;
+            Ok(Some(subnet_state))
+        } else {
+            db.save_subnet_genesis_info(&mut wtxn, self.subnet_id, genesis_info)?;
+            wtxn.commit()?;
+            Ok(None)
         }
-        db.save_subnet_genesis_info(&mut wtxn, self.subnet_id, genesis_info)?;
-        wtxn.commit()?;
-
-        Ok(())
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,3 +32,6 @@ pub const BTC_CONFIRMATIONS: u64 = bitcoin_utils::confirmations(NETWORK);
 pub const DEFAULT_BTC_FEE_RATE: FeeRate = FeeRate::from_sat_per_vb_unchecked(10);
 pub const MINIMUM_BTC_FEE_RATE: FeeRate = FeeRate::from_sat_per_vb_unchecked(1);
 pub const MAXIMUM_BTC_FEE_RATE: FeeRate = FeeRate::from_sat_per_vb_unchecked(100);
+
+/// Name of the wallet used to store the subnet validator multisig addresses
+pub const WATCHONLY_WALLET_NAME: &str = "subnets-watchonly";

--- a/src/provider/rpc.rs
+++ b/src/provider/rpc.rs
@@ -65,6 +65,7 @@ impl actix_web::error::ResponseError for RpcError {
 pub struct ServerData {
     pub db: Arc<HeedDb>,
     pub btc_rpc: Arc<Client>,
+    pub btc_watchonly_rpc: Arc<Client>,
 }
 
 //

--- a/src/wallet.rs
+++ b/src/wallet.rs
@@ -1,4 +1,4 @@
-use log::{error, trace};
+use log::{debug, error, trace};
 use thiserror::Error;
 
 use bitcoin::{
@@ -117,6 +117,11 @@ pub fn import_address(
     addr: &bitcoin::Address,
     label: String,
 ) -> Result<(), bitcoincore_rpc::Error> {
+    debug!(
+        "Importing watch-only address {} to bitcoincore wallet with label {}",
+        addr, label
+    );
+
     let raw_descriptor = format!("addr({})", addr);
     let descriptor_info = rpc.get_descriptor_info(&raw_descriptor)?;
     let descriptor = descriptor_info.descriptor;

--- a/src/wallet.rs
+++ b/src/wallet.rs
@@ -10,7 +10,7 @@ use bitcoin::{
 };
 
 use bitcoincore_rpc::{
-    json::{EstimateMode, FundRawTransactionOptions},
+    json::{EstimateMode, FundRawTransactionOptions, ListUnspentResultEntry},
     Client, RawTx, RpcApi,
 };
 
@@ -101,6 +101,37 @@ pub fn sign_tx(rpc: &Client, unsigned_tx: Transaction) -> Result<Transaction, Wa
 
 pub fn get_new_address(rpc: &Client) -> Result<bitcoin::Address, WalletError> {
     Ok(rpc.get_new_address(None, None)?.assume_checked())
+}
+
+pub fn get_unspent_for_address(
+    rpc: &Client,
+    addr: &bitcoin::Address,
+) -> Result<Vec<ListUnspentResultEntry>, WalletError> {
+    let unspent = rpc.list_unspent(None, None, Some(&[addr]), None, None)?;
+    Ok(unspent)
+}
+
+/// Imports an address descriptor into the wallet
+pub fn import_address(
+    rpc: &Client,
+    addr: &bitcoin::Address,
+    label: String,
+) -> Result<(), bitcoincore_rpc::Error> {
+    let raw_descriptor = format!("addr({})", addr);
+    let descriptor_info = rpc.get_descriptor_info(&raw_descriptor)?;
+    let descriptor = descriptor_info.descriptor;
+
+    let req = bitcoincore_rpc::json::ImportDescriptors {
+        descriptor,
+        label: Some(label),
+        timestamp: bitcoincore_rpc::json::Timestamp::Now,
+        active: None,
+        range: None,
+        next_index: None,
+        internal: None,
+    };
+    rpc.import_descriptors(req)?;
+    Ok(())
 }
 
 #[derive(Error, Debug)]


### PR DESCRIPTION
When you run `monitor` or `provider` this wallet should be automatically created. Create a subnet, and join with enough validators, you should see the message printed like so:

```sh
Importing watch-only address bcrt1pw9rm2vz742azym7snjerxzj7rqdwehjarrvka7mg82zhsu7t26uq2wlf2t to bitcoincore wallet with label /b4/t420fxm3vljgrnt4az4nbhwo74ih3b4lce2ecfzfrytqtzfnulhjfuagct52yci-1
```

The `/b4/t420fxm3vljgrnt4az4nbhwo74ih3b4lce2ecfzfrytqtzfnulhjfuagct52yci-1` is `{subnet_id}-{committee_number}. 

For now you can list the labels, each committee for each subnet will get a label.

```sh
bitcoin-cli -rpcwallet=subnets-watchonly listlabels

[
  "/b4/t420f7gmk32wp44h5kxcc2sbonm6iysmmkvfscmxr74kx4cqrofc4len4quzaha-1",
  "/b4/t420f7qsjtp7oh7iu7ycejniahcmeylljvmv5472gbxlkufzetepwnsso5uqyyu-1",
  "/b4/t420fmsv2gwpnksrxob6yij4wi6iuu2pg4vowy6xopfembcl6axt5ocqtymspsm-1",
  "/b4/t420fxm3vljgrnt4az4nbhwo74ih3b4lce2ecfzfrytqtzfnulhjfuagct52yci-1"
]
```

For a label, fetch the address:

```sh
bitcoin-cli -rpcwallet=subnets-watchonly getaddressesbylabel /b4/t420fxm3vljgrnt4az4nbhwo74ih3b4lce2ecfzfrytqtzfnulhjfuagct52yci-1

{
  "bcrt1pw9rm2vz742azym7snjerxzj7rqdwehjarrvka7mg82zhsu7t26uq2wlf2t": {
    "purpose": "receive"
  }
}
```

And then for each address get the unspents:

```sh
bitcoin-cli -rpcwallet=subnets-watchonly listunspent 0 9999999 '["bcrt1pw9rm2vz742azym7snjerxzj7rqdwehjarrvka7mg82zhsu7t26uq2wlf2t"]'

[
  {
    "txid": "9a559484f70678d0ec2cd612a5ff3b5b3c0708d3cdd8f6bbfbe1de464c04b304",
    "vout": 1,
    "address": "bcrt1pw9rm2vz742azym7snjerxzj7rqdwehjarrvka7mg82zhsu7t26uq2wlf2t",
    "label": "/b4/t420fxm3vljgrnt4az4nbhwo74ih3b4lce2ecfzfrytqtzfnulhjfuagct52yci-1",
    "scriptPubKey": "51207147b5305eaaba226fd09cb2330a5e181aecde5d18d96efb683a857873cb56b8",
    "amount": 0.40000000,
    "confirmations": 1,
    "spendable": true,
    "solvable": true,
    "desc": "rawtr(7147b5305eaaba226fd09cb2330a5e181aecde5d18d96efb683a857873cb56b8)#waqaavyx",
    "parent_descs": [
      "addr(bcrt1pw9rm2vz742azym7snjerxzj7rqdwehjarrvka7mg82zhsu7t26uq2wlf2t)#0yjuh7at"
    ],
    "safe": true
  },
  {
    "txid": "f5f59e3551b7cb7b1f82b8c29a7024c3eb85fa207e9ff0b3e0f5c816f13f55a0",
    "vout": 1,
    "address": "bcrt1pw9rm2vz742azym7snjerxzj7rqdwehjarrvka7mg82zhsu7t26uq2wlf2t",
    "label": "/b4/t420fxm3vljgrnt4az4nbhwo74ih3b4lce2ecfzfrytqtzfnulhjfuagct52yci-1",
    "scriptPubKey": "51207147b5305eaaba226fd09cb2330a5e181aecde5d18d96efb683a857873cb56b8",
    "amount": 0.40000000,
    "confirmations": 2,
    "spendable": true,
    "solvable": true,
    "desc": "rawtr(7147b5305eaaba226fd09cb2330a5e181aecde5d18d96efb683a857873cb56b8)#waqaavyx",
    "parent_descs": [
      "addr(bcrt1pw9rm2vz742azym7snjerxzj7rqdwehjarrvka7mg82zhsu7t26uq2wlf2t)#0yjuh7at"
    ],
    "safe": true
  }
]
```

There won't be any unspents if the subnet wasn't funded, so make sure you **`fundsubnet`** before that.