### PR TITLE
Sign multisig spend PSBT

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,6 +5,10 @@ RPC_PASS=pass
 RPC_URL=http://localhost:18443
 WALLET_NAME=default
 
+# Validator
+
+VALIDATOR_SK_PATH=~/.ipc/path/to/key.sk
+
 # Provider + Monitor
 
 DATABASE_URL=local_dev_db
@@ -16,4 +20,4 @@ PROVIDER_AUTH_TOKEN=xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
 
 # General
 
-RUST_LOG=bitcoin_ipc=debug,monitor=debug,bitcoincore_rpc=error,actix_web=info
+RUST_LOG=bitcoin_ipc=debug,monitor=debug,provider=debug,bitcoincore_rpc=error,actix_web=info

--- a/src/bin/provider.rs
+++ b/src/bin/provider.rs
@@ -5,7 +5,7 @@ use std::sync::Arc;
 use bitcoin_ipc::db::HeedDb;
 use bitcoin_ipc::{bitcoin_utils, eth_utils, provider};
 use clap::Parser;
-use log::error;
+use log::{error, info};
 
 const DEFAULT_PROVIDER_PORT: &str = "3030";
 
@@ -64,6 +64,9 @@ async fn main() -> std::io::Result<()> {
     let btc_rpc = Arc::new(bitcoin_utils::make_rpc_client_from_env());
     let btc_watchonly_rpc = Arc::new(bitcoin_utils::make_watchonly_rpc_client_from_env());
 
+    // Load validator secret key
+    let validator_sk = load_validator_sk()?;
+
     // Set correct fvm network
 
     eth_utils::set_fvm_network();
@@ -76,9 +79,56 @@ async fn main() -> std::io::Result<()> {
         db,
         btc_rpc,
         btc_watchonly_rpc,
+        validator_sk,
     });
 
     provider::Server::new(token, port, server_data)
         .serve()
         .await
+}
+
+fn load_validator_sk() -> Result<bitcoin::secp256k1::SecretKey, std::io::Error> {
+    // Load validator secret key from path
+    let sk_path = std::env::var("VALIDATOR_SK_PATH").map_err(|e| {
+        error!("Couldn't load VALIDATOR_SK_PATH: {}", e);
+        std::io::Error::new(std::io::ErrorKind::Other, "Couldn't load VALIDATOR_SK_PATH")
+    })?;
+    let sk_path = PathBuf::from(sk_path);
+
+    let sk_hex = std::fs::read_to_string(&sk_path).map_err(|e| {
+        error!(
+            "Couldn't read validator secret key from {}: {}",
+            sk_path.display(),
+            e
+        );
+        std::io::Error::new(
+            std::io::ErrorKind::Other,
+            format!("Couldn't read validator secret key: {}", e),
+        )
+    })?;
+
+    // Trim whitespace and remove any '0x' prefix if present
+    let sk_hex = sk_hex.trim();
+    let sk_hex = sk_hex.strip_prefix("0x").unwrap_or(sk_hex);
+
+    // Convert hex string to bytes
+    let sk_bytes = hex::decode(sk_hex).map_err(|e| {
+        error!("Invalid hex encoding in secret key file: {}", e);
+        std::io::Error::new(
+            std::io::ErrorKind::InvalidData,
+            format!("Invalid hex encoding in secret key file: {}", e),
+        )
+    })?;
+
+    let validator_sk = bitcoin::secp256k1::SecretKey::from_slice(&sk_bytes).map_err(|e| {
+        error!("Invalid validator secret key: {}", e);
+        std::io::Error::new(
+            std::io::ErrorKind::Other,
+            format!("Invalid validator secret key: {}", e),
+        )
+    })?;
+
+    info!("Loaded validator secret key from {}", sk_path.display());
+
+    Ok(validator_sk)
 }

