### PR TITLE
Generate multisig spending PSBT

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -634,6 +634,7 @@ dependencies = [
  "actix-web-httpauth",
  "alloy-primitives",
  "async-trait",
+ "base64 0.22.1",
  "bitcoin",
  "bitcoinconsensus",
  "bitcoincore-rpc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ num-traits = "0.2.19"
 num-bigint = "0.4.6"
 alloy-primitives = { version = "0.8.19", features = ["serde"] }
 fvm_shared = "4.5.3"
+base64 = "0.22.1"
 
 [dev-dependencies]
 bitcoinconsensus = "0.106.0"

--- a/internal/curl_reqs.md
+++ b/internal/curl_reqs.md
@@ -149,4 +149,18 @@ curl -X POST http://localhost:3030/api \
     },
     "id": 1
 }' | jq
+
+curl -X POST http://localhost:3030/api \
+-H "Content-Type: application/json" \
+-H "Authorization: Bearer asda123123jhaskjdhgbjsjhdj" \
+-d '{
+    "jsonrpc": "2.0",
+    "method": "genmultisigspendpsbt",
+    "params": {
+			"subnet_id": "/b4/t420fxm3vljgrnt4az4nbhwo74ih3b4lce2ecfzfrytqtzfnulhjfuagct52yci",
+			"recipient": "bcrt1q3pw5xfrph88qgd4uwmwgw5xh60np6mdcdd2h5k",
+			"amount": 20000000
+    },
+    "id": 1
+}' | jq
 ```

--- a/src/bitcoin_utils.rs
+++ b/src/bitcoin_utils.rs
@@ -111,7 +111,7 @@ pub fn init_rpc_client(
 }
 
 /// Returns a provably unspendable internal key
-pub fn create_unspendable_internal_key() -> XOnlyPublicKey {
+pub fn unspenable_internal_key() -> XOnlyPublicKey {
     // the Gx of SECP, incremented till a valid x is found
     // See
     // https://github.com/bitcoin/bips/blob/master/bip-0341.mediawiki#constructing-and-spending-taproot-outputs,
@@ -237,7 +237,7 @@ pub fn create_commit_reveal_txs(
     let commit_script = make_push_data_script(data);
 
     // this transaction can only be spent through the script path
-    let unspendable_pubkey = create_unspendable_internal_key();
+    let unspendable_pubkey = unspenable_internal_key();
 
     let amount_to_send = amount_to_send.unwrap_or(Amount::ZERO);
 
@@ -500,7 +500,7 @@ pub fn create_send_with_timelock_release_tx_script(
         .add_leaf(1, send_script)?
         .add_leaf(1, release_script)?;
 
-    let unspendable_pubkey = create_unspendable_internal_key();
+    let unspendable_pubkey = unspenable_internal_key();
 
     let spend_info = taproot_builder
         .finalize(secp, unspendable_pubkey)
@@ -553,4 +553,19 @@ pub enum BitcoinUtilsError {
 
     #[error("cannot construct control block for the given script")]
     CannotConstructControlBlock,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_unspendable_internal_key_does_not_change() {
+        let key = unspenable_internal_key();
+        assert_eq!(key, unspenable_internal_key());
+        assert_eq!(
+            format!("{key}"),
+            "79be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81799"
+        );
+    }
 }

--- a/src/bitcoin_utils.rs
+++ b/src/bitcoin_utils.rs
@@ -231,7 +231,7 @@ pub fn create_commit_reveal_txs(
         &data
     );
 
-    let fee_rate = get_current_fee_rate(rpc, None, None);
+    let fee_rate = get_fee_rate(rpc, None, None);
 
     // construct the script that will contain the data
     let commit_script = make_push_data_script(data);
@@ -369,11 +369,7 @@ pub fn create_commit_reveal_txs(
     Ok((commit_tx, reveal_tx))
 }
 
-pub fn get_current_fee_rate(
-    rpc: &Client,
-    mode: Option<EstimateMode>,
-    target: Option<u16>,
-) -> FeeRate {
+pub fn get_fee_rate(rpc: &Client, mode: Option<EstimateMode>, target: Option<u16>) -> FeeRate {
     let mode = mode.or(Some(EstimateMode::Economical));
     let target = target.unwrap_or(6);
 
@@ -394,7 +390,12 @@ pub fn get_current_fee_rate(
         _ => DEFAULT_BTC_FEE_RATE,
     };
 
-    trace!("Current fee rate is {}", fee_rate);
+    trace!(
+        "Fee rate is {} with mode={:?} and target={}",
+        fee_rate,
+        mode,
+        target
+    );
 
     FeeRate::clamp(fee_rate, MINIMUM_BTC_FEE_RATE, MAXIMUM_BTC_FEE_RATE)
 }

--- a/src/db.rs
+++ b/src/db.rs
@@ -1,6 +1,7 @@
 use crate::{
+    bitcoin_utils,
     ipc_lib::{IpcCreateSubnetMsg, IpcFundSubnetMsg},
-    multisig::{create_subnet_multisig_address, multisig_threshold},
+    multisig::{self, create_subnet_multisig_address, multisig_threshold},
     wallet, SubnetId, NETWORK,
 };
 use async_trait::async_trait;
@@ -115,6 +116,38 @@ impl SubnetCommittee {
             .require_network(NETWORK)
             .expect("Multisig should be valid for saved subnet genesis info");
         wallet::get_unspent_for_address(rpc, &address)
+    }
+
+    pub fn construct_spend_psbt(
+        &self,
+        rpc: &bitcoincore_rpc::Client,
+        subnet_id: &SubnetId,
+        to: &Address,
+        amount: bitcoin::Amount,
+    ) -> Result<bitcoin::Psbt, multisig::MultisigError> {
+        let address = self
+            .multisig_address
+            .clone()
+            .require_network(NETWORK)
+            .expect("Multisig should be valid for saved subnet genesis info");
+
+        let unspent = wallet::get_unspent_for_address(rpc, &address).expect("temp expect");
+        let fee_rate = bitcoin_utils::get_fee_rate(&rpc, None, None);
+        let public_keys = self.validators.iter().map(|v| v.pubkey).collect::<Vec<_>>();
+
+        let psbt = multisig::construct_spend_psbt(
+            to,
+            amount,
+            &unspent,
+            &address,
+            self.validators.len() as u16,
+            self.threshold,
+            &fee_rate,
+            &subnet_id,
+            &public_keys,
+        )?;
+
+        Ok(psbt)
     }
 }
 

--- a/src/ipc_lib.rs
+++ b/src/ipc_lib.rs
@@ -1117,9 +1117,13 @@ pub enum IpcLibError {
 
 #[cfg(test)]
 mod tests {
-    use crate::L1_NAME;
-
     use super::*;
+    use crate::L1_NAME;
+    use fvm_shared::address::{set_current_network, Network as FvmNetwork};
+
+    fn set_test_fvm_network() {
+        set_current_network(FvmNetwork::Testnet);
+    }
 
     #[test]
     fn test_ipc_tag_as_str() {
@@ -1141,6 +1145,7 @@ mod tests {
 
     #[test]
     fn test_ipc_create_subnet_msg_serialize() {
+        set_test_fvm_network();
         let validator1 = XOnlyPublicKey::from_str(
             "18845781f631c48f1c9709e23092067d06837f30aa0cd0544ac887fe91ddd166",
         )
@@ -1176,6 +1181,8 @@ mod tests {
 
     #[test]
     fn test_ipc_create_subnet_msg_deserialize() {
+        set_test_fvm_network();
+
         let validator1 = XOnlyPublicKey::from_str(
             "18845781f631c48f1c9709e23092067d06837f30aa0cd0544ac887fe91ddd166",
         )
@@ -1215,6 +1222,8 @@ mod tests {
 
     #[test]
     fn test_ipc_join_subnet_msg_validate() {
+        set_test_fvm_network();
+
         let pubkey = XOnlyPublicKey::from_str(
             "18845781f631c48f1c9709e23092067d06837f30aa0cd0544ac887fe91ddd166",
         )
@@ -1264,6 +1273,8 @@ mod tests {
 
     #[test]
     fn test_ipc_join_subnet_msg_serialize_deserialize() {
+        set_test_fvm_network();
+
         let pubkey = XOnlyPublicKey::from_str(
             "18845781f631c48f1c9709e23092067d06837f30aa0cd0544ac887fe91ddd166",
         )
@@ -1341,6 +1352,7 @@ mod tests {
 
     #[test]
     fn test_subnet_id_from_str() {
+        set_test_fvm_network();
         let subnet_id_str = format!(
             "{}/t420fhor637l2pmjle6whfq7go5upmf74qg6drcffcmr2t64kusy6lzfagfyi6m",
             crate::L1_NAME
@@ -1355,6 +1367,7 @@ mod tests {
 
     #[test]
     fn test_subnet_id_display() {
+        set_test_fvm_network();
         let txid =
             Txid::from_str("4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b")
                 .unwrap();
@@ -1371,6 +1384,8 @@ mod tests {
 
     #[test]
     fn test_invalid_subnet_id() {
+        set_test_fvm_network();
+
         // Test invalid txid
         let result = SubnetId::from_str(&format!("{}/invalid-txid", crate::L1_NAME));
         assert!(matches!(result, Err(SubnetIdError::InvalidFvmAddress(_))));
@@ -1394,6 +1409,8 @@ mod tests {
 
     #[test]
     fn test_subnet_id_serde() {
+        set_test_fvm_network();
+
         let txid =
             Txid::from_str("4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b")
                 .unwrap();

--- a/src/multisig.rs
+++ b/src/multisig.rs
@@ -1,18 +1,19 @@
 use std::vec;
 
-use log::error;
+use log::{error, trace};
 use thiserror::Error;
 
 use bitcoin::{
+    absolute::LockTime,
     blockdata::script::Builder,
     hashes::Hash,
     opcodes,
     secp256k1::{All, Secp256k1},
     taproot::{TaprootBuilder, TaprootSpendInfo},
-    Address, Network, ScriptBuf, XOnlyPublicKey,
+    Address, Amount, FeeRate, Network, ScriptBuf, Transaction, TxOut, XOnlyPublicKey,
 };
 
-use crate::bitcoin_utils::create_unspendable_internal_key;
+use crate::bitcoin_utils::unspenable_internal_key;
 
 use crate::SubnetId;
 
@@ -69,7 +70,7 @@ pub fn create_subnet_multisig_spend_info(
 
     let builder =
         TaprootBuilder::with_huffman_tree(vec![(1, multisig_script), (0, subnet_id_script)])?;
-    let internal_key = create_unspendable_internal_key();
+    let internal_key = unspenable_internal_key();
     let spend_info = builder
         .finalize(secp, internal_key)
         .map_err(|_| MultisigError::TaprootBuilderNotFinalizable)?;

--- a/src/multisig.rs
+++ b/src/multisig.rs
@@ -10,7 +10,8 @@ use bitcoin::{
     opcodes,
     secp256k1::{All, Secp256k1},
     taproot::{TaprootBuilder, TaprootSpendInfo},
-    Address, Amount, FeeRate, Network, ScriptBuf, Transaction, TxOut, XOnlyPublicKey,
+    Address, Amount, FeeRate, Network, ScriptBuf, Transaction, TxIn, TxOut, VarInt, Weight,
+    Witness, XOnlyPublicKey,
 };
 
 use crate::bitcoin_utils::unspenable_internal_key;
@@ -101,10 +102,210 @@ pub fn multisig_threshold(participants: u16) -> u16 {
     (participants / 2) + 1
 }
 
+/// Calculates the size in bytes of witness elements for spending a multisig utxo
+/// Useful for fee calculations.
+pub fn multisig_spend_witness_size(committee_size: u16, committee_threshold: u16) -> usize {
+    // Each required signature
+    let signatures_size =
+        bitcoin::key::constants::SCHNORR_SIGNATURE_SIZE * committee_threshold as usize;
+
+    // For each unused key position, we need an empty signature (represented as empty vector with 1 byte length)
+    // In witness format, an empty element still takes 1 byte (the length byte indicating zero-length data)
+    let empty_sigs_size = (committee_size - committee_threshold) as usize;
+
+    // Script size: all x-only public keys (32 bytes each) plus opcodes
+    // - Each key needs 1 byte push operation (for the 32-byte key) = 33 bytes per key
+    // - 1 byte for each OP_CHECKSIG or OP_CHECKSIGADD
+    // - 1 byte for integer push (required_sigs)
+    // - 1 byte for OP_GREATERTHANOREQUAL
+    let script_size =
+        (bitcoin::key::constants::SCHNORR_PUBLIC_KEY_SIZE + 2) * committee_size as usize + 2;
+
+    // Control block calculation:
+    // - TAPROOT_CONTROL_BASE_SIZE (33 bytes: 1 byte version + 32 bytes internal key)
+    // - TAPROOT_CONTROL_NODE_SIZE (32 bytes for the merkle node)
+    let control_block_content_size =
+        bitcoin::taproot::TAPROOT_CONTROL_BASE_SIZE + bitcoin::taproot::TAPROOT_CONTROL_NODE_SIZE;
+
+    let var_ints =
+	    // varint for the number of witnesses, which is a signature for each committee member + script + control block
+	    bitcoin::VarInt::from(committee_size + 2).size()
+	    // each schnorr sig
+        + VarInt::from(bitcoin::key::constants::SCHNORR_SIGNATURE_SIZE).size() * committee_threshold as usize
+        // script size
+        + VarInt::from(script_size).size()
+        // control block size
+        + VarInt::from(control_block_content_size).size();
+
+    signatures_size + empty_sigs_size + script_size + control_block_content_size + var_ints
+}
+
+/// Selects UTXOs to spend for a transaction
+/// Returns the selected UTXOs and the change output if any
+///
+/// It uses the largest utxos first
+// TODO improve coin selection algorithm
+pub fn select_coins(
+    target: Amount,
+    mut utxos: Vec<bitcoincore_rpc::json::ListUnspentResultEntry>,
+    fee_rate: FeeRate,
+    base_tx_weight: Weight,
+    satisfaction_weight_per_input: Weight,
+    change_address: &Address,
+) -> Result<
+    (
+        // The list of selected UTXOs
+        Vec<bitcoincore_rpc::json::ListUnspentResultEntry>,
+        // Optional change output
+        Option<TxOut>,
+    ),
+    MultisigError,
+> {
+    // Sort UTXOs deterministically by amount, txid and vout
+    utxos.sort_by(|a, b| {
+        b.amount
+            .cmp(&a.amount)
+            .then(a.txid.cmp(&b.txid))
+            .then(a.vout.cmp(&b.vout))
+    });
+
+    trace!(
+        "Selecting coins for target amount {}. Unspent: {:?}",
+        target,
+        utxos
+    );
+
+    let non_dust_change_tx_out = bitcoin::TxOut::minimal_non_dust(change_address.script_pubkey());
+
+    let mut selected = Vec::with_capacity(utxos.len());
+    let mut total_amount = Amount::ZERO;
+    let mut total_weight = base_tx_weight;
+
+    for utxo in utxos {
+        // Append the utxo
+        selected.push(utxo.clone());
+
+        total_amount += utxo.amount;
+        total_weight += satisfaction_weight_per_input;
+
+        let total_fee = fee_rate
+            .fee_wu(total_weight)
+            .expect("fee rate shouldn't overflow");
+
+        if total_amount >= target + total_fee {
+            let change = total_amount - target - total_fee;
+            trace!(
+                "Selected coins for target amount {}. Total amount: {}, total fee: {}, change: {}",
+                target,
+                total_amount,
+                total_fee,
+                change
+            );
+            dbg!(
+                "change is {change}, min dust is {}",
+                non_dust_change_tx_out.value
+            );
+
+            // if change is non-dust, return it
+            if change > non_dust_change_tx_out.value {
+                let change_tx_out = bitcoin::TxOut {
+                    value: change,
+                    script_pubkey: change_address.script_pubkey(),
+                };
+                return Ok((selected, Some(change_tx_out)));
+            } else {
+                return Ok((selected, None));
+            }
+        }
+    }
+
+    Err(MultisigError::CoinSelectionFailed(
+        "Insufficient funds".to_string(),
+    ))
+}
+
+pub fn construct_multisig_spend_transaction(
+    to: &Address,
+    amount: Amount,
+    unspent: &Vec<bitcoincore_rpc::json::ListUnspentResultEntry>,
+    committee_change_address: &Address,
+    committee_size: u16,
+    committee_threshold: u16,
+    fee_rate: &FeeRate,
+) -> Result<Transaction, MultisigError> {
+    trace!(
+        "Creating multisig spend tx for address={}, amount={}",
+        &to,
+        &amount
+    );
+
+    // size of the witness data when spending a multisig utxo
+    let spend_witness_size = multisig_spend_witness_size(committee_size, committee_threshold);
+    // base input size
+    let spend_txin_size = bitcoin::TxIn::default().base_size();
+    // weight of spending one input
+    let spending_weight_per_input = Weight::from_non_witness_data_size(spend_txin_size as u64)
+        + Weight::from_witness_data_size(spend_witness_size as u64);
+
+    let tx_out = bitcoin::TxOut {
+        value: amount,
+        script_pubkey: to.script_pubkey(),
+    };
+    let non_dust_change_tx_out =
+        bitcoin::TxOut::minimal_non_dust(committee_change_address.script_pubkey());
+
+    // base transaction, assume a change output
+    let base_tx = Transaction {
+        version: bitcoin::transaction::Version::TWO,
+        lock_time: LockTime::ZERO,
+        input: vec![],
+        output: vec![tx_out.clone(), non_dust_change_tx_out],
+    };
+    let base_tx_weight = base_tx.weight();
+
+    // coin selection from utxos
+    let (selected_utxos, change) = select_coins(
+        amount,
+        unspent.clone(),
+        *fee_rate,
+        base_tx_weight,
+        spending_weight_per_input,
+        committee_change_address,
+    )?;
+
+    let inputs = selected_utxos
+        .iter()
+        .map(|utxo| TxIn {
+            previous_output: bitcoin::OutPoint {
+                txid: utxo.txid,
+                vout: utxo.vout,
+            },
+            script_sig: ScriptBuf::new(),
+            sequence: bitcoin::Sequence::MAX,
+            witness: Witness::new(),
+        })
+        .collect::<Vec<TxIn>>();
+
+    let mut spend_tx = Transaction {
+        version: bitcoin::transaction::Version::TWO,
+        lock_time: LockTime::ZERO,
+        input: inputs,
+        output: vec![tx_out],
+    };
+    if let Some(change_tx_out) = change {
+        spend_tx.output.push(change_tx_out);
+    }
+
+    Ok(spend_tx)
+}
+
 #[derive(Error, Debug)]
 pub enum MultisigError {
     #[error("insufficient public keys provided")]
     InsufficientPublicKeys,
+
+    #[error("error during coin selection: {0}")]
+    CoinSelectionFailed(String),
 
     #[error("taproot builder is not finalizable")]
     TaprootBuilderNotFinalizable,
@@ -303,6 +504,8 @@ mod tests {
             .control_block(&(script.clone(), LeafVersion::TapScript))
             .expect("Should create control block");
 
+        dbg!(&control_block.size());
+
         let multisig_address =
             create_subnet_multisig_address(&secp, &subnet_id, &public_keys, required_sigs, network)
                 .expect("Failed to create multisig address");
@@ -409,7 +612,7 @@ mod tests {
         }
 
         //
-        // Case 2: Valid spend with required signatures (3 of 3)
+        // Case 2: Valid spend with required signatures (3 of 5)
         //
         {
             let mut tx_valid = spending_tx.clone();
@@ -430,6 +633,10 @@ mod tests {
 
             witness.push(script.to_bytes());
             witness.push(control_block.serialize());
+
+            // Test the spend witness size calculation
+            let spend_witness_size = multisig_spend_witness_size(5, 3);
+            assert_eq!(witness.size(), spend_witness_size);
 
             tx_valid.input[0].witness = witness;
 
@@ -551,5 +758,323 @@ mod tests {
             address_1, address_2,
             "Addresses should be different with different subnet IDs"
         );
+    }
+
+    #[test]
+    fn test_witness_size_calculation() {
+        let committee_configs: [(u16, u16); 7] =
+            [(1, 1), (2, 3), (3, 5), (5, 7), (7, 10), (11, 15), (14, 20)];
+
+        // Create a 2-of-3 multisig setup
+        let secp = Secp256k1::new();
+
+        for (required_sigs, committee_size) in committee_configs {
+            let keypairs = generate_keypairs(committee_size as usize);
+            let public_keys: Vec<XOnlyPublicKey> =
+                keypairs.iter().map(|kp| kp.x_only_public_key().0).collect();
+
+            let subnet_id = generate_subnet_id();
+            let script = create_multisig_script(&public_keys, required_sigs as i64).unwrap();
+
+            let spend_info = create_subnet_multisig_spend_info(
+                &secp,
+                &subnet_id,
+                &public_keys,
+                required_sigs as i64,
+            )
+            .unwrap();
+            let control_block = spend_info
+                .control_block(&(script.clone(), LeafVersion::TapScript))
+                .unwrap();
+
+            // Create a witness
+            let mut witness = Witness::new();
+
+            // Add 2 signatures
+            let dummy_sig = [1u8; bitcoin::key::constants::SCHNORR_SIGNATURE_SIZE];
+            for _ in 0..required_sigs {
+                witness.push(&dummy_sig[..]);
+            }
+            // Add empty signatures for unused keys
+            for _ in required_sigs..committee_size {
+                witness.push([]);
+            }
+            // Add the script and control block
+            witness.push(script.to_bytes());
+            witness.push(control_block.serialize());
+
+            // Calculate the actual size
+            let actual_size = witness.size();
+
+            // Calculate using our function
+            let calculated_size = multisig_spend_witness_size(committee_size, required_sigs);
+
+            // They should match
+            assert_eq!(calculated_size, actual_size);
+            println!(
+                "{required_sigs}-of-{committee_size} Witness Size: Actual={}, Calculated={}",
+                actual_size, calculated_size
+            );
+        }
+    }
+}
+
+#[cfg(test)]
+mod coin_selection_tests {
+    use std::str::FromStr;
+
+    use super::*;
+    use bitcoin::Amount;
+    use bitcoincore_rpc::json::ListUnspentResultEntry;
+
+    fn create_test_utxo(amount: u64, txid: &str, vout: u32) -> ListUnspentResultEntry {
+        ListUnspentResultEntry {
+            txid: txid.parse().unwrap(),
+            vout,
+            address: None,
+            label: None,
+            redeem_script: None,
+            witness_script: None,
+            script_pub_key: ScriptBuf::new(),
+            amount: Amount::from_sat(amount),
+            confirmations: 1,
+            spendable: true,
+            solvable: true,
+            descriptor: None,
+            safe: true,
+        }
+    }
+
+    #[test]
+    fn test_basic() {
+        let target = Amount::from_sat(1000);
+        let utxos = vec![
+            create_test_utxo(
+                500,
+                "7224e1f11ddc838100abd123d23af0d02493001fdd746685dc539fe062b45e3e",
+                0,
+            ),
+            create_test_utxo(
+                1000,
+                "d7f3553b9631f48a2842a2cb6e0f2b6e344bf82d3ee78295a5361adc17b838b1",
+                0,
+            ),
+        ];
+        let fee_rate = FeeRate::from_sat_per_vb(1).expect("works");
+        let base_weight = Weight::from_wu(100);
+        let input_weight = Weight::from_wu(50);
+        let change_address = Address::from_str("bcrt1qw508d6qejxtdg4y5r3zarvary0c5xw7kygt080")
+            .unwrap()
+            .assume_checked();
+
+        let (selected, change) = select_coins(
+            target,
+            utxos,
+            fee_rate,
+            base_weight,
+            input_weight,
+            &change_address,
+        )
+        .unwrap();
+
+        assert_eq!(selected.len(), 2);
+        assert!(change.is_some());
+        assert_eq!(change.unwrap().value, Amount::from_sat(450));
+    }
+
+    #[test]
+    fn test_change_below_dust() {
+        let target = Amount::from_sat(1000);
+        let utxos = vec![create_test_utxo(
+            1050,
+            "d7f3553b9631f48a2842a2cb6e0f2b6e344bf82d3ee78295a5361adc17b838b1",
+            0,
+        )];
+        let fee_rate = FeeRate::from_sat_per_vb(1).expect("works");
+        let base_weight = Weight::from_wu(100);
+        let input_weight = Weight::from_wu(50);
+        let change_address = Address::from_str("bcrt1qw508d6qejxtdg4y5r3zarvary0c5xw7kygt080")
+            .unwrap()
+            .assume_checked();
+
+        let (selected, change) = select_coins(
+            target,
+            utxos,
+            fee_rate,
+            base_weight,
+            input_weight,
+            &change_address,
+        )
+        .unwrap();
+
+        assert_eq!(selected.len(), 1);
+        assert!(change.is_none()); // No change expected for exact match
+    }
+
+    #[test]
+    fn test_insufficient_funds() {
+        let target = Amount::from_sat(2000);
+        let utxos = vec![
+            create_test_utxo(
+                500,
+                "7224e1f11ddc838100abd123d23af0d02493001fdd746685dc539fe062b45e3e",
+                0,
+            ),
+            create_test_utxo(
+                1000,
+                "d7f3553b9631f48a2842a2cb6e0f2b6e344bf82d3ee78295a5361adc17b838b1",
+                0,
+            ),
+        ];
+        let fee_rate = FeeRate::from_sat_per_vb(1).expect("works");
+        let base_weight = Weight::from_wu(100);
+        let input_weight = Weight::from_wu(50);
+        let change_address = Address::from_str("bcrt1qw508d6qejxtdg4y5r3zarvary0c5xw7kygt080")
+            .unwrap()
+            .assume_checked();
+
+        let result = select_coins(
+            target,
+            utxos,
+            fee_rate,
+            base_weight,
+            input_weight,
+            &change_address,
+        );
+
+        assert!(result.is_err());
+        match result {
+            Err(MultisigError::CoinSelectionFailed(_)) => {}
+            _ => panic!("Expected CoinSelectionFailed error"),
+        }
+    }
+
+    #[test]
+    fn test_largest_sort() {
+        let target = Amount::from_sat(1500);
+        let utxos = vec![
+            create_test_utxo(
+                500,
+                "7224e1f11ddc838100abd123d23af0d02493001fdd746685dc539fe062b45e3e",
+                0,
+            ),
+            create_test_utxo(
+                2000,
+                "d7f3553b9631f48a2842a2cb6e0f2b6e344bf82d3ee78295a5361adc17b838b1",
+                0,
+            ),
+            create_test_utxo(
+                1000,
+                "f4184fc596403b9d638783cf57adfe4c75c605f6356fbc91338530e9831e9e16",
+                0,
+            ),
+        ];
+        let fee_rate = FeeRate::from_sat_per_vb(1).expect("works");
+        let base_weight = Weight::from_wu(100);
+        let input_weight = Weight::from_wu(50);
+        let change_address = Address::from_str("bcrt1qw508d6qejxtdg4y5r3zarvary0c5xw7kygt080")
+            .unwrap()
+            .assume_checked();
+
+        let (selected, _) = select_coins(
+            target,
+            utxos,
+            fee_rate,
+            base_weight,
+            input_weight,
+            &change_address,
+        )
+        .unwrap();
+
+        // Algorithm should select the 2000 sat UTXO first since it's the largest
+        assert_eq!(selected.len(), 1);
+        assert_eq!(selected[0].amount, Amount::from_sat(2000));
+    }
+
+    #[test]
+    fn test_high_fee() {
+        let target = Amount::from_sat(1000);
+        let utxos = vec![create_test_utxo(
+            1500,
+            "7224e1f11ddc838100abd123d23af0d02493001fdd746685dc539fe062b45e3e",
+            0,
+        )];
+        // Very high fee rate
+        let fee_rate = FeeRate::from_sat_per_vb(100).expect("works");
+        let base_weight = Weight::from_wu(1000); // Large tx
+        let input_weight = Weight::from_wu(500); // Heavy input
+        let change_address = Address::from_str("bcrt1qw508d6qejxtdg4y5r3zarvary0c5xw7kygt080")
+            .unwrap()
+            .assume_checked();
+
+        let result = select_coins(
+            target,
+            utxos,
+            fee_rate,
+            base_weight,
+            input_weight,
+            &change_address,
+        );
+
+        assert!(result.is_err());
+        match result {
+            Err(MultisigError::CoinSelectionFailed(_)) => {}
+            _ => panic!("Expected CoinSelectionFailed error"),
+        }
+    }
+
+    #[test]
+    fn test_multiple_utxos_needed() {
+        let target = Amount::from_sat(3000);
+        let utxos = vec![
+            create_test_utxo(
+                1000,
+                "7224e1f11ddc838100abd123d23af0d02493001fdd746685dc539fe062b45e3e",
+                0,
+            ),
+            create_test_utxo(
+                1200,
+                "d7f3553b9631f48a2842a2cb6e0f2b6e344bf82d3ee78295a5361adc17b838b1",
+                0,
+            ),
+            create_test_utxo(
+                1500,
+                "f4184fc596403b9d638783cf57adfe4c75c605f6356fbc91338530e9831e9e16",
+                0,
+            ),
+        ];
+        let fee_rate = FeeRate::from_sat_per_vb(1).expect("works");
+        let base_weight = Weight::from_wu(100);
+        let input_weight = Weight::from_wu(50);
+        let change_address = Address::from_str("bcrt1qw508d6qejxtdg4y5r3zarvary0c5xw7kygt080")
+            .unwrap()
+            .assume_checked();
+
+        let (selected, change) = select_coins(
+            target,
+            utxos,
+            fee_rate,
+            base_weight,
+            input_weight,
+            &change_address,
+        )
+        .unwrap();
+
+        // We should select at least 2 UTXOs to meet the target
+        assert!(selected.len() >= 2);
+
+        // Verify the total amount is sufficient
+        let total_selected = selected
+            .iter()
+            .fold(Amount::ZERO, |acc, utxo| acc + utxo.amount);
+        let total_fee = fee_rate
+            .fee_wu(base_weight + input_weight * selected.len() as u64)
+            .unwrap();
+        assert!(total_selected >= target + total_fee);
+
+        // Verify change if present
+        let change_out = change.unwrap();
+        assert_eq!(change_out.script_pubkey, change_address.script_pubkey());
+        assert_eq!(change_out.value, total_selected - target - total_fee);
     }
 }

--- a/src/multisig.rs
+++ b/src/multisig.rs
@@ -224,7 +224,7 @@ pub fn select_coins(
     ))
 }
 
-pub fn construct_multisig_spend_transaction(
+pub fn construct_spend_unsigned_transaction(
     to: &Address,
     amount: Amount,
     unspent: &Vec<bitcoincore_rpc::json::ListUnspentResultEntry>,
@@ -297,6 +297,95 @@ pub fn construct_multisig_spend_transaction(
     }
 
     Ok(spend_tx)
+}
+
+/// Constructs a PSBT for spending a multisig output
+pub fn construct_spend_psbt(
+    to: &Address,
+    amount: Amount,
+    unspent: &Vec<bitcoincore_rpc::json::ListUnspentResultEntry>,
+    committee_change_address: &Address,
+    committee_size: u16,
+    committee_threshold: u16,
+    fee_rate: &FeeRate,
+    subnet_id: &SubnetId,
+    public_keys: &[XOnlyPublicKey],
+) -> Result<bitcoin::Psbt, MultisigError> {
+    trace!(
+        "Creating multisig spend PSBT for address={}, amount={}",
+        &to,
+        &amount
+    );
+
+    let secp = Secp256k1::new();
+
+    // First construct the unsigned transaction
+    let unsigned_tx = construct_spend_unsigned_transaction(
+        to,
+        amount,
+        unspent,
+        committee_change_address,
+        committee_size,
+        committee_threshold,
+        fee_rate,
+    )?;
+
+    // Create the PSBT from the unsigned transaction
+    let mut psbt = bitcoin::psbt::Psbt::from_unsigned_tx(unsigned_tx.clone())
+        .map_err(|e| MultisigError::CoinSelectionFailed(format!("Failed to create PSBT: {}", e)))?;
+
+    // Create the script that will be used for spending
+    let required_sigs = committee_threshold as i64;
+    let script = create_multisig_script(public_keys, required_sigs)?;
+    let leaf_version = bitcoin::taproot::LeafVersion::TapScript;
+
+    // Get the spend info for the multisig
+    let spend_info =
+        create_subnet_multisig_spend_info(&secp, subnet_id, public_keys, required_sigs)?;
+
+    // Create the control block
+    let control_block = spend_info
+        .control_block(&(script.clone(), leaf_version))
+        .ok_or_else(|| MultisigError::TaprootBuilderNotFinalizable)?;
+
+    psbt.inputs = psbt
+        .inputs
+        .into_iter()
+        .enumerate()
+        .map(|(psbt_input_index, mut psbt_input)| {
+            // Find the matching UTXO from our list
+            let utxo = unspent
+                .iter()
+                .find(|u| {
+                    u.txid == unsigned_tx.input[psbt_input_index].previous_output.txid
+                        && u.vout == unsigned_tx.input[psbt_input_index].previous_output.vout
+                })
+                .ok_or_else(|| format!("Failed to find UTXO for input {}", psbt_input_index))
+                // temp expect
+                .expect("Should find matching UTXO");
+
+            // 1. Witnessable script (the tapscript)
+            psbt_input.witness_script = Some(script.clone());
+
+            // 2. Taproot-specific fields
+            psbt_input.tap_script_sigs = Default::default();
+            let mut tap_scripts = std::collections::BTreeMap::new();
+            tap_scripts.insert(control_block.clone(), (script.clone(), leaf_version));
+            psbt_input.tap_scripts = tap_scripts;
+            psbt_input.tap_merkle_root = spend_info.merkle_root();
+            psbt_input.tap_internal_key = Some(spend_info.internal_key());
+
+            // 3. Previous UTXO information
+            psbt_input.witness_utxo = Some(TxOut {
+                value: utxo.amount,
+                script_pubkey: utxo.script_pub_key.clone(),
+            });
+
+            psbt_input
+        })
+        .collect();
+
+    Ok(psbt)
 }
 
 #[derive(Error, Debug)]

--- a/src/provider/rpc.rs
+++ b/src/provider/rpc.rs
@@ -2,8 +2,9 @@ use crate::{
     bitcoin_utils::get_confirmed_from_height,
     db::{self, Database, HeedDb},
     ipc_lib::{IpcFundSubnetMsg, IpcJoinSubnetMsg, IpcPrefundSubnetMsg, IpcValidate, SubnetId},
-    IpcCreateSubnetMsg,
+    IpcCreateSubnetMsg, NETWORK,
 };
+use base64::{engine::general_purpose::STANDARD as BASE64_STANDARD, Engine};
 use bitcoincore_rpc::{Client, RpcApi};
 use jsonrpc_v2::{Data, Error as JsonRpcError, ErrorLike, MapRouter, Params};
 use log::{error, trace};
@@ -343,6 +344,62 @@ pub async fn get_rootnet_messages(
         })
 }
 
+#[derive(Serialize, Deserialize)]
+pub struct GenMultisigSpendPsbtParams {
+    subnet_id: SubnetId,
+    recipient: bitcoin::Address<bitcoin::address::NetworkUnchecked>,
+    #[serde(with = "bitcoin::amount::serde::as_sat")]
+    amount: bitcoin::Amount,
+}
+
+#[derive(Serialize, Deserialize)]
+pub struct GenMultisigSpendPsbtResponse {
+    psbt: bitcoin::Psbt,
+    psbt_base64: String,
+}
+
+pub async fn gen_multisig_spend_psbt(
+    data: Data<Arc<ServerData>>,
+    Params(params): Params<GenMultisigSpendPsbtParams>,
+) -> Result<GenMultisigSpendPsbtResponse, JsonRpcError> {
+    // Check subnet exists
+    let subnet = data
+        .db
+        .get_subnet_state(params.subnet_id)
+        .map_err(|e| {
+            error!("Error getting subnet info from Db: {}", e);
+            RpcError::DbError(e)
+        })?
+        .ok_or(RpcError::InvalidParams(format!(
+            "Subnet {} not found.",
+            params.subnet_id
+        )))?;
+
+    let recipient = params.recipient.require_network(NETWORK).map_err(|_| {
+        RpcError::InvalidParams(format!("Invalid address network, required {NETWORK}"))
+    })?;
+
+    let psbt = subnet
+        .committee
+        .construct_spend_psbt(
+            &data.btc_watchonly_rpc,
+            &params.subnet_id,
+            &recipient,
+            params.amount,
+        )
+        .map_err(|e| {
+            error!(
+                "Error generating multisig spend psbt for subnet_id={}: {}",
+                &params.subnet_id, e
+            );
+            RpcError::InternalError(e.to_string())
+        })?;
+
+    let psbt_base64 = BASE64_STANDARD.encode(psbt.serialize());
+
+    Ok(GenMultisigSpendPsbtResponse { psbt, psbt_base64 })
+}
+
 pub fn make_rpc_server(server_data: Arc<ServerData>) -> RpcServer {
     jsonrpc_v2::Server::new()
         .with_data(Data::new(server_data))
@@ -359,5 +416,7 @@ pub fn make_rpc_server(server_data: Arc<ServerData>) -> RpcServer {
         .with_method("fundsubnet", fund_subnet)
         // rootnet messages
         .with_method("getrootnetmessages", get_rootnet_messages)
+        // multisig
+        .with_method("genmultisigspendpsbt", gen_multisig_spend_psbt)
         .finish()
 }

--- a/src/wallet.rs
+++ b/src/wallet.rs
@@ -108,6 +108,7 @@ pub fn get_unspent_for_address(
     addr: &bitcoin::Address,
 ) -> Result<Vec<ListUnspentResultEntry>, WalletError> {
     let unspent = rpc.list_unspent(None, None, Some(&[addr]), None, None)?;
+    debug!("get_unspent_for_address {addr}: {unspent:?}");
     Ok(unspent)
 }
 


### PR DESCRIPTION
An rpc method to return a generated PSBT ready to be signed by validators and published.

The coin selection algorithm is largest-first which is not ideal so it could be optimised. We should look into a prebuild library  with deterministic coin-selection for production use.

See the curl request I've added and look at the response. I'll think about removing the PSBT json in response and only keep the base64 hex. If you're testing, make sure that the validators have enough funds. See #64  and #72 .

Part of #41 