### PR TITLE
Process side effects after syncing and processing new blocks

### DIFF
--- a/internal/checkpoint_subnet.sh
+++ b/internal/checkpoint_subnet.sh
@@ -44,7 +44,7 @@ RANDOM_HASH=$(openssl rand -hex 32)
 CURRENT_BLOCK=$(bitcoin-cli getblockcount)
 BLOCK_HASH=$(bitcoin-cli getblockhash "$CURRENT_BLOCK")
 
-DESTINATION_SUBNET_ID_1="/b4/t410fj6mjiujytgrenfyxeyvlxcudynxik4hvbb6u2pa"
+DESTINATION_SUBNET_ID_1="/b4/t410fdmafb4l6rb2cqa5zass2qmdr67drvxejlkvpdca"
 
 echo "Current block: $CURRENT_BLOCK ($BLOCK_HASH)"
 echo "Using checkpoint hash: $RANDOM_HASH"

--- a/internal/curl_reqs.md
+++ b/internal/curl_reqs.md
@@ -130,7 +130,7 @@ curl -X POST http://localhost:3030/api \
     "jsonrpc": "2.0",
     "method": "fundsubnet",
     "params": {
-			"subnet_id": "/b4/t420fmsv2gwpnksrxob6yij4wi6iuu2pg4vowy6xopfembcl6axt5ocqtymspsm",
+			"subnet_id": "/b4/t410fuvtcymuzlxqj4ypvbf7ybk4rdlkq6u4mqtcrybi",
 			"amount": 40000000,
 			"address": "0xbce2f194e9628e6ae06fa0d85dd57cd5579213bf"
     },

--- a/src/bin/monitor.rs
+++ b/src/bin/monitor.rs
@@ -105,6 +105,16 @@ async fn main() {
     info!("Shutting down");
 }
 
+/// Side-effects that need to be executed after processing blocks
+#[derive(Debug)]
+enum SideEffect {
+    ImportAddress {
+        address: bitcoin::Address,
+        label: String,
+        timestamp: u32, // block.header.time
+    },
+}
+
 // TODO use generics for rpc + add a trait for the monitor
 struct Monitor<D: Database> {
     db: D,
@@ -113,6 +123,7 @@ struct Monitor<D: Database> {
     check_interval: Duration,
     current_height: u64,
     cancel_token: CancellationToken,
+    side_effects: Vec<SideEffect>,
 }
 
 impl<D> Monitor<D>
@@ -133,6 +144,7 @@ where
             check_interval,
             cancel_token,
             current_height: 0,
+            side_effects: Vec::new(),
         }
     }
 
@@ -200,6 +212,9 @@ where
             }
         }
 
+        // Process any collected side effects
+        self.process_side_effects()?;
+
         Ok(true)
     }
 
@@ -244,8 +259,58 @@ where
                 }
             }
 
+            // Process any collected side effects
+            self.process_side_effects()?;
+
             tokio::time::sleep(self.check_interval).await;
         }
+    }
+
+    fn import_watchonly_address(
+        &mut self,
+        address: bitcoin::Address,
+        label: String,
+        timestamp: u32,
+    ) {
+        self.side_effects.push(SideEffect::ImportAddress {
+            address,
+            label,
+            timestamp,
+        });
+    }
+
+    fn process_side_effects(&mut self) -> Result<(), MonitorError> {
+        if self.side_effects.is_empty() {
+            trace!("No side effects to process");
+            return Ok(());
+        }
+        debug!("Processing side effects.");
+
+        // Group import address effects
+        let import_addresses: Vec<(bitcoin::Address, String, u32)> = self
+            .side_effects
+            .iter()
+            .filter_map(|effect| {
+                let SideEffect::ImportAddress {
+                    address,
+                    label,
+                    timestamp,
+                } = effect;
+
+                Some((address.clone(), label.clone(), *timestamp))
+            })
+            .collect();
+
+        if !import_addresses.is_empty() {
+            // Import all addresses in a batch, each with its own timestamp
+            bitcoin_ipc::wallet::import_address_batch(&self.watchonly_rpc, &import_addresses)?;
+
+            debug!("Imported {} addresses in batch.", import_addresses.len());
+        }
+
+        // Clear processed side effects
+        self.side_effects.clear();
+        Ok(())
     }
 
     async fn sync_and_listen(&mut self) -> Result<(), MonitorError> {
@@ -284,13 +349,13 @@ where
         Ok(latest - BTC_CONFIRMATIONS)
     }
 