--- a/src/db.rs
+++ b/src/db.rs
@@ -125,26 +125,30 @@ impl SubnetCommittee {
         to: &Address,
         amount: bitcoin::Amount,
     ) -> Result<bitcoin::Psbt, multisig::MultisigError> {
-        let address = self
+        let committee_address = self
             .multisig_address
             .clone()
             .require_network(NETWORK)
             .expect("Multisig should be valid for saved subnet genesis info");
 
-        let unspent = wallet::get_unspent_for_address(rpc, &address).expect("temp expect");
-        let fee_rate = bitcoin_utils::get_fee_rate(&rpc, None, None);
-        let public_keys = self.validators.iter().map(|v| v.pubkey).collect::<Vec<_>>();
+        let unspent =
+            wallet::get_unspent_for_address(rpc, &committee_address).expect("temp expect");
+        let fee_rate = bitcoin_utils::get_fee_rate(rpc, None, None);
+        let committee_keys = self.validators.iter().map(|v| v.pubkey).collect::<Vec<_>>();
+        let commitee_threshold = self.threshold;
+
+        let secp = bitcoin::secp256k1::Secp256k1::new();
 
         let psbt = multisig::construct_spend_psbt(
+            &secp,
+            subnet_id,
+            &committee_keys,
+            commitee_threshold,
+            &committee_address,
+            &unspent,
             to,
             amount,
-            &unspent,
-            &address,
-            self.validators.len() as u16,
-            self.threshold,
             &fee_rate,
-            &subnet_id,
-            &public_keys,
         )?;
 
         Ok(psbt)

--- a/src/db.rs
+++ b/src/db.rs
@@ -379,7 +379,10 @@ impl HeedDb {
         }
 
         let flags = if read_only {
-            debug!("Opening database in read-only mode");
+            debug!(
+                "Opening database '{}' in read-only mode",
+                database_path.display()
+            );
             heed::EnvFlags::READ_ONLY
         } else {
             heed::EnvFlags::empty()

--- a/src/multisig.rs
+++ b/src/multisig.rs
@@ -392,7 +392,7 @@ pub fn sign_spend_psbt(
     secp: &Secp256k1<All>,
     mut psbt: bitcoin::Psbt,
     keypair: bitcoin::key::Keypair,
-) -> Result<(bitcoin::Psbt, Vec<bitcoin::taproot::Signature>), MultisigError> {
+) -> Result<(bitcoin::Psbt, Vec<bitcoin::secp256k1::schnorr::Signature>), MultisigError> {
     let (xonly_pubkey, _parity) = keypair.x_only_public_key();
     let mut signatures = Vec::new();
 
@@ -439,7 +439,10 @@ pub fn sign_spend_psbt(
 
         // Sign the message
         let signature = secp.sign_schnorr(&msg, &keypair);
-        let signature = bitcoin::taproot::Signature {
+        // Add to our returned signatures
+        signatures.push(signature);
+
+        let taproot_sig = bitcoin::taproot::Signature {
             signature,
             sighash_type,
         };
@@ -447,10 +450,7 @@ pub fn sign_spend_psbt(
         // Add the signature to the PSBT
         input
             .tap_script_sigs
-            .insert((xonly_pubkey, leaf_hash), signature);
-
-        // Add to our returned signatures
-        signatures.push(signature);
+            .insert((xonly_pubkey, leaf_hash), taproot_sig);
     }
 
     if signatures.is_empty() {
@@ -524,11 +524,11 @@ pub fn finalize_spend_psbt_from_sigs(
     committee_keys: &[XOnlyPublicKey],
     committee_threshold: u16,
     psbt: &bitcoin::Psbt,
-    signature_sets: &[&[bitcoin::taproot::Signature]],
+    signature_sets: &[&[bitcoin::secp256k1::schnorr::Signature]],
 ) -> Result<Transaction, MultisigError> {
     let mut signed_psbt = psbt.clone();
 
-    let script = create_multisig_script(&committee_keys, committee_threshold.into()).unwrap();
+    let script = create_multisig_script(committee_keys, committee_threshold.into()).unwrap();
     let leaf_hash = script.tapscript_leaf_hash();
 
     for (xonly_pubkey, signatures) in committee_keys.iter().zip(signature_sets.iter()) {
@@ -536,18 +536,23 @@ pub fn finalize_spend_psbt_from_sigs(
         for (input_idx, signature) in signatures.iter().enumerate() {
             // Make sure we don't go out of bounds
             if input_idx < signed_psbt.inputs.len() {
+                let taproot_sig = bitcoin::taproot::Signature {
+                    signature: *signature,
+                    sighash_type: bitcoin::sighash::TapSighashType::Default,
+                };
+
                 // Add the signature to the PSBT
                 signed_psbt.inputs[input_idx]
                     .tap_script_sigs
-                    .insert((*xonly_pubkey, leaf_hash), *signature);
+                    .insert((*xonly_pubkey, leaf_hash), taproot_sig);
             }
         }
     }
 
     let finalized_psbt = finalize_spend_psbt(
-        &secp,
-        &subnet_id,
-        &committee_keys,
+        secp,
+        subnet_id,
+        committee_keys,
         committee_threshold,
         &signed_psbt,
     )?;
@@ -1449,7 +1454,7 @@ mod psbt_tests {
             .map(|(_, sig)| sig);
 
         assert!(found_sig.is_some());
-        assert_eq!(found_sig.unwrap(), &signatures[0]);
+        assert_eq!(found_sig.unwrap().signature, signatures[0]);
 
         // Verify the signature is valid by checking it against the sighash
         let mut sighash_cache = SighashCache::new(&signed_psbt.unsigned_tx);
@@ -1472,14 +1477,8 @@ mod psbt_tests {
 
         let msg = Message::from_digest_slice(sighash.as_ref()).unwrap();
 
-        // Verify the signature against the message and public key
-        let schnorr_sig = bitcoin::secp256k1::schnorr::Signature::from_slice(
-            &signatures[0].to_vec()[..64], // Take only the signature part, not the sighash byte
-        )
-        .unwrap();
-
         assert!(
-            secp.verify_schnorr(&schnorr_sig, &msg, &xonly_pubkey)
+            secp.verify_schnorr(&signatures[0], &msg, &xonly_pubkey)
                 .is_ok(),
             "Schnorr signature verification failed"
         );

--- a/src/multisig.rs
+++ b/src/multisig.rs
@@ -14,7 +14,7 @@ use bitcoin::{
     Witness, XOnlyPublicKey,
 };
 
-use crate::bitcoin_utils::unspenable_internal_key;
+use crate::{bitcoin_utils::unspenable_internal_key, NETWORK};
 
 use crate::SubnetId;
 
@@ -201,10 +201,7 @@ pub fn select_coins(
                 total_fee,
                 change
             );
-            dbg!(
-                "change is {change}, min dust is {}",
-                non_dust_change_tx_out.value
-            );
+            dbg!(change, non_dust_change_tx_out.value);
 
             // if change is non-dust, return it
             if change > non_dust_change_tx_out.value {
@@ -388,6 +385,77 @@ pub fn construct_spend_psbt(
     Ok(psbt)
 }
 
+pub fn sign_psbt(
+    secp: &Secp256k1<All>,
+    mut psbt: bitcoin::Psbt,
+    keypair: bitcoin::key::Keypair,
+) -> Result<(bitcoin::Psbt, Vec<bitcoin::taproot::Signature>), MultisigError> {
+    // Create a key provider from our keypair
+    struct SingleKeyProvider {
+        keypair: bitcoin::key::Keypair,
+    }
+
+    impl bitcoin::psbt::GetKey for SingleKeyProvider {
+        type Error = ();
+
+        fn get_key<C: bitcoin::secp256k1::Signing>(
+            &self,
+            _key_request: bitcoin::psbt::KeyRequest,
+            _secp: &Secp256k1<C>,
+        ) -> Result<Option<bitcoin::key::PrivateKey>, Self::Error> {
+            dbg!(&_key_request);
+
+            let private_key = bitcoin::key::PrivateKey {
+                compressed: true,
+                network: NETWORK.into(),
+                inner: self.keypair.secret_key(),
+            };
+            dbg!(&private_key);
+            Ok(Some(private_key))
+        }
+    }
+
+    let key_provider = SingleKeyProvider { keypair };
+
+    // Sign the PSBT using the built-in sign method
+    let signing_result = psbt.sign(&key_provider, secp);
+
+    dbg!(&signing_result);
+
+    // Process the signing result
+    match signing_result {
+        Ok(_) => {
+            // Collect all the signatures that were added
+            let mut signatures = Vec::new();
+            let (x_only_pubkey, _) = keypair.x_only_public_key();
+
+            for i in 0..psbt.inputs.len() {
+                // Find signatures for our x-only pubkey for each input
+                for (key_pair, sig) in &psbt.inputs[i].tap_script_sigs {
+                    if key_pair.0 == x_only_pubkey {
+                        // Found a signature by our keypair for this input
+                        signatures.push(sig.clone());
+                        break; // We expect only one signature per input with our keypair
+                    }
+                }
+            }
+
+            // Return the signed PSBT and the added signatures
+            Ok((psbt, signatures))
+        }
+        Err((_, errors)) => {
+            // Log errors
+            for (input_idx, error) in errors.iter() {
+                error!("Error signing input {}: {:?}", input_idx, error);
+            }
+
+            Err(MultisigError::SigningError(
+                "Failed to sign PSBT inputs".to_string(),
+            ))
+        }
+    }
+}
+
 #[derive(Error, Debug)]
 pub enum MultisigError {
     #[error("insufficient public keys provided")]
@@ -395,6 +463,9 @@ pub enum MultisigError {
 
     #[error("error during coin selection: {0}")]
     CoinSelectionFailed(String),
+
+    #[error("signing error: {0}")]
+    SigningError(String),
 
     #[error("taproot builder is not finalizable")]
     TaprootBuilderNotFinalizable,
@@ -468,7 +539,7 @@ mod tests {
             .collect()
     }
 
-    fn generate_keypairs(n: usize) -> Vec<Keypair> {
+    pub fn generate_keypairs(n: usize) -> Vec<Keypair> {
         let secp = Secp256k1::new();
         let mut keypairs: Vec<Keypair> = (0..n)
             .map(|_| {
@@ -484,7 +555,7 @@ mod tests {
         keypairs
     }
 
-    fn generate_subnet_id() -> SubnetId {
+    pub fn generate_subnet_id() -> SubnetId {
         SubnetId::from_txid(&Txid::from_slice(&rand::random::<[u8; 32]>()).unwrap())
     }
 
@@ -854,7 +925,6 @@ mod tests {
         let committee_configs: [(u16, u16); 7] =
             [(1, 1), (2, 3), (3, 5), (5, 7), (7, 10), (11, 15), (14, 20)];
 
-        // Create a 2-of-3 multisig setup
         let secp = Secp256k1::new();
 
         for (required_sigs, committee_size) in committee_configs {
@@ -879,7 +949,7 @@ mod tests {
             // Create a witness
             let mut witness = Witness::new();
 
-            // Add 2 signatures
+            // Add required signatures
             let dummy_sig = [1u8; bitcoin::key::constants::SCHNORR_SIGNATURE_SIZE];
             for _ in 0..required_sigs {
                 witness.push(&dummy_sig[..]);
@@ -1165,5 +1235,137 @@ mod coin_selection_tests {
         let change_out = change.unwrap();
         assert_eq!(change_out.script_pubkey, change_address.script_pubkey());
         assert_eq!(change_out.value, total_selected - target - total_fee);
+    }
+}
+
+#[cfg(test)]
+mod sign_psbt_tests {
+    use super::tests::{generate_keypairs, generate_subnet_id};
+    use super::*;
+    use bitcoin::secp256k1::{Message, Secp256k1};
+    use bitcoin::sighash::{Prevouts, SighashCache, TapSighashType};
+    use bitcoin::{Amount, Network, TxOut};
+    use std::str::FromStr;
+
+    #[test]
+    fn test_sign_psbt() {
+        let secp = Secp256k1::new();
+
+        // Generate keypairs for the committee
+        let committee_keypairs = generate_keypairs(3);
+        let committee_pubkeys: Vec<XOnlyPublicKey> = committee_keypairs
+            .iter()
+            .map(|kp| kp.x_only_public_key().0)
+            .collect();
+
+        // Generate a subnet ID
+        let subnet_id = generate_subnet_id();
+
+        // Create the multisig script and spend info
+        let required_sigs = 2;
+        let script = create_multisig_script(&committee_pubkeys, required_sigs).unwrap();
+
+        // Create a multisig address
+        let multisig_address = create_subnet_multisig_address(
+            &secp,
+            &subnet_id,
+            &committee_pubkeys,
+            required_sigs,
+            Network::Regtest,
+        )
+        .unwrap();
+
+        // Create a "funding UTXO" - a UTXO that sends funds to our multisig address
+        let funding_amount = Amount::from_sat(100_000);
+        let utxo = bitcoincore_rpc::json::ListUnspentResultEntry {
+            txid: bitcoin::Txid::from_str(
+                "f61b1742ca13176464adb3cb66050c00787bb3a4eead37e985f2df1e37718126",
+            )
+            .unwrap(),
+            vout: 0,
+            address: None,
+            label: None,
+            redeem_script: None,
+            witness_script: None,
+            script_pub_key: multisig_address.script_pubkey(),
+            amount: funding_amount,
+            confirmations: 1,
+            spendable: true,
+            solvable: true,
+            descriptor: None,
+            safe: true,
+        };
+
+        // Destination address and amount
+        let destination = Address::from_str("bcrt1qw508d6qejxtdg4y5r3zarvary0c5xw7kygt080")
+            .unwrap()
+            .assume_checked();
+        let spend_amount = Amount::from_sat(50_000);
+
+        // Construct a PSBT for spending
+        let fee_rate = FeeRate::from_sat_per_vb(2).unwrap();
+        let psbt = construct_spend_psbt(
+            &destination,
+            spend_amount,
+            &vec![utxo],
+            &multisig_address, // Use the same address for change
+            3,                 // committee size
+            2,                 // required signatures
+            &fee_rate,
+            &subnet_id,
+            &committee_pubkeys,
+        )
+        .unwrap();
+
+        // Sign the PSBT with the first keypair
+        let (signed_psbt, signatures) =
+            sign_psbt(&secp, psbt, committee_keypairs[0].clone()).unwrap();
+
+        // Verify we got exactly one signature (one for each input)
+        assert_eq!(signatures.len(), 1);
+
+        // Verify the signature is actually in the PSBT
+        let (xonly_pubkey, _parity) = committee_keypairs[0].x_only_public_key();
+        let found_sig = signed_psbt.inputs[0]
+            .tap_script_sigs
+            .iter()
+            .find(|((pubkey, _), _)| *pubkey == xonly_pubkey)
+            .map(|(_, sig)| sig);
+
+        assert!(found_sig.is_some());
+        assert_eq!(found_sig.unwrap(), &signatures[0]);
+
+        // Verify the signature is valid by checking it against the sighash
+        let mut sighash_cache = SighashCache::new(&signed_psbt.unsigned_tx);
+        let leaf_hash = script.tapscript_leaf_hash();
+
+        // We need to recreate the TxOut that's being spent
+        let prev_txout = TxOut {
+            value: funding_amount,
+            script_pubkey: multisig_address.script_pubkey(),
+        };
+
+        let sighash = sighash_cache
+            .taproot_script_spend_signature_hash(
+                0,
+                &Prevouts::All(&[prev_txout]),
+                leaf_hash,
+                TapSighashType::Default,
+            )
+            .unwrap();
+
+        let msg = Message::from_digest_slice(sighash.as_ref()).unwrap();
+
+        // Verify the signature against the message and public key
+        let schnorr_sig = bitcoin::secp256k1::schnorr::Signature::from_slice(
+            &signatures[0].to_vec()[..64], // Take only the signature part, not the sighash byte
+        )
+        .unwrap();
+
+        assert!(
+            secp.verify_schnorr(&schnorr_sig, &msg, &xonly_pubkey)
+                .is_ok(),
+            "Schnorr signature verification failed"
+        );
     }
 }

--- a/src/multisig.rs
+++ b/src/multisig.rs
@@ -9,12 +9,12 @@ use bitcoin::{
     hashes::Hash,
     opcodes,
     secp256k1::{All, Secp256k1},
-    taproot::{TaprootBuilder, TaprootSpendInfo},
+    taproot::{LeafVersion, TaprootBuilder, TaprootSpendInfo},
     Address, Amount, FeeRate, Network, ScriptBuf, Transaction, TxIn, TxOut, VarInt, Weight,
     Witness, XOnlyPublicKey,
 };
 
-use crate::{bitcoin_utils::unspenable_internal_key, NETWORK};
+use crate::bitcoin_utils::unspenable_internal_key;
 
 use crate::SubnetId;
 
@@ -147,7 +147,7 @@ pub fn multisig_spend_witness_size(committee_size: u16, committee_threshold: u16
 // TODO improve coin selection algorithm
 pub fn select_coins(
     target: Amount,
-    mut utxos: Vec<bitcoincore_rpc::json::ListUnspentResultEntry>,
+    utxos: &[bitcoincore_rpc::json::ListUnspentResultEntry],
     fee_rate: FeeRate,
     base_tx_weight: Weight,
     satisfaction_weight_per_input: Weight,
@@ -161,6 +161,7 @@ pub fn select_coins(
     ),
     MultisigError,
 > {
+    let mut utxos = utxos.to_vec();
     // Sort UTXOs deterministically by amount, txid and vout
     utxos.sort_by(|a, b| {
         b.amount
@@ -222,12 +223,12 @@ pub fn select_coins(
 }
 
 pub fn construct_spend_unsigned_transaction(
-    to: &Address,
-    amount: Amount,
-    unspent: &Vec<bitcoincore_rpc::json::ListUnspentResultEntry>,
-    committee_change_address: &Address,
     committee_size: u16,
     committee_threshold: u16,
+    committee_change_address: &Address,
+    unspent: &[bitcoincore_rpc::json::ListUnspentResultEntry],
+    to: &Address,
+    amount: Amount,
     fee_rate: &FeeRate,
 ) -> Result<Transaction, MultisigError> {
     trace!(
@@ -263,7 +264,7 @@ pub fn construct_spend_unsigned_transaction(
     // coin selection from utxos
     let (selected_utxos, change) = select_coins(
         amount,
-        unspent.clone(),
+        unspent,
         *fee_rate,
         base_tx_weight,
         spending_weight_per_input,
@@ -297,16 +298,17 @@ pub fn construct_spend_unsigned_transaction(
 }
 
 /// Constructs a PSBT for spending a multisig output
+#[allow(clippy::too_many_arguments)]
 pub fn construct_spend_psbt(
+    secp: &Secp256k1<All>,
+    subnet_id: &SubnetId,
+    committee_keys: &[XOnlyPublicKey],
+    committee_threshold: u16,
+    committee_change_address: &Address,
+    unspent: &[bitcoincore_rpc::json::ListUnspentResultEntry],
     to: &Address,
     amount: Amount,
-    unspent: &Vec<bitcoincore_rpc::json::ListUnspentResultEntry>,
-    committee_change_address: &Address,
-    committee_size: u16,
-    committee_threshold: u16,
     fee_rate: &FeeRate,
-    subnet_id: &SubnetId,
-    public_keys: &[XOnlyPublicKey],
 ) -> Result<bitcoin::Psbt, MultisigError> {
     trace!(
         "Creating multisig spend PSBT for address={}, amount={}",
@@ -314,16 +316,19 @@ pub fn construct_spend_psbt(
         &amount
     );
 
-    let secp = Secp256k1::new();
+    let committee_size: u16 = committee_keys
+        .len()
+        .try_into()
+        .map_err(|_| MultisigError::PsbtError("Committee size too large".to_string()))?;
 
     // First construct the unsigned transaction
     let unsigned_tx = construct_spend_unsigned_transaction(
-        to,
-        amount,
-        unspent,
-        committee_change_address,
         committee_size,
         committee_threshold,
+        committee_change_address,
+        unspent,
+        to,
+        amount,
         fee_rate,
     )?;
 
@@ -331,129 +336,186 @@ pub fn construct_spend_psbt(
     let mut psbt = bitcoin::psbt::Psbt::from_unsigned_tx(unsigned_tx.clone())
         .map_err(|e| MultisigError::CoinSelectionFailed(format!("Failed to create PSBT: {}", e)))?;
 
-    // Create the script that will be used for spending
-    let required_sigs = committee_threshold as i64;
-    let script = create_multisig_script(public_keys, required_sigs)?;
-    let leaf_version = bitcoin::taproot::LeafVersion::TapScript;
+    let script = create_multisig_script(committee_keys, committee_threshold.into())?;
 
     // Get the spend info for the multisig
-    let spend_info =
-        create_subnet_multisig_spend_info(&secp, subnet_id, public_keys, required_sigs)?;
+    let spend_info = create_subnet_multisig_spend_info(
+        secp,
+        subnet_id,
+        committee_keys,
+        committee_threshold.into(),
+    )?;
 
     // Create the control block
     let control_block = spend_info
-        .control_block(&(script.clone(), leaf_version))
-        .ok_or_else(|| MultisigError::TaprootBuilderNotFinalizable)?;
+        .control_block(&(script.clone(), LeafVersion::TapScript))
+        .ok_or(MultisigError::TaprootBuilderNotFinalizable)?;
 
-    psbt.inputs = psbt
-        .inputs
-        .into_iter()
-        .enumerate()
-        .map(|(psbt_input_index, mut psbt_input)| {
-            // Find the matching UTXO from our list
-            let utxo = unspent
-                .iter()
-                .find(|u| {
-                    u.txid == unsigned_tx.input[psbt_input_index].previous_output.txid
-                        && u.vout == unsigned_tx.input[psbt_input_index].previous_output.vout
-                })
-                .ok_or_else(|| format!("Failed to find UTXO for input {}", psbt_input_index))
-                // temp expect
-                .expect("Should find matching UTXO");
+    for (psbt_input_index, psbt_input) in psbt.inputs.iter_mut().enumerate() {
+        // Find the matching UTXO from our list
+        let utxo = unspent
+            .iter()
+            .find(|u| {
+                u.txid == unsigned_tx.input[psbt_input_index].previous_output.txid
+                    && u.vout == unsigned_tx.input[psbt_input_index].previous_output.vout
+            })
+            .ok_or_else(|| {
+                MultisigError::PsbtError(format!(
+                    "Cannot find matching utxo for {psbt_input_index}"
+                ))
+            })?;
 
-            // 1. Witnessable script (the tapscript)
-            psbt_input.witness_script = Some(script.clone());
+        psbt_input.witness_script = Some(script.clone());
 
-            // 2. Taproot-specific fields
-            psbt_input.tap_script_sigs = Default::default();
-            let mut tap_scripts = std::collections::BTreeMap::new();
-            tap_scripts.insert(control_block.clone(), (script.clone(), leaf_version));
-            psbt_input.tap_scripts = tap_scripts;
-            psbt_input.tap_merkle_root = spend_info.merkle_root();
-            psbt_input.tap_internal_key = Some(spend_info.internal_key());
+        // 2. Taproot-specific fields
+        psbt_input.tap_script_sigs = Default::default();
+        let mut tap_scripts = std::collections::BTreeMap::new();
+        tap_scripts.insert(
+            control_block.clone(),
+            (script.clone(), LeafVersion::TapScript),
+        );
+        psbt_input.tap_scripts = tap_scripts;
+        psbt_input.tap_merkle_root = spend_info.merkle_root();
+        psbt_input.tap_internal_key = Some(spend_info.internal_key());
 
-            // 3. Previous UTXO information
-            psbt_input.witness_utxo = Some(TxOut {
-                value: utxo.amount,
-                script_pubkey: utxo.script_pub_key.clone(),
-            });
-
-            psbt_input
-        })
-        .collect();
+        // 3. Previous UTXO information
+        psbt_input.witness_utxo = Some(TxOut {
+            value: utxo.amount,
+            script_pubkey: utxo.script_pub_key.clone(),
+        });
+    }
 
     Ok(psbt)
 }
 
-pub fn sign_psbt(
+pub fn sign_spend_psbt(
     secp: &Secp256k1<All>,
     mut psbt: bitcoin::Psbt,
     keypair: bitcoin::key::Keypair,
 ) -> Result<(bitcoin::Psbt, Vec<bitcoin::taproot::Signature>), MultisigError> {
-    // Create a key provider from our keypair
-    struct SingleKeyProvider {
-        keypair: bitcoin::key::Keypair,
+    let (xonly_pubkey, _parity) = keypair.x_only_public_key();
+    let mut signatures = Vec::new();
+
+    let all_witness_utxos: Vec<TxOut> = psbt
+        .iter_funding_utxos()
+        .collect::<Result<Vec<_>, _>>()
+        .map_err(|e| MultisigError::SigningError(format!("Failed to collect UTXOs: {}", e)))?
+        .into_iter()
+        .cloned()
+        .collect();
+
+    // Create a sighash cache once for the transaction
+    let mut sighash_cache = bitcoin::sighash::SighashCache::new(&psbt.unsigned_tx);
+    let sighash_type = bitcoin::sighash::TapSighashType::Default;
+
+    // For each input in the PSBT
+    for (input_index, input) in psbt.inputs.iter_mut().enumerate() {
+        // dbg!(input_index, &input);
+
+        // We need the script from tap_scripts
+        let (_control_block, (script, _leaf_version)) = match input.tap_scripts.iter().next() {
+            Some(entry) => entry,
+            None => continue,
+        };
+
+        let leaf_hash = script.tapscript_leaf_hash();
+        let prevouts = bitcoin::sighash::Prevouts::All(&all_witness_utxos);
+
+        // Calculate the sighash
+        let sighash = sighash_cache
+            .taproot_script_spend_signature_hash(input_index, &prevouts, leaf_hash, sighash_type)
+            .map_err(|e| {
+                MultisigError::SigningError(format!(
+                    "Failed to create sighash for input {}: {}",
+                    input_index, e
+                ))
+            })?;
+
+        // Create message from sighash
+        let msg =
+            bitcoin::secp256k1::Message::from_digest_slice(sighash.as_ref()).map_err(|e| {
+                MultisigError::SigningError(format!("Failed to create message from sighash: {}", e))
+            })?;
+
+        // Sign the message
+        let signature = secp.sign_schnorr(&msg, &keypair);
+        let signature = bitcoin::taproot::Signature {
+            signature,
+            sighash_type,
+        };
+
+        // Add the signature to the PSBT
+        input
+            .tap_script_sigs
+            .insert((xonly_pubkey, leaf_hash), signature);
+
+        // Add to our returned signatures
+        signatures.push(signature);
     }
 
-    impl bitcoin::psbt::GetKey for SingleKeyProvider {
-        type Error = ();
-
-        fn get_key<C: bitcoin::secp256k1::Signing>(
-            &self,
-            _key_request: bitcoin::psbt::KeyRequest,
-            _secp: &Secp256k1<C>,
-        ) -> Result<Option<bitcoin::key::PrivateKey>, Self::Error> {
-            dbg!(&_key_request);
-
-            let private_key = bitcoin::key::PrivateKey {
-                compressed: true,
-                network: NETWORK.into(),
-                inner: self.keypair.secret_key(),
-            };
-            dbg!(&private_key);
-            Ok(Some(private_key))
-        }
+    if signatures.is_empty() {
+        return Err(MultisigError::SigningError(
+            "No inputs were signed".to_string(),
+        ));
     }
 
-    let key_provider = SingleKeyProvider { keypair };
+    Ok((psbt, signatures))
+}
 
-    // Sign the PSBT using the built-in sign method
-    let signing_result = psbt.sign(&key_provider, secp);
+pub fn finalize_spend_psbt(
+    secp: &Secp256k1<All>,
+    subnet_id: &SubnetId,
+    committee_keys: &[XOnlyPublicKey],
+    committee_threshold: u16,
+    psbt: &bitcoin::Psbt,
+) -> Result<Transaction, MultisigError> {
+    let script = create_multisig_script(committee_keys, committee_threshold.into())?;
+    let leaf_hash = script.tapscript_leaf_hash();
 
-    dbg!(&signing_result);
+    // Get the spend info for the multisig
+    let spend_info = create_subnet_multisig_spend_info(
+        secp,
+        subnet_id,
+        committee_keys,
+        committee_threshold.into(),
+    )?;
 
-    // Process the signing result
-    match signing_result {
-        Ok(_) => {
-            // Collect all the signatures that were added
-            let mut signatures = Vec::new();
-            let (x_only_pubkey, _) = keypair.x_only_public_key();
+    // Create the control block
+    let control_block = spend_info
+        .control_block(&(script.clone(), LeafVersion::TapScript))
+        .ok_or(MultisigError::TaprootBuilderNotFinalizable)?;
 
-            for i in 0..psbt.inputs.len() {
-                // Find signatures for our x-only pubkey for each input
-                for (key_pair, sig) in &psbt.inputs[i].tap_script_sigs {
-                    if key_pair.0 == x_only_pubkey {
-                        // Found a signature by our keypair for this input
-                        signatures.push(sig.clone());
-                        break; // We expect only one signature per input with our keypair
-                    }
-                }
+    let mut finalized_psbt = psbt.clone();
+
+    // Finalize each input in the PSBT
+    for input in finalized_psbt.inputs.iter_mut() {
+        let mut witness = Witness::new();
+
+        for pubkey in committee_keys.iter().rev() {
+            if let Some(sig) = input.tap_script_sigs.get(&(*pubkey, leaf_hash)) {
+                witness.push(sig.signature.serialize());
+            } else {
+                witness.push([]);
             }
-
-            // Return the signed PSBT and the added signatures
-            Ok((psbt, signatures))
         }
-        Err((_, errors)) => {
-            // Log errors
-            for (input_idx, error) in errors.iter() {
-                error!("Error signing input {}: {:?}", input_idx, error);
-            }
 
-            Err(MultisigError::SigningError(
-                "Failed to sign PSBT inputs".to_string(),
-            ))
-        }
+        // Add script and control block
+        witness.push(script.to_bytes());
+        witness.push(control_block.serialize());
+
+        // Set the finalized witness
+        input.final_script_witness = Some(witness);
+        // Clear other fields now that we've finalized
+        input.tap_script_sigs.clear();
+        input.tap_scripts.clear();
     }
+
+    // Extract the transaction
+    let finalized_tx = finalized_psbt
+        .extract_tx()
+        .map_err(|e| MultisigError::PsbtError(format!("Failed to extract transaction: {}", e)))?;
+
+    Ok(finalized_tx)
 }
 
 #[derive(Error, Debug)]
@@ -466,6 +528,12 @@ pub enum MultisigError {
 
     #[error("signing error: {0}")]
     SigningError(String),
+
+    #[error("psbt error: {0}")]
+    PsbtError(String),
+
+    #[error("taproot error: {0}")]
+    SighashTaprootError(#[from] bitcoin::sighash::TaprootError),
 
     #[error("taproot builder is not finalizable")]
     TaprootBuilderNotFinalizable,
@@ -1028,7 +1096,7 @@ mod coin_selection_tests {
 
         let (selected, change) = select_coins(
             target,
-            utxos,
+            &utxos,
             fee_rate,
             base_weight,
             input_weight,
@@ -1058,7 +1126,7 @@ mod coin_selection_tests {
 
         let (selected, change) = select_coins(
             target,
-            utxos,
+            &utxos,
             fee_rate,
             base_weight,
             input_weight,
@@ -1094,7 +1162,7 @@ mod coin_selection_tests {
 
         let result = select_coins(
             target,
-            utxos,
+            &utxos,
             fee_rate,
             base_weight,
             input_weight,
@@ -1137,7 +1205,7 @@ mod coin_selection_tests {
 
         let (selected, _) = select_coins(
             target,
-            utxos,
+            &utxos,
             fee_rate,
             base_weight,
             input_weight,
@@ -1168,7 +1236,7 @@ mod coin_selection_tests {
 
         let result = select_coins(
             target,
-            utxos,
+            &utxos,
             fee_rate,
             base_weight,
             input_weight,
@@ -1211,7 +1279,7 @@ mod coin_selection_tests {
 
         let (selected, change) = select_coins(
             target,
-            utxos,
+            &utxos,
             fee_rate,
             base_weight,
             input_weight,
@@ -1239,12 +1307,14 @@ mod coin_selection_tests {
 }
 
 #[cfg(test)]
-mod sign_psbt_tests {
+mod psbt_tests {
     use super::tests::{generate_keypairs, generate_subnet_id};
     use super::*;
+    use crate::multisig::tests::verify_transaction;
+    use crate::NETWORK;
     use bitcoin::secp256k1::{Message, Secp256k1};
     use bitcoin::sighash::{Prevouts, SighashCache, TapSighashType};
-    use bitcoin::{Amount, Network, TxOut};
+    use bitcoin::{transaction, Amount, OutPoint, Sequence, TxOut, Txid};
     use std::str::FromStr;
 
     #[test]
@@ -1271,7 +1341,7 @@ mod sign_psbt_tests {
             &subnet_id,
             &committee_pubkeys,
             required_sigs,
-            Network::Regtest,
+            NETWORK,
         )
         .unwrap();
 
@@ -1305,21 +1375,21 @@ mod sign_psbt_tests {
         // Construct a PSBT for spending
         let fee_rate = FeeRate::from_sat_per_vb(2).unwrap();
         let psbt = construct_spend_psbt(
-            &destination,
-            spend_amount,
-            &vec![utxo],
-            &multisig_address, // Use the same address for change
-            3,                 // committee size
-            2,                 // required signatures
-            &fee_rate,
+            &secp,
             &subnet_id,
             &committee_pubkeys,
+            2,                 // required signatures
+            &multisig_address, // Use the same address for change
+            &vec![utxo],
+            &destination,
+            spend_amount,
+            &fee_rate,
         )
         .unwrap();
 
         // Sign the PSBT with the first keypair
         let (signed_psbt, signatures) =
-            sign_psbt(&secp, psbt, committee_keypairs[0].clone()).unwrap();
+            sign_spend_psbt(&secp, psbt, committee_keypairs[0]).unwrap();
 
         // Verify we got exactly one signature (one for each input)
         assert_eq!(signatures.len(), 1);
@@ -1367,5 +1437,164 @@ mod sign_psbt_tests {
                 .is_ok(),
             "Schnorr signature verification failed"
         );
+    }
+
+    #[test]
+    fn test_signing_and_spending() {
+        let secp = Secp256k1::new();
+
+        // Generate 3 keypairs for the committee
+        let keypairs = generate_keypairs(3);
+
+        for keypair in keypairs.iter() {
+            let (x_only, parity) = keypair.x_only_public_key();
+            println!(
+                "PK = {}\nP = {:?}\nXPK = {}\nSK = {}\nADDR = {}\n\n",
+                keypair.public_key(),
+                parity,
+                x_only,
+                keypair.secret_key().display_secret(),
+                alloy_primitives::Address::from_raw_public_key(
+                    &keypair.public_key().serialize_uncompressed()[1..]
+                ),
+            );
+        }
+
+        let committee_pubkeys: Vec<XOnlyPublicKey> =
+            keypairs.iter().map(|kp| kp.x_only_public_key().0).collect();
+
+        // Generate a subnet ID
+        let subnet_id = generate_subnet_id();
+
+        // Create a 2-of-3 multisig setup
+        let required_sigs = 2_u16;
+        let script = create_multisig_script(&committee_pubkeys, required_sigs.into()).unwrap();
+
+        // Create multisig address
+        let multisig_address = create_subnet_multisig_address(
+            &secp,
+            &subnet_id,
+            &committee_pubkeys,
+            required_sigs.into(),
+            NETWORK,
+        )
+        .unwrap();
+
+        println!("Multisig address: {}", multisig_address);
+
+        // Create a funding UTXO that sends to our multisig address
+        let funding_amount = Amount::from_sat(100_000);
+
+        // Create the actual funding transaction (for verification later)
+        let funding_tx = Transaction {
+            version: transaction::Version::TWO,
+            lock_time: LockTime::ZERO,
+            input: vec![TxIn {
+                previous_output: OutPoint {
+                    txid: Txid::all_zeros(),
+                    vout: 0,
+                },
+                script_sig: ScriptBuf::new(),
+                sequence: Sequence::MAX,
+                witness: Witness::new(),
+            }],
+            output: vec![TxOut {
+                value: funding_amount,
+                script_pubkey: multisig_address.script_pubkey(),
+            }],
+        };
+
+        let utxo = bitcoincore_rpc::json::ListUnspentResultEntry {
+            txid: funding_tx.compute_txid(),
+            vout: 0,
+            address: None,
+            label: None,
+            redeem_script: None,
+            witness_script: None,
+            script_pub_key: multisig_address.script_pubkey(),
+            amount: funding_amount,
+            confirmations: 1,
+            spendable: true,
+            solvable: true,
+            descriptor: None,
+            safe: true,
+        };
+
+        // Destination for the spending transaction
+        let destination = Address::from_str("bcrt1qrj2fz0jj45y5gx9nawgmpyzegnn828vzvletjm")
+            .unwrap()
+            .assume_checked();
+        let spend_amount = Amount::from_sat(90_000);
+
+        // Create a PSBT to spend from the multisig
+        let fee_rate = FeeRate::from_sat_per_vb(2).unwrap();
+        let unsigned_psbt = construct_spend_psbt(
+            &secp,
+            &subnet_id,
+            &committee_pubkeys,
+            2,                 // required signatures
+            &multisig_address, // Use the same address for change
+            &vec![utxo.clone()],
+            &destination,
+            spend_amount,
+            &fee_rate,
+        )
+        .unwrap();
+
+        // dbg!(&unsigned_psbt);
+
+        // Sign with first keypair
+        let (psbt_signed_once, sigs1) = sign_spend_psbt(&secp, unsigned_psbt, keypairs[0])
+            .expect("First signature should work");
+
+        println!("Signed with first keypair");
+        assert_eq!(sigs1.len(), 1);
+
+        // Sign with second keypair
+        let (psbt_signed_twice, sigs2) = sign_spend_psbt(&secp, psbt_signed_once, keypairs[1])
+            .expect("Second signature should work");
+
+        println!("Signed with second keypair");
+        assert_eq!(sigs2.len(), 1);
+
+        // Verify the signatures are for the correct pubkeys
+        let (xonly_pubkey1, _) = keypairs[0].x_only_public_key();
+        let (xonly_pubkey2, _) = keypairs[1].x_only_public_key();
+
+        // Check that signatures for both pubkeys exist in the PSBT
+        let leaf_hash = script.tapscript_leaf_hash();
+
+        assert!(psbt_signed_twice.inputs[0]
+            .tap_script_sigs
+            .contains_key(&(xonly_pubkey1, leaf_hash)));
+        assert!(psbt_signed_twice.inputs[0]
+            .tap_script_sigs
+            .contains_key(&(xonly_pubkey2, leaf_hash)));
+
+        //
+        // Finalize the PSBT
+        //
+
+        let finalized_tx = finalize_spend_psbt(
+            &secp,
+            &subnet_id,
+            &committee_pubkeys,
+            required_sigs.try_into().unwrap(),
+            &psbt_signed_twice,
+        )
+        .expect("Failed to finalize PSBT");
+
+        dbg!(&finalized_tx);
+
+        // Verify the finalized transaction can spend the UTXO
+        let verify_result =
+            verify_transaction(&finalized_tx, |_| Some(funding_tx.output[0].clone()));
+
+        assert!(
+            verify_result.is_ok(),
+            "Transaction should be valid with 2 of 3 signatures: {:?}",
+            verify_result
+        );
+        println!("Transaction successfully verified with 2-of-3 signatures!");
     }
 }

--- a/src/multisig.rs
+++ b/src/multisig.rs
@@ -518,6 +518,43 @@ pub fn finalize_spend_psbt(
     Ok(finalized_tx)
 }
 
+pub fn finalize_spend_psbt_from_sigs(
+    secp: &Secp256k1<All>,
+    subnet_id: &SubnetId,
+    committee_keys: &[XOnlyPublicKey],
+    committee_threshold: u16,
+    psbt: &bitcoin::Psbt,
+    signature_sets: &[&[bitcoin::taproot::Signature]],
+) -> Result<Transaction, MultisigError> {
+    let mut signed_psbt = psbt.clone();
+
+    let script = create_multisig_script(&committee_keys, committee_threshold.into()).unwrap();
+    let leaf_hash = script.tapscript_leaf_hash();
+
+    for (xonly_pubkey, signatures) in committee_keys.iter().zip(signature_sets.iter()) {
+        // For each input this signer has signed
+        for (input_idx, signature) in signatures.iter().enumerate() {
+            // Make sure we don't go out of bounds
+            if input_idx < signed_psbt.inputs.len() {
+                // Add the signature to the PSBT
+                signed_psbt.inputs[input_idx]
+                    .tap_script_sigs
+                    .insert((*xonly_pubkey, leaf_hash), *signature);
+            }
+        }
+    }
+
+    let finalized_psbt = finalize_spend_psbt(
+        &secp,
+        &subnet_id,
+        &committee_keys,
+        committee_threshold,
+        &signed_psbt,
+    )?;
+
+    Ok(finalized_psbt)
+}
+
 #[derive(Error, Debug)]
 pub enum MultisigError {
     #[error("insufficient public keys provided")]
@@ -570,21 +607,30 @@ mod tests {
         S: FnMut(&OutPoint) -> Option<TxOut>,
     {
         let serialized_tx = encode::serialize(tx);
-        for (idx, input) in tx.input.iter().enumerate() {
+
+        // First, collect all UTXOs being spent in this transaction
+        let mut all_spent_utxos = Vec::with_capacity(tx.input.len());
+        for input in &tx.input {
             if let Some(output) = spent(&input.previous_output) {
-                // duplicating the same output because bitcoinconsensus is weird
-                // this is needed for taproot verification
-                let spent_utxo = bitcoinconsensus::Utxo {
+                all_spent_utxos.push(bitcoinconsensus::Utxo {
                     script_pubkey: output.script_pubkey.as_bytes().as_ptr(),
                     script_pubkey_len: output.script_pubkey.len() as u32,
                     value: output.value.to_sat() as i64,
-                };
+                });
+            } else {
+                println!("Unknown spent output: {:?}", input.previous_output);
+                panic!("Unknown spent output");
+            }
+        }
 
+        for (idx, input) in tx.input.iter().enumerate() {
+            // Get the current input's UTXO for the first argument
+            if let Some(output) = spent(&input.previous_output) {
                 bitcoinconsensus::verify_with_flags(
                     output.script_pubkey.as_bytes(),
                     output.value.to_sat(),
                     serialized_tx.as_slice(),
-                    Some(&[spent_utxo]),
+                    Some(&all_spent_utxos),
                     idx,
                     bitcoinconsensus::VERIFY_ALL_PRE_TAPROOT | bitcoinconsensus::VERIFY_TAPROOT,
                 )?;
@@ -1596,5 +1642,186 @@ mod psbt_tests {
             verify_result
         );
         println!("Transaction successfully verified with 2-of-3 signatures!");
+    }
+
+    #[test]
+    fn test_parallel_signing_and_spending() {
+        let secp = Secp256k1::new();
+
+        // Generate 3 keypairs for the committee
+        let keypairs = generate_keypairs(3);
+        let committee_pubkeys: Vec<XOnlyPublicKey> =
+            keypairs.iter().map(|kp| kp.x_only_public_key().0).collect();
+
+        // Generate a subnet ID
+        let subnet_id = generate_subnet_id();
+
+        // Create a 2-of-3 multisig setup
+        let required_sigs = 2_u16;
+
+        // Create multisig address
+        let multisig_address = create_subnet_multisig_address(
+            &secp,
+            &subnet_id,
+            &committee_pubkeys,
+            required_sigs.into(),
+            NETWORK,
+        )
+        .unwrap();
+
+        println!("Multisig address: {}", multisig_address);
+
+        // Create two funding UTXOs that send to our multisig address
+        let funding_amount1 = Amount::from_sat(70_000);
+        let funding_amount2 = Amount::from_sat(60_000);
+
+        // Create the first funding transaction (for verification later)
+        let funding_tx1 = Transaction {
+            version: transaction::Version::TWO,
+            lock_time: LockTime::ZERO,
+            input: vec![TxIn {
+                previous_output: OutPoint {
+                    txid: Txid::all_zeros(),
+                    vout: 0,
+                },
+                script_sig: ScriptBuf::new(),
+                sequence: Sequence::MAX,
+                witness: Witness::new(),
+            }],
+            output: vec![TxOut {
+                value: funding_amount1,
+                script_pubkey: multisig_address.script_pubkey(),
+            }],
+        };
+
+        // Create the second funding transaction
+        let funding_tx2 = Transaction {
+            version: transaction::Version::TWO,
+            lock_time: LockTime::ZERO,
+            input: vec![TxIn {
+                previous_output: OutPoint {
+                    txid: Txid::from_str(
+                        "1111111111111111111111111111111111111111111111111111111111111111",
+                    )
+                    .unwrap(),
+                    vout: 0,
+                },
+                script_sig: ScriptBuf::new(),
+                sequence: Sequence::MAX,
+                witness: Witness::new(),
+            }],
+            output: vec![TxOut {
+                value: funding_amount2,
+                script_pubkey: multisig_address.script_pubkey(),
+            }],
+        };
+
+        let utxos = vec![
+            bitcoincore_rpc::json::ListUnspentResultEntry {
+                txid: funding_tx1.compute_txid(),
+                vout: 0,
+                address: None,
+                label: None,
+                redeem_script: None,
+                witness_script: None,
+                script_pub_key: multisig_address.script_pubkey(),
+                amount: funding_amount1,
+                confirmations: 1,
+                spendable: true,
+                solvable: true,
+                descriptor: None,
+                safe: true,
+            },
+            bitcoincore_rpc::json::ListUnspentResultEntry {
+                txid: funding_tx2.compute_txid(),
+                vout: 0,
+                address: None,
+                label: None,
+                redeem_script: None,
+                witness_script: None,
+                script_pub_key: multisig_address.script_pubkey(),
+                amount: funding_amount2,
+                confirmations: 1,
+                spendable: true,
+                solvable: true,
+                descriptor: None,
+                safe: true,
+            },
+        ];
+
+        // Destination for the spending transaction
+        let destination = Address::from_str("bcrt1qrj2fz0jj45y5gx9nawgmpyzegnn828vzvletjm")
+            .unwrap()
+            .assume_checked();
+        let spend_amount = Amount::from_sat(90_000);
+
+        // Create a PSBT to spend from the multisig
+        let fee_rate = FeeRate::from_sat_per_vb(2).unwrap();
+        let unsigned_psbt = construct_spend_psbt(
+            &secp,
+            &subnet_id,
+            &committee_pubkeys,
+            2,                 // required signatures
+            &multisig_address, // Use the same address for change
+            &utxos,
+            &destination,
+            spend_amount,
+            &fee_rate,
+        )
+        .unwrap();
+
+        // Verify the PSBT has two inputs (one for each UTXO)
+        assert_eq!(unsigned_psbt.inputs.len(), 2, "PSBT should have two inputs");
+
+        // Clone the unsigned PSBT for each signer
+        let unsigned_psbt_for_signer1 = unsigned_psbt.clone();
+        let unsigned_psbt_for_signer2 = unsigned_psbt.clone();
+
+        // Each signer signs their own copy of the PSBT independently
+        let (_, sigs1) = sign_spend_psbt(&secp, unsigned_psbt_for_signer1, keypairs[0])
+            .expect("First signature should work");
+
+        let (_, sigs2) = sign_spend_psbt(&secp, unsigned_psbt_for_signer2, keypairs[1])
+            .expect("Second signature should work");
+
+        println!("Signed independently with two keypairs");
+
+        // Verify we have signatures for both inputs
+        assert_eq!(sigs1.len(), 2, "First signer should sign both inputs");
+        assert_eq!(sigs2.len(), 2, "Second signer should sign both inputs");
+
+        // Create a fresh PSBT and manually add all signatures
+        let finalized_tx = finalize_spend_psbt_from_sigs(
+            &secp,
+            &subnet_id,
+            &committee_pubkeys,
+            required_sigs,
+            &unsigned_psbt,
+            &[&sigs1, &sigs2],
+        )
+        .expect("should finalize");
+
+        // Verify the finalized transaction can spend the UTXO
+        let verify_result = verify_transaction(&finalized_tx, |outpoint| {
+            dbg!(&outpoint);
+            dbg!(funding_tx1.compute_txid());
+            dbg!(funding_tx2.compute_txid());
+
+            if outpoint.txid == funding_tx1.compute_txid() && outpoint.vout == 0 {
+                Some(funding_tx1.output[0].clone())
+            } else if outpoint.txid == funding_tx2.compute_txid() && outpoint.vout == 0 {
+                Some(funding_tx2.output[0].clone())
+            } else {
+                None
+            }
+        });
+
+        assert!(
+            verify_result.is_ok(),
+            "Transaction should be valid with signatures collected in parallel: {:?}",
+            verify_result
+        );
+
+        println!("Transaction successfully verified with signatures collected in parallel!");
     }
 }

--- a/src/provider/rpc.rs
+++ b/src/provider/rpc.rs
@@ -474,6 +474,5 @@ pub fn make_rpc_server(server_data: Arc<ServerData>) -> RpcServer {
         .with_method("getrootnetmessages", get_rootnet_messages)
         // multisig
         .with_method("genmultisigspendpsbt", gen_multisig_spend_psbt)
-        .with_method("signmultisigspendpsbt", gen_multisig_spend_psbt)
         .finish()
 }

--- a/src/provider/rpc.rs
+++ b/src/provider/rpc.rs
@@ -67,6 +67,7 @@ pub struct ServerData {
     pub db: Arc<HeedDb>,
     pub btc_rpc: Arc<Client>,
     pub btc_watchonly_rpc: Arc<Client>,
+    pub validator_sk: bitcoin::secp256k1::SecretKey,
 }
 
 //

--- a/src/provider/rpc.rs
+++ b/src/provider/rpc.rs
@@ -1,10 +1,14 @@
 use crate::{
-    bitcoin_utils::get_confirmed_from_height,
-    db::{self, Database, HeedDb},
-    ipc_lib::{IpcFundSubnetMsg, IpcJoinSubnetMsg, IpcPrefundSubnetMsg, IpcValidate, SubnetId},
-    IpcCreateSubnetMsg, NETWORK,
+    bitcoin_utils,
+    db::{self, Database},
+    ipc_lib::{
+        IpcCreateSubnetMsg, IpcFundSubnetMsg, IpcJoinSubnetMsg, IpcPrefundSubnetMsg, IpcValidate,
+        SubnetId,
+    },
+    multisig, NETWORK,
 };
 use base64::{engine::general_purpose::STANDARD as BASE64_STANDARD, Engine};
+use bitcoin::hashes::Hash;
 use bitcoincore_rpc::{Client, RpcApi};
 use jsonrpc_v2::{Data, Error as JsonRpcError, ErrorLike, MapRouter, Params};
 use log::{error, trace};
@@ -64,7 +68,7 @@ impl actix_web::error::ResponseError for RpcError {
 // TODO use generics
 #[derive(Clone)]
 pub struct ServerData {
-    pub db: Arc<HeedDb>,
+    pub db: Arc<db::HeedDb>,
     pub btc_rpc: Arc<Client>,
     pub btc_watchonly_rpc: Arc<Client>,
     pub validator_sk: bitcoin::secp256k1::SecretKey,
@@ -105,14 +109,15 @@ pub async fn get_confirmed_block_height(data: Data<Arc<ServerData>>) -> Result<u
 
     match client.get_block_count() {
         Ok(current_height) => {
-            let confirmed_block_height = match get_confirmed_from_height(current_height) {
-                Some(height) => height,
-                None => {
-                    return Err(JsonRpcError::internal(
-                        "Not enough blocks to have a confirmed block",
-                    ))
-                }
-            };
+            let confirmed_block_height =
+                match bitcoin_utils::get_confirmed_from_height(current_height) {
+                    Some(height) => height,
+                    None => {
+                        return Err(JsonRpcError::internal(
+                            "Not enough blocks to have a confirmed block",
+                        ))
+                    }
+                };
             Ok(confirmed_block_height)
         }
         Err(e) => Err(JsonRpcError::internal(e)),
@@ -345,7 +350,7 @@ pub async fn get_rootnet_messages(
         })
 }
 
-#[derive(Serialize, Deserialize)]
+#[derive(Serialize, Deserialize, Debug)]
 pub struct GenMultisigSpendPsbtParams {
     subnet_id: SubnetId,
     recipient: bitcoin::Address<bitcoin::address::NetworkUnchecked>,
@@ -355,14 +360,18 @@ pub struct GenMultisigSpendPsbtParams {
 
 #[derive(Serialize, Deserialize)]
 pub struct GenMultisigSpendPsbtResponse {
-    psbt: bitcoin::Psbt,
-    psbt_base64: String,
+    unsigned_psbt: bitcoin::Psbt,
+    unsigned_psbt_base64: String,
+    unsigned_psbt_hash: bitcoin::hashes::sha256::Hash,
+    psbt_inputs_signatures: Vec<bitcoin::secp256k1::schnorr::Signature>,
 }
 
 pub async fn gen_multisig_spend_psbt(
     data: Data<Arc<ServerData>>,
     Params(params): Params<GenMultisigSpendPsbtParams>,
 ) -> Result<GenMultisigSpendPsbtResponse, JsonRpcError> {
+    trace!("gen_multisig_spend_psbt: {:?}", params);
+
     // Check subnet exists
     let subnet = data
         .db
@@ -380,25 +389,71 @@ pub async fn gen_multisig_spend_psbt(
         RpcError::InvalidParams(format!("Invalid address network, required {NETWORK}"))
     })?;
 
-    let psbt = subnet
+    let committee_address = subnet
         .committee
-        .construct_spend_psbt(
-            &data.btc_watchonly_rpc,
-            &params.subnet_id,
-            &recipient,
-            params.amount,
-        )
-        .map_err(|e| {
-            error!(
-                "Error generating multisig spend psbt for subnet_id={}: {}",
-                &params.subnet_id, e
-            );
-            RpcError::InternalError(e.to_string())
-        })?;
+        .multisig_address
+        .clone()
+        .require_network(NETWORK)
+        .expect("Multisig should be valid for saved subnet genesis info");
+    let committee_keys = subnet
+        .committee
+        .validators
+        .iter()
+        .map(|v| v.pubkey)
+        .collect::<Vec<_>>();
+    let commitee_threshold = subnet.committee.threshold;
 
-    let psbt_base64 = BASE64_STANDARD.encode(psbt.serialize());
+    let unspent = subnet
+        .committee
+        .get_unspent(&data.btc_watchonly_rpc)
+        .map_err(|e| RpcError::InternalError(e.to_string()))?;
 
-    Ok(GenMultisigSpendPsbtResponse { psbt, psbt_base64 })
+    let fee_rate = bitcoin_utils::get_fee_rate(&data.btc_watchonly_rpc, None, None);
+
+    let secp = bitcoin::secp256k1::Secp256k1::new();
+
+    let unsigned_psbt = multisig::construct_spend_psbt(
+        &secp,
+        &params.subnet_id,
+        &committee_keys,
+        commitee_threshold,
+        &committee_address,
+        &unspent,
+        &recipient,
+        params.amount,
+        &fee_rate,
+    )
+    .map_err(|e| {
+        error!(
+            "Error generating multisig spend psbt for subnet_id={}: {}",
+            &params.subnet_id, e
+        );
+        RpcError::InternalError(e.to_string())
+    })?;
+
+    let validator_keypair = data.validator_sk.keypair(&secp);
+
+    let (_, psbt_inputs_signatures) =
+        multisig::sign_spend_psbt(&secp, unsigned_psbt.clone(), validator_keypair).map_err(
+            |e| {
+                error!(
+                    "Error signing multisig spend psbt for subnet_id={}: {}",
+                    &params.subnet_id, e
+                );
+                RpcError::InternalError(e.to_string())
+            },
+        )?;
+
+    let unsigned_psbt_bytes = unsigned_psbt.serialize();
+    let unsigned_psbt_hash = bitcoin::hashes::sha256::Hash::hash(&unsigned_psbt_bytes);
+    let unsigned_psbt_base64 = BASE64_STANDARD.encode(unsigned_psbt_bytes);
+
+    Ok(GenMultisigSpendPsbtResponse {
+        unsigned_psbt_base64,
+        unsigned_psbt_hash,
+        psbt_inputs_signatures,
+        unsigned_psbt,
+    })
 }
 
 pub fn make_rpc_server(server_data: Arc<ServerData>) -> RpcServer {
@@ -419,5 +474,6 @@ pub fn make_rpc_server(server_data: Arc<ServerData>) -> RpcServer {
         .with_method("getrootnetmessages", get_rootnet_messages)
         // multisig
         .with_method("genmultisigspendpsbt", gen_multisig_spend_psbt)
+        .with_method("signmultisigspendpsbt", gen_multisig_spend_psbt)
         .finish()
 }


### PR DESCRIPTION
This PR adds code needed to sign and finalize a PSBT, making a spending transaction ready to be posted. Nothing to test, you can look at the tests and see how it would generally work.

**EDIT:** Added validator key to `.env` so you get back the signature for the multisig spend psbt.

Connected to #74, look at the `genmultisigspendpsbt` request in curl reqs to test it. What you get back now is the following:

```json
{
  "jsonrpc": "2.0",
  "result": {
    "unsigned_psbt": {
      "unsigned_tx": {
        "version": 2,
        "lock_time": 0,
        "input": [
          {
            "previous_output": "ebe5a4ba4d891fa033d1d06e2a141641e1404526278c0f114f2dc81826dbecc9:1",
            "script_sig": "",
            "sequence": 4294967295,
            "witness": []
          },
          {
            "previous_output": "e290a81d5a28d18e1aa9b064334eaae8c4d5258a1162df13bb1f3e2e7247dc77:1",
            "script_sig": "",
            "sequence": 4294967295,
            "witness": []
          }
        ],
        "output": [
          {
            "value": 1000000000,
            "script_pubkey": "0014885d432461b9ce0436bc76dc8750d7d3e61d6db8"
          },
          {
            "value": 399996325,
            "script_pubkey": "512062a5334e31b8ab5f3bb297ca44d6f6d6aa0eac9f6ac8eb2d2252dde4a866d180"
          }
        ]
      },
      "version": 0,
      "xpub": {},
      "proprietary": [],
      "unknown": [],
      "inputs": [
        {
          "non_witness_utxo": null,
          "witness_utxo": {
            "value": 800000000,
            "script_pubkey": "512062a5334e31b8ab5f3bb297ca44d6f6d6aa0eac9f6ac8eb2d2252dde4a866d180"
          },
          "partial_sigs": {},
          "sighash_type": null,
          "redeem_script": null,
          "witness_script": "205f0dfed3a527ac740c7d4a594cd3aa1059a936187399fc49e3fc6ea6ae177268ac20851c1bda327584479e98a7c28ea7adc097d290efd105310bcf714231bb99faf4ba20b15f99928f2478a10c5739a03f5495d342e77352d624e7cc8ebfbded544f9ac0ba20b45fd52573e8e6bfe0aff82fb228e887fdd92210fe0952ae65a59080fec7e529ba53a2",
          "bip32_derivation": [],
          "final_script_sig": null,
          "final_script_witness": null,
          "ripemd160_preimages": {},
          "sha256_preimages": {},
          "hash160_preimages": {},
          "hash256_preimages": {},
          "tap_key_sig": null,
          "tap_script_sigs": [],
          "tap_scripts": [
            [
              {
                "leaf_version": 192,
                "output_key_parity": 1,
                "internal_key": "79be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81799",
                "merkle_branch": [
                  "045906ce33546aa5aff6d43249d04245182f9498aba14979e0e8641b56d30e02"
                ]
              },
              [
                "205f0dfed3a527ac740c7d4a594cd3aa1059a936187399fc49e3fc6ea6ae177268ac20851c1bda327584479e98a7c28ea7adc097d290efd105310bcf714231bb99faf4ba20b15f99928f2478a10c5739a03f5495d342e77352d624e7cc8ebfbded544f9ac0ba20b45fd52573e8e6bfe0aff82fb228e887fdd92210fe0952ae65a59080fec7e529ba53a2",
                192
              ]
            ]
          ],
          "tap_key_origins": [],
          "tap_internal_key": "79be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81799",
          "tap_merkle_root": "984242492b8dfa69c67d88a84c3c64af1bf9eb8723d3c805d4093356870dc480",
          "proprietary": [],
          "unknown": []
        },
        {
          "non_witness_utxo": null,
          "witness_utxo": {
            "value": 600000000,
            "script_pubkey": "512062a5334e31b8ab5f3bb297ca44d6f6d6aa0eac9f6ac8eb2d2252dde4a866d180"
          },
          "partial_sigs": {},
          "sighash_type": null,
          "redeem_script": null,
          "witness_script": "205f0dfed3a527ac740c7d4a594cd3aa1059a936187399fc49e3fc6ea6ae177268ac20851c1bda327584479e98a7c28ea7adc097d290efd105310bcf714231bb99faf4ba20b15f99928f2478a10c5739a03f5495d342e77352d624e7cc8ebfbded544f9ac0ba20b45fd52573e8e6bfe0aff82fb228e887fdd92210fe0952ae65a59080fec7e529ba53a2",
          "bip32_derivation": [],
          "final_script_sig": null,
          "final_script_witness": null,
          "ripemd160_preimages": {},
          "sha256_preimages": {},
          "hash160_preimages": {},
          "hash256_preimages": {},
          "tap_key_sig": null,
          "tap_script_sigs": [],
          "tap_scripts": [
            [
              {
                "leaf_version": 192,
                "output_key_parity": 1,
                "internal_key": "79be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81799",
                "merkle_branch": [
                  "045906ce33546aa5aff6d43249d04245182f9498aba14979e0e8641b56d30e02"
                ]
              },
              [
                "205f0dfed3a527ac740c7d4a594cd3aa1059a936187399fc49e3fc6ea6ae177268ac20851c1bda327584479e98a7c28ea7adc097d290efd105310bcf714231bb99faf4ba20b15f99928f2478a10c5739a03f5495d342e77352d624e7cc8ebfbded544f9ac0ba20b45fd52573e8e6bfe0aff82fb228e887fdd92210fe0952ae65a59080fec7e529ba53a2",
                192
              ]
            ]
          ],
          "tap_key_origins": [],
          "tap_internal_key": "79be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81799",
          "tap_merkle_root": "984242492b8dfa69c67d88a84c3c64af1bf9eb8723d3c805d4093356870dc480",
          "proprietary": [],
          "unknown": []
        }
      ],
      "outputs": [
        {
          "redeem_script": null,
          "witness_script": null,
          "bip32_derivation": [],
          "tap_internal_key": null,
          "tap_tree": null,
          "tap_key_origins": [],
          "proprietary": [],
          "unknown": []
        },
        {
          "redeem_script": null,
          "witness_script": null,
          "bip32_derivation": [],
          "tap_internal_key": null,
          "tap_tree": null,
          "tap_key_origins": [],
          "proprietary": [],
          "unknown": []
        }
      ]
    },
    "unsigned_psbt_base64": "cHNidP8BAKYCAAAAAsns2yYYyC1PEQ+MJyZFQOFBFhQqbtDRM6AfiU26pOXrAQAAAAD/////d9xHci4+H7sT32IRiiXVxOiqTjNksKkajtEoWh2okOIBAAAAAP////8CAMqaOwAAAAAWABSIXUMkYbnOBDa8dtyHUNfT5h1tuKV11xcAAAAAIlEgYqUzTjG4q187spfKRNb21qoOrJ9qyOstIlLd5Khm0YAAAAAAAAEBKwAIry8AAAAAIlEgYqUzTjG4q187spfKRNb21qoOrJ9qyOstIlLd5Khm0YABBYogXw3+06UnrHQMfUpZTNOqEFmpNhhzmfxJ4/xupq4XcmisIIUcG9oydYRHnpinwo6nrcCX0pDv0QUxC89xQjG7mfr0uiCxX5mSjyR4oQxXOaA/VJXTQudzUtYk58yOv73tVE+awLogtF/VJXPo5r/gr/gvsijoh/3ZIhD+CVKuZaWQgP7H5Sm6U6JCFcF5vmZ++dy7rFWgYpXOhwsHApv82y3OKNlZ8oFbFvgXmQRZBs4zVGqlr/bUMknQQkUYL5SYq6FJeeDoZBtW0w4CiyBfDf7TpSesdAx9SllM06oQWak2GHOZ/Enj/G6mrhdyaKwghRwb2jJ1hEeemKfCjqetwJfSkO/RBTELz3FCMbuZ+vS6ILFfmZKPJHihDFc5oD9UldNC53NS1iTnzI6/ve1UT5rAuiC0X9Ulc+jmv+Cv+C+yKOiH/dkiEP4JUq5lpZCA/sflKbpTosABFyB5vmZ++dy7rFWgYpXOhwsHApv82y3OKNlZ8oFbFvgXmQEYIJhCQkkrjfppxn2IqEw8ZK8b+euHI9PIBdQJM1aHDcSAAAEBKwBGwyMAAAAAIlEgYqUzTjG4q187spfKRNb21qoOrJ9qyOstIlLd5Khm0YABBYogXw3+06UnrHQMfUpZTNOqEFmpNhhzmfxJ4/xupq4XcmisIIUcG9oydYRHnpinwo6nrcCX0pDv0QUxC89xQjG7mfr0uiCxX5mSjyR4oQxXOaA/VJXTQudzUtYk58yOv73tVE+awLogtF/VJXPo5r/gr/gvsijoh/3ZIhD+CVKuZaWQgP7H5Sm6U6JCFcF5vmZ++dy7rFWgYpXOhwsHApv82y3OKNlZ8oFbFvgXmQRZBs4zVGqlr/bUMknQQkUYL5SYq6FJeeDoZBtW0w4CiyBfDf7TpSesdAx9SllM06oQWak2GHOZ/Enj/G6mrhdyaKwghRwb2jJ1hEeemKfCjqetwJfSkO/RBTELz3FCMbuZ+vS6ILFfmZKPJHihDFc5oD9UldNC53NS1iTnzI6/ve1UT5rAuiC0X9Ulc+jmv+Cv+C+yKOiH/dkiEP4JUq5lpZCA/sflKbpTosABFyB5vmZ++dy7rFWgYpXOhwsHApv82y3OKNlZ8oFbFvgXmQEYIJhCQkkrjfppxn2IqEw8ZK8b+euHI9PIBdQJM1aHDcSAAAAA",
    "unsigned_psbt_hash": "044fd24f327c42565ae82030923b955598c3773e4019211ba5f98622373286d5",
    "psbt_inputs_signatures": [
      "46964b5564cf31bbef98780f0cb5c5cb76bec06f23af35a13340188ac03e50ca7d7d31354d2a65438d183694f00565c09aff9f7522a864d45f9fbef1c04c0cfe",
      "0c94f920360f95d33624ee28e040228ba62bf8d3e018dac1247c31fbb899e946428e5067fa98321532855afb7ee116a94309ba9d511f5e38abff60b7e9d76edf"
    ]
  },
  "id": 1
}
```

The signatures is an array of schnoor signatures for each input. You can see the `unsigned_psbt_hash` which I envision will be useful for collection of signatures, to make sure the validators are signing the same psbt.

Part of https://github.com/bitcoinscalinglabs/bitcoin-ipc/issues/41