-    async fn process_block(&self, block_height: u64) -> Result<(), MonitorError> {
+    async fn process_block(&mut self, block_height: u64) -> Result<(), MonitorError> {
         info!("Processing block {}", block_height);
         let block_hash = self.rpc.get_block_hash(block_height)?;
         let block = self.rpc.get_block(&block_hash)?;
 
         for tx in block.txdata {
-            self.process_transaction(&tx, block_height, block_hash)
+            self.process_transaction(&tx, block_height, block_hash, block.header.time)
                 .await?;
         }
 
@@ -298,10 +363,11 @@ where
     }
 
     async fn process_transaction(
-        &self,
+        &mut self,
         tx: &bitcoin::Transaction,
         block_height: u64,
         block_hash: BlockHash,
+        block_time: u32,
     ) -> Result<(), MonitorError> {
         let txid = tx.compute_txid();
         debug!("Processing transaction {}", txid);
@@ -329,7 +395,7 @@ where
                 };
 
                 match self
-                    .process_ipc_msg(block_height, block_hash, tx, txid, ipc_message)
+                    .process_ipc_msg(block_height, block_hash, block_time, tx, txid, ipc_message)
                     .await
                 {
                     Ok(_) => {}
@@ -345,7 +411,7 @@ where
             let ipc_message = IpcMessage::PrefundSubnet(prefund_msg);
 
             match self
-                .process_ipc_msg(block_height, block_hash, tx, txid, ipc_message)
+                .process_ipc_msg(block_height, block_hash, block_time, tx, txid, ipc_message)
                 .await
             {
                 Ok(_) => {}
@@ -355,7 +421,7 @@ where
             let ipc_message = IpcMessage::FundSubnet(fund_msg);
 
             match self
-                .process_ipc_msg(block_height, block_hash, tx, txid, ipc_message)
+                .process_ipc_msg(block_height, block_hash, block_time, tx, txid, ipc_message)
                 .await
             {
                 Ok(_) => {}
@@ -367,7 +433,7 @@ where
             let ipc_message = IpcMessage::CheckpointSubnet(checkpoint_msg);
 
             match self
-                .process_ipc_msg(block_height, block_hash, tx, txid, ipc_message)
+                .process_ipc_msg(block_height, block_hash, block_time, tx, txid, ipc_message)
                 .await
             {
                 Ok(_) => {}
@@ -377,7 +443,7 @@ where
             let ipc_message = IpcMessage::BatchTransfer(batch_transfer_msg);
 
             match self
-                .process_ipc_msg(block_height, block_hash, tx, txid, ipc_message)
+                .process_ipc_msg(block_height, block_hash, block_time, tx, txid, ipc_message)
                 .await
             {
                 Ok(_) => {}
@@ -389,9 +455,10 @@ where
     }
 
     async fn process_ipc_msg(
-        &self,
+        &mut self,
         block_height: u64,
         block_hash: BlockHash,
+        block_time: u32,
         tx: &bitcoin::Transaction,
         txid: bitcoin::Txid,
         msg: IpcMessage,
@@ -404,8 +471,9 @@ where
                 let subnet_genesis_info =
                     create_subnet_msg.save_to_db(&self.db, block_height, txid)?;
 
-                // TODO think about how to handle side-effects in monitor
-                subnet_genesis_info.import_whitelist_address_to_wallet(&self.watchonly_rpc)?;
+                let (whitelist_addr, label) = subnet_genesis_info.whitelist_address_label();
+
+                self.import_watchonly_address(whitelist_addr, label, block_time);
 
                 info!(
                     "Processed CreateSubnet for Subnet ID: {}",
@@ -429,9 +497,9 @@ where
 
                 join_subnet_msg.validate()?;
                 if let Some(subnet) = join_subnet_msg.save_to_db(&self.db, block_height, txid)? {
-                    // TODO think about how to handle side-effects in monitor
                     // Subnet bootstrapped
-                    subnet.import_current_address_to_wallet(&self.watchonly_rpc)?;
+                    let (committee_addr, label) = subnet.committee_address_label();
+                    self.import_watchonly_address(committee_addr, label, block_time);
                 }
 
                 info!(
@@ -475,7 +543,13 @@ where
 
                 let checkpoint_tx = self
                     .watchonly_rpc
-                    .get_transaction(&msg.checkpoint_txid, Some(true))?;
+                    .get_transaction(&msg.checkpoint_txid, Some(true))
+                    .map_err(|e| {
+                        MonitorError::IpcTxInvalid(format!(
+                            "Can't get Checkpoint Txid {} for BatchTransferMsg invalid: {e}",
+                            msg.checkpoint_txid
+                        ))
+                    })?;
 
                 let checkpoint_tx = checkpoint_tx.transaction().map_err(|e| {
                     MonitorError::IpcTxInvalid(format!(

--- a/src/db.rs
+++ b/src/db.rs
@@ -213,16 +213,10 @@ impl SubnetState {
             .expect("Multisig should be valid for saved subnet genesis info")
     }
 
-    /// Imports the subnet multisig address to Bitcoin Core
-    /// as a watch-only address. Bitcoincore will monitor the UTXOs.
-    pub fn import_current_address_to_wallet(
-        &self,
-        rpc: &bitcoincore_rpc::Client,
-    ) -> Result<(), bitcoincore_rpc::Error> {
+    pub fn committee_address_label(&self) -> (bitcoin::Address, String) {
         let address = self.multisig_address();
         let label = format!("{}-{}", self.id, self.committee_number);
-        wallet::import_address(rpc, &address, label)?;
-        Ok(())
+        (address, label)
     }
 
     pub fn is_validator(&self, pubkey: &XOnlyPublicKey) -> bool {
@@ -305,18 +299,10 @@ impl SubnetGenesisInfo {
         .expect("Multisig should be valid for saved subnet genesis info")
     }
 
-    /// Imports the whitelist multisig address to Bitcoin Core
-    /// as a watch-only address. Bitcoincore will monitor the UTXOs.
-    pub fn import_whitelist_address_to_wallet(
-        &self,
-        rpc: &bitcoincore_rpc::Client,
-    ) -> Result<(), bitcoincore_rpc::Error> {
+    pub fn whitelist_address_label(&self) -> (bitcoin::Address, String) {
         let address = self.multisig_address();
-        // Import the subnet whitelist address to the wallet
-        // with a committee number 0
         let label = format!("{}-{}", self.subnet_id, 0);
-        wallet::import_address(rpc, &address, label)?;
-        Ok(())
+        (address, label)
     }
 
     pub fn to_subnet(&self) -> SubnetState {

--- a/src/multisig.rs
+++ b/src/multisig.rs
@@ -497,7 +497,10 @@ pub fn finalize_spend_psbt(
 ) -> Result<Transaction, MultisigError> {
     println!("finalize_spend_psbt");
     let committee_keys = sort_committee_keys(&committee_keys);
-    dbg!(&committee_keys);
+    trace!(
+        "finalize_spend_psbt sorted committee_keys: {:?}",
+        &committee_keys
+    );
 
     let script = create_multisig_script(&committee_keys, committee_threshold)?;
     let leaf_hash = script.tapscript_leaf_hash();

--- a/src/wallet.rs
+++ b/src/wallet.rs
@@ -140,6 +140,48 @@ pub fn import_address(
     Ok(())
 }
 
+pub fn import_address_batch(
+    rpc: &Client,
+    addresses: &[(bitcoin::Address, String, u32)], // (address, label, unix_timestamp)
+) -> Result<Vec<bitcoincore_rpc::json::ImportMultiResult>, bitcoincore_rpc::Error> {
+    use bitcoincore_rpc::json::{ImportDescriptors, Timestamp};
+
+    let json_reqs = addresses
+        .iter()
+        .map(|(address, label, timestamp)| {
+            let raw_descriptor = format!("addr({})", address);
+            let descriptor_info = rpc.get_descriptor_info(&raw_descriptor)?;
+            let descriptor = descriptor_info.descriptor;
+
+            let req = ImportDescriptors {
+                descriptor,
+                label: Some(label.clone()),
+                timestamp: Timestamp::Time((*timestamp).into()),
+                active: None,
+                range: None,
+                next_index: None,
+                internal: None,
+            };
+            Ok(req)
+        })
+        .collect::<Result<Vec<ImportDescriptors>, bitcoincore_rpc::Error>>()?;
+
+    let json_reqs = json_reqs
+        .iter()
+        .map(|r| serde_json::to_value(r))
+        .collect::<Result<Vec<serde_json::Value>, serde_json::Error>>()?;
+
+    let args: [serde_json::Value; 1] = [json_reqs.into()];
+
+    debug!(
+        "Importing {} descriptors into wallet: {}",
+        addresses.len(),
+        args[0]
+    );
+
+    rpc.call("importdescriptors", &args)
+}
+
 #[derive(Error, Debug)]
 pub enum WalletError {
     #[error(transparent)]


### PR DESCRIPTION
Import watchonly addresses in batch after processing. It requires the `txindex=1` which we configure by default.