### PR TITLE
Support joining of new validator

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -49,7 +49,7 @@ dependencies = [
  "mime",
  "percent-encoding",
  "pin-project-lite",
- "rand",
+ "rand 0.8.5",
  "sha1",
  "smallvec",
  "tokio",
@@ -65,7 +65,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e01ed3140b2f8d422c68afa1ed2e85d996ea619c988ac834d255db32138655cb"
 dependencies = [
  "quote",
- "syn 2.0.91",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -182,7 +182,7 @@ dependencies = [
  "actix-router",
  "proc-macro2",
  "quote",
- "syn 2.0.91",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -254,15 +254,15 @@ dependencies = [
 
 [[package]]
 name = "alloy-primitives"
-version = "0.8.19"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec878088ec6283ce1e90d280316aadd3d6ce3de06ff63d68953c855e7e447e92"
+checksum = "70b98b99c1dcfbe74d7f0b31433ff215e7d1555e367d90e62db904f3c9d4ff53"
 dependencies = [
  "alloy-rlp",
  "bytes",
  "cfg-if",
  "const-hex",
- "derive_more 1.0.0",
+ "derive_more 2.0.1",
  "foldhash",
  "hashbrown",
  "indexmap",
@@ -271,7 +271,7 @@ dependencies = [
  "keccak-asm",
  "paste",
  "proptest",
- "rand",
+ "rand 0.9.1",
  "ruint",
  "rustc-hash",
  "serde",
@@ -455,7 +455,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1df2c09229cbc5a028b1d70e00fdb2acee28b1055dfb5ca73eea49c5a25c4e7c"
 dependencies = [
  "num-traits",
- "rand",
+ "rand 0.8.5",
 ]
 
 [[package]]
@@ -465,7 +465,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94893f1e0c6eeab764ade8dc4c0db24caf4fe7cbbaafc0eba0a9030f447b5185"
 dependencies = [
  "num-traits",
- "rand",
+ "rand 0.8.5",
 ]
 
 [[package]]
@@ -488,7 +488,7 @@ checksum = "721cae7de5c34fbb2acd27e21e6d2cf7b886dce0c27388d46c4e6c47ea4318dd"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.91",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -499,7 +499,7 @@ checksum = "e12882f59de5360c748c4cbf569a042d5fb0eb515f7bea9c1f470b47f6ffbd73"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.91",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -600,18 +600,18 @@ dependencies = [
 
 [[package]]
 name = "bit-set"
-version = "0.5.3"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0700ddab506f33b20a03b13996eccd309a48e5ff77d0d95926aa0210fb4e95f1"
+checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
 dependencies = [
  "bit-vec",
 ]
 
 [[package]]
 name = "bit-vec"
-version = "0.6.3"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb"
+checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
 
 [[package]]
 name = "bitcoin"
@@ -670,7 +670,7 @@ dependencies = [
  "log",
  "num-bigint",
  "num-traits",
- "rand",
+ "rand 0.8.5",
  "serde",
  "serde_json",
  "tempfile",
@@ -897,7 +897,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.91",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -1009,7 +1009,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0dc92fb57ca44df6db8059111ab3af99a63d5d0f8375d9972e319a379c6bab76"
 dependencies = [
  "generic-array",
- "rand_core",
+ "rand_core 0.6.4",
  "subtle",
  "zeroize",
 ]
@@ -1047,7 +1047,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1145d32e826a7748b69ee8fc62d3e6355ff7f1051df53141e7048162fc90481b"
 dependencies = [
  "data-encoding",
- "syn 2.0.91",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -1090,27 +1090,27 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustc_version 0.4.1",
- "syn 2.0.91",
+ "syn 2.0.100",
 ]
 
 [[package]]
 name = "derive_more"
-version = "1.0.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a9b99b9cbbe49445b21764dc0625032a89b145a2642e67603e1c936f5458d05"
+checksum = "093242cf7570c207c83073cf82f79706fe7b8317e98620a47d5be7c3d8497678"
 dependencies = [
  "derive_more-impl",
 ]
 
 [[package]]
 name = "derive_more-impl"
-version = "1.0.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb7330aeadfbe296029522e6c40f315320aba36fc43a5b3632f3795348f3bd22"
+checksum = "bda628edc44c4bb645fbe0f758797143e4e07926f7ebf4e9bdfbd3d2ce621df3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.91",
+ "syn 2.0.100",
  "unicode-xid",
 ]
 
@@ -1143,7 +1143,7 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.91",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -1194,7 +1194,7 @@ dependencies = [
  "generic-array",
  "group",
  "pkcs8",
- "rand_core",
+ "rand_core 0.6.4",
  "sec1",
  "subtle",
  "zeroize",
@@ -1300,7 +1300,7 @@ version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ded41244b729663b1e574f1b4fb731469f69f79c17667b5d776b16cda0479449"
 dependencies = [
- "rand_core",
+ "rand_core 0.6.4",
  "subtle",
 ]
 
@@ -1311,7 +1311,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "835c052cb0c08c1acf6ffd71c022172e18723949c8282f2b9f27efbc51e64534"
 dependencies = [
  "byteorder",
- "rand",
+ "rand 0.8.5",
  "rustc-hex",
  "static_assertions",
 ]
@@ -1409,7 +1409,7 @@ checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.91",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -1550,7 +1550,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0f9ef7462f7c099f518d754361858f86d8a07af53ba9af0fe635bbccb151a63"
 dependencies = [
  "ff",
- "rand_core",
+ "rand_core 0.6.4",
  "subtle",
 ]
 
@@ -1810,7 +1810,7 @@ checksum = "1ec89e9337638ecdc08744df490b221a7399bf8d164eb52a665454e60e075ad6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.91",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -1857,7 +1857,7 @@ checksum = "a0eb5a3343abf848c0984fe4604b2b105da9539376e24fc0a3b0007411ae4fd9"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.91",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -1876,7 +1876,7 @@ name = "ipc_serde"
 version = "0.1.0"
 dependencies = [
  "quote",
- "syn 2.0.91",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -2159,7 +2159,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.91",
+ "syn 2.0.100",
  "synstructure",
 ]
 
@@ -2187,7 +2187,7 @@ checksum = "ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.91",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -2323,7 +2323,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48e4cc64c2ad9ebe670cb8fd69dd50ae301650392e81c05f9bfcb2d5bdbc24b0"
 dependencies = [
  "phf_shared",
- "rand",
+ "rand 0.8.5",
 ]
 
 [[package]]
@@ -2336,7 +2336,7 @@ dependencies = [
  "phf_shared",
  "proc-macro2",
  "quote",
- "syn 2.0.91",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -2419,17 +2419,17 @@ dependencies = [
 
 [[package]]
 name = "proptest"
-version = "1.5.0"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4c2511913b88df1637da85cc8d96ec8e43a3f8bb8ccb71ee1ac240d6f3df58d"
+checksum = "14cae93065090804185d3b75f0bf93b8eeda30c7a9b4a33d3bdb3988d6229e50"
 dependencies = [
  "bit-set",
  "bit-vec",
  "bitflags",
  "lazy_static",
  "num-traits",
- "rand",
- "rand_chacha",
+ "rand 0.8.5",
+ "rand_chacha 0.3.1",
  "rand_xorshift",
  "regex-syntax",
  "rusty-fork",
@@ -2465,8 +2465,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
  "libc",
- "rand_chacha",
- "rand_core",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9fbfd9d094a40bf3ae768db9361049ace4c0e04a4fd6b359518bd7b73a73dd97"
+dependencies = [
+ "rand_chacha 0.9.0",
+ "rand_core 0.9.3",
  "serde",
 ]
 
@@ -2477,7 +2487,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.9.3",
 ]
 
 [[package]]
@@ -2490,12 +2510,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand_core"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38"
+dependencies = [
+ "getrandom 0.3.1",
+ "serde",
+]
+
+[[package]]
 name = "rand_xorshift"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d25bf25ec5ae4a3f1b92f929810509a2f53d7dca2f50b794ff57e3face536c8f"
 dependencies = [
- "rand_core",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -2564,9 +2594,9 @@ dependencies = [
 
 [[package]]
 name = "ruint"
-version = "1.12.4"
+version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5ef8fb1dd8de3870cb8400d51b4c2023854bbafd5431a3ac7e7317243e22d2f"
+checksum = "78a46eb779843b2c4f21fac5773e25d6d5b7c8f0922876c91541790d2ca27eef"
 dependencies = [
  "alloy-rlp",
  "ark-ff 0.3.0",
@@ -2580,7 +2610,8 @@ dependencies = [
  "parity-scale-codec",
  "primitive-types",
  "proptest",
- "rand",
+ "rand 0.8.5",
+ "rand 0.9.1",
  "rlp",
  "ruint-macro",
  "serde",
@@ -2688,7 +2719,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0e0cc0f1cf93f4969faf3ea1c7d8a9faed25918d96affa959720823dfe86d4f3"
 dependencies = [
  "bitcoin_hashes",
- "rand",
+ "rand 0.8.5",
  "secp256k1-sys",
  "serde",
 ]
@@ -2752,7 +2783,7 @@ checksum = "5a9bf7cf98d04a2b28aead066b7496853d4779c9cc183c440dbac457641e19a0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.91",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -2787,7 +2818,7 @@ checksum = "6c64451ba24fc7a6a2d60fc75dd9c83c90903b19028d4eff35e88fc1e86564e9"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.91",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -2881,7 +2912,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
 dependencies = [
  "digest 0.10.7",
- "rand_core",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -2962,9 +2993,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.91"
+version = "2.0.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d53cbcb5a243bd33b7858b1d7f4aca2153490815872d86d955d6ea29f743c035"
+checksum = "b09a44accad81e1ba1cd74a32461ba89dee89095ba17b32f5d03683b1b1fc2a0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2988,7 +3019,7 @@ checksum = "c8af7666ab7b6390ab78131fb5b0fce11d6b7a6951602017c35fa82800708971"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.91",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -3048,7 +3079,7 @@ checksum = "46c3384250002a6d5af4d114f2845d37b57521033f30d5c3f46c4d70e1197533"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.91",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -3059,7 +3090,7 @@ checksum = "26afc1baea8a989337eeb52b6e72a039780ce45c3edfcc9c5b9d112feeb173c2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.91",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -3138,7 +3169,7 @@ checksum = "693d596312e88961bc67d7f1f97af8a70227d9f90c31bba5806eec004978d752"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.91",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -3479,7 +3510,7 @@ checksum = "2380878cad4ac9aac1e2435f3eb4020e8374b5f13c296cb75b4620ff8e229154"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.91",
+ "syn 2.0.100",
  "synstructure",
 ]
 
@@ -3500,7 +3531,7 @@ checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.91",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -3520,7 +3551,7 @@ checksum = "595eed982f7d355beb85837f651fa22e90b3c044842dc7f2c2842c086f295808"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.91",
+ "syn 2.0.100",
  "synstructure",
 ]
 
@@ -3541,7 +3572,7 @@ checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.91",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -3563,7 +3594,7 @@ checksum = "6eafa6dfb17584ea3e2bd6e76e0cc15ad7af12b09abdd1ca55961bed9b1063c6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.91",
+ "syn 2.0.100",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ heed = "0.21.0"
 tokio-util = "0.7.13"
 num-traits = "0.2.19"
 num-bigint = "0.4.6"
-alloy-primitives = { version = "0.8.19", features = ["serde"] }
+alloy-primitives = { version = "1.0.0", features = ["serde"] }
 fvm_shared = "4.5.3"
 base64 = "0.22.1"
 bincode = { version = "2.0.0", features = ["alloc", "std", "serde"] }

--- a/internal/bitcoin_wallets.md
+++ b/internal/bitcoin_wallets.md
@@ -1,0 +1,61 @@
+
+```sh
+bitcoin-cli -rpcwallet=default_subnets_watchonly listlabels
+
+[
+	"/b4/t410fbr36gwprxna7jegp27w26plfkojdg4tha337ccy-0",
+  "/b4/t410fbr36gwprxna7jegp27w26plfkojdg4tha337ccy-1",
+  "/b4/t410fcvxguh46ztf2ai3a2uull7nxazrrgbjlizguqxi-0",
+  "/b4/t410fcvxguh46ztf2ai3a2uull7nxazrrgbjlizguqxi-1",
+  "/b4/t410fe53urhgvv6rfdevyyhz6s5p75lnq3w33za2zzdy-0"
+]
+```
+
+```sh
+bitcoin-cli -rpcwallet=default_subnets_watchonly getaddressesbylabel /b4/t410fmkhwlg65rgq2hs6yxpxe2r3yyi55cz6vpz7f7mi-1
+
+{
+  "bcrt1pw9rm2vz742azym7snjerxzj7rqdwehjarrvka7mg82zhsu7t26uq2wlf2t": {
+    "purpose": "receive"
+  }
+}
+```
+
+```sh
+bitcoin-cli -rpcwallet=default_subnets_watchonly listunspent 0 9999999 '["bcrt1pcmdctveccxe09nl3lhaenyjddjggss95fkhf77vahnkqkn4eu95s3len9c"]'
+
+[
+  {
+    "txid": "9a559484f70678d0ec2cd612a5ff3b5b3c0708d3cdd8f6bbfbe1de464c04b304",
+    "vout": 1,
+    "address": "bcrt1pw9rm2vz742azym7snjerxzj7rqdwehjarrvka7mg82zhsu7t26uq2wlf2t",
+    "label": "/b4/t420fxm3vljgrnt4az4nbhwo74ih3b4lce2ecfzfrytqtzfnulhjfuagct52yci-1",
+    "scriptPubKey": "51207147b5305eaaba226fd09cb2330a5e181aecde5d18d96efb683a857873cb56b8",
+    "amount": 0.40000000,
+    "confirmations": 1,
+    "spendable": true,
+    "solvable": true,
+    "desc": "rawtr(7147b5305eaaba226fd09cb2330a5e181aecde5d18d96efb683a857873cb56b8)#waqaavyx",
+    "parent_descs": [
+      "addr(bcrt1pw9rm2vz742azym7snjerxzj7rqdwehjarrvka7mg82zhsu7t26uq2wlf2t)#0yjuh7at"
+    ],
+    "safe": true
+  },
+  {
+    "txid": "f5f59e3551b7cb7b1f82b8c29a7024c3eb85fa207e9ff0b3e0f5c816f13f55a0",
+    "vout": 1,
+    "address": "bcrt1pw9rm2vz742azym7snjerxzj7rqdwehjarrvka7mg82zhsu7t26uq2wlf2t",
+    "label": "/b4/t420fxm3vljgrnt4az4nbhwo74ih3b4lce2ecfzfrytqtzfnulhjfuagct52yci-1",
+    "scriptPubKey": "51207147b5305eaaba226fd09cb2330a5e181aecde5d18d96efb683a857873cb56b8",
+    "amount": 0.40000000,
+    "confirmations": 2,
+    "spendable": true,
+    "solvable": true,
+    "desc": "rawtr(7147b5305eaaba226fd09cb2330a5e181aecde5d18d96efb683a857873cb56b8)#waqaavyx",
+    "parent_descs": [
+      "addr(bcrt1pw9rm2vz742azym7snjerxzj7rqdwehjarrvka7mg82zhsu7t26uq2wlf2t)#0yjuh7at"
+    ],
+    "safe": true
+  }
+]
+```

--- a/internal/bootstrap_subnet.sh
+++ b/internal/bootstrap_subnet.sh
@@ -42,7 +42,7 @@ CREATE_OUTPUT=$(curl -s -X POST "$API_URL" \
           \"min_validator_stake\": $MIN_VAL,
           \"min_validators\": 4,
           \"bottomup_check_period\": 50,
-          \"active_validators_limit\": 4,
+          \"active_validators_limit\": 10,
           \"min_cross_msg_fee\": 200,
           \"whitelist\": [
               \"5f0dfed3a527ac740c7d4a594cd3aa1059a936187399fc49e3fc6ea6ae177268\",

--- a/internal/checkpoint_subnet.sh
+++ b/internal/checkpoint_subnet.sh
@@ -44,7 +44,7 @@ RANDOM_HASH=$(openssl rand -hex 32)
 CURRENT_BLOCK=$(bitcoin-cli getblockcount)
 BLOCK_HASH=$(bitcoin-cli getblockhash "$CURRENT_BLOCK")
 
-DESTINATION_SUBNET_ID_1="/b4/t410fdmafb4l6rb2cqa5zass2qmdr67drvxejlkvpdca"
+DESTINATION_SUBNET_ID_1="/b4/t410flvvhb2htwqlujcxras5v5wludcmruhvxfueyiji"
 
 echo "Current block: $CURRENT_BLOCK ($BLOCK_HASH)"
 echo "Using checkpoint hash: $RANDOM_HASH"

--- a/internal/checkpoint_subnet.sh
+++ b/internal/checkpoint_subnet.sh
@@ -22,12 +22,14 @@ API_URL="http://localhost:${PORT}/api"
 
 # Check if a subnet ID is provided as an argument
 if [ -z "$1" ]; then
-  echo "Usage: $0 <subnet_id>"
+  echo "Usage: $0 <subnet_id> [configuration_number]"
   exit 1
 fi
 
 SUBNET_ID="$1"
+CONFIGURATION_NUMBER="${2:-0}"
 echo "Working with subnet: $SUBNET_ID"
+echo "Configuration number: $CONFIGURATION_NUMBER"
 
 # Secret keys for signing (validator private keys)
 SECRET_KEYS=(
@@ -59,6 +61,7 @@ CHECKPOINT_RESPONSE=$(curl -s -X POST "$API_URL" \
         \"subnet_id\": \"$SUBNET_ID\",
         \"checkpoint_hash\": \"$RANDOM_HASH\",
         \"checkpoint_height\": 50,
+        \"next_committee_configuration_number\": $CONFIGURATION_NUMBER,
         \"withdrawals\": [
             {
                 \"amount\": 25000,

--- a/internal/curl_reqs.md
+++ b/internal/curl_reqs.md
@@ -46,11 +46,29 @@ curl -X POST http://localhost:3040/api \
     "jsonrpc": "2.0",
     "method": "joinsubnet",
     "params": {
-			"subnet_id": "/b4/t410fe53urhgvv6rfdevyyhz6s5p75lnq3w33za2zzdy",
+			"subnet_id": "/b4/t410frrlhcnglpz3ka6kcp4b2wltlxbugdaxiacw2vfq",
 			"collateral": 20000000,
 			"ip": "66.222.44.55:8080",
 			"backup_address": "bcrt1q3fznspr3e02artm9df7tk827a2xhny2m4zzr6n",
 			"pubkey": "e327a66b169732bde49d827d90781327af558fc12d5cd2d5004e7551ec00c662"
+    },
+    "id": 1
+}' | jq
+
+# join new validator 2
+
+curl -X POST http://localhost:3040/api \
+-H "Content-Type: application/json" \
+-H "Authorization: Bearer asda123123jhaskjdhgbjsjhdj" \
+-d '{
+    "jsonrpc": "2.0",
+    "method": "joinsubnet",
+    "params": {
+			"subnet_id": "/b4/t410frrlhcnglpz3ka6kcp4b2wltlxbugdaxiacw2vfq",
+			"collateral": 20000000,
+			"ip": "66.222.44.55:8080",
+			"backup_address": "bcrt1q3fznspr3e02artm9df7tk827a2xhny2m4zzr6n",
+			"pubkey": "71ac1eb874233999e11cd050f388f1dd6da9b446180fdf9b06740419cc487b6f"
     },
     "id": 1
 }' | jq
@@ -122,7 +140,7 @@ curl -X POST http://localhost:3040/api \
     "jsonrpc": "2.0",
     "method": "getsubnet",
     "params": {
-			"subnet_id": "/b4/t410fe53urhgvv6rfdevyyhz6s5p75lnq3w33za2zzdy"
+			"subnet_id": "/b4/t410frrlhcnglpz3ka6kcp4b2wltlxbugdaxiacw2vfq"
     },
     "id": 1
 }' | jq

--- a/internal/curl_reqs.md
+++ b/internal/curl_reqs.md
@@ -46,7 +46,7 @@ curl -X POST http://localhost:3040/api \
     "jsonrpc": "2.0",
     "method": "joinsubnet",
     "params": {
-			"subnet_id": "/b4/t410fpy5hpfsz5c3yve4r27eu7kew7fnfpjrdetgn46q",
+			"subnet_id": "/b4/t410fe53urhgvv6rfdevyyhz6s5p75lnq3w33za2zzdy",
 			"collateral": 20000000,
 			"ip": "66.222.44.55:8080",
 			"backup_address": "bcrt1q3fznspr3e02artm9df7tk827a2xhny2m4zzr6n",
@@ -122,7 +122,7 @@ curl -X POST http://localhost:3040/api \
     "jsonrpc": "2.0",
     "method": "getsubnet",
     "params": {
-			"subnet_id": "/b4/t410fup22efdbdpdg5rebem5f2cud6fegnm7qedmoknq"
+			"subnet_id": "/b4/t410fe53urhgvv6rfdevyyhz6s5p75lnq3w33za2zzdy"
     },
     "id": 1
 }' | jq

--- a/internal/curl_reqs.md
+++ b/internal/curl_reqs.md
@@ -46,7 +46,7 @@ curl -X POST http://localhost:3040/api \
     "jsonrpc": "2.0",
     "method": "joinsubnet",
     "params": {
-			"subnet_id": "/b4/t410frrlhcnglpz3ka6kcp4b2wltlxbugdaxiacw2vfq",
+			"subnet_id": "/b4/t410f3iid2fasqwb75plfaaoqbds4fwdu6btidyk7lwq",
 			"collateral": 20000000,
 			"ip": "66.222.44.55:8080",
 			"backup_address": "bcrt1q3fznspr3e02artm9df7tk827a2xhny2m4zzr6n",
@@ -64,7 +64,7 @@ curl -X POST http://localhost:3040/api \
     "jsonrpc": "2.0",
     "method": "joinsubnet",
     "params": {
-			"subnet_id": "/b4/t410frrlhcnglpz3ka6kcp4b2wltlxbugdaxiacw2vfq",
+			"subnet_id": "/b4/t410f3iid2fasqwb75plfaaoqbds4fwdu6btidyk7lwq",
 			"collateral": 20000000,
 			"ip": "66.222.44.55:8080",
 			"backup_address": "bcrt1q3fznspr3e02artm9df7tk827a2xhny2m4zzr6n",
@@ -140,7 +140,7 @@ curl -X POST http://localhost:3040/api \
     "jsonrpc": "2.0",
     "method": "getsubnet",
     "params": {
-			"subnet_id": "/b4/t410frrlhcnglpz3ka6kcp4b2wltlxbugdaxiacw2vfq"
+			"subnet_id": "/b4/t410f3iid2fasqwb75plfaaoqbds4fwdu6btidyk7lwq"
     },
     "id": 1
 }' | jq
@@ -193,8 +193,8 @@ curl -X POST http://localhost:3040/api \
     "jsonrpc": "2.0",
     "method": "getstakechanges",
     "params": {
-			"subnet_id": "/b4/t410fpy5hpfsz5c3yve4r27eu7kew7fnfpjrdetgn46q",
-			"block_height": 1194
+			"subnet_id": "/b4/t410f3iid2fasqwb75plfaaoqbds4fwdu6btidyk7lwq",
+			"block_height": 1298
     },
     "id": 1
 }' | jq

--- a/internal/curl_reqs.md
+++ b/internal/curl_reqs.md
@@ -37,6 +37,24 @@ curl -X POST http://localhost:3030/api \
     "id": 1
 }' | jq
 
+# join new validator
+
+curl -X POST http://localhost:3040/api \
+-H "Content-Type: application/json" \
+-H "Authorization: Bearer asda123123jhaskjdhgbjsjhdj" \
+-d '{
+    "jsonrpc": "2.0",
+    "method": "joinsubnet",
+    "params": {
+			"subnet_id": "/b4/t410fpy5hpfsz5c3yve4r27eu7kew7fnfpjrdetgn46q",
+			"collateral": 20000000,
+			"ip": "66.222.44.55:8080",
+			"backup_address": "bcrt1q3fznspr3e02artm9df7tk827a2xhny2m4zzr6n",
+			"pubkey": "e327a66b169732bde49d827d90781327af558fc12d5cd2d5004e7551ec00c662"
+    },
+    "id": 1
+}' | jq
+
 curl -X POST http://localhost:3030/api \
 -H "Content-Type: application/json" \
 -H "Authorization: Bearer asda123123jhaskjdhgbjsjhdj" \
@@ -97,14 +115,14 @@ curl -X POST http://localhost:3030/api \
 	"id": 1
 }' | jq
 
-curl -X POST http://localhost:3030/api \
+curl -X POST http://localhost:3040/api \
 -H "Content-Type: application/json" \
 -H "Authorization: Bearer asda123123jhaskjdhgbjsjhdj" \
 -d '{
     "jsonrpc": "2.0",
     "method": "getsubnet",
     "params": {
-			"subnet_id": "/b4/t420fmsv2gwpnksrxob6yij4wi6iuu2pg4vowy6xopfembcl6axt5ocqtymspsm"
+			"subnet_id": "/b4/t410fup22efdbdpdg5rebem5f2cud6fegnm7qedmoknq"
     },
     "id": 1
 }' | jq

--- a/internal/curl_reqs.md
+++ b/internal/curl_reqs.md
@@ -168,6 +168,19 @@ curl -X POST http://localhost:3030/api \
     "id": 1
 }' | jq
 
+curl -X POST http://localhost:3040/api \
+-H "Content-Type: application/json" \
+-H "Authorization: Bearer asda123123jhaskjdhgbjsjhdj" \
+-d '{
+    "jsonrpc": "2.0",
+    "method": "getstakechanges",
+    "params": {
+			"subnet_id": "/b4/t410fpy5hpfsz5c3yve4r27eu7kew7fnfpjrdetgn46q",
+			"block_height": 1194
+    },
+    "id": 1
+}' | jq
+
 curl -X POST http://localhost:3030/api \
 -H "Content-Type: application/json" \
 -H "Authorization: Bearer asda123123jhaskjdhgbjsjhdj" \

--- a/internal/spin_up_subnet.sh
+++ b/internal/spin_up_subnet.sh
@@ -95,6 +95,7 @@ run_validator() {
 run_validator 2 26756 26757 8645 26755 &
 run_validator 3 26856 26857 8745 26855 &
 run_validator 4 26956 26957 8845 26955 &
+run_validator 5 27056 27057 8945 27055 &
 
 # Wait for all background processes to complete
 wait

--- a/src/bin/monitor.rs
+++ b/src/bin/monitor.rs
@@ -556,18 +556,12 @@ where
                 debug!("Found IPC message: {:#?}", msg);
 
                 msg.validate()?;
-                let checkpoint = msg.save_to_db(&self.db, block_height, txid)?;
+                let checkpoint = msg.save_to_db(&self.db, block_height, block_hash, txid)?;
 
                 // Save the checkpoint tx to db
                 // we need it available for any batch transfer messages
                 let mut wtxn = self.db.write_txn()?;
                 self.db.save_transaction(&mut wtxn, tx)?;
-                self.db.confirm_stake_changes(
-                    &mut wtxn,
-                    msg.subnet_id,
-                    block_height,
-                    block_hash,
-                )?;
                 wtxn.commit().map_err(db::DbError::from)?;
 
                 info!(

--- a/src/bin/monitor.rs
+++ b/src/bin/monitor.rs
@@ -10,7 +10,7 @@ use tokio_util::sync::CancellationToken;
 
 use bitcoin::BlockHash;
 use bitcoin_ipc::db::{self, Database, HeedDb};
-use bitcoin_ipc::ipc_lib::{self, IpcLibError, IpcValidate};
+use bitcoin_ipc::ipc_lib::{self, IpcLibError, IpcValidate, IpcValidateError};
 use bitcoin_ipc::{bitcoin_utils, eth_utils, IpcMessage, BTC_CONFIRMATIONS};
 use bitcoincore_rpc::RpcApi;
 
@@ -560,9 +560,32 @@ where
 
                 // Save the checkpoint tx to db
                 // we need it available for any batch transfer messages
-                let mut wtxn = self.db.write_txn()?;
-                self.db.save_transaction(&mut wtxn, tx)?;
-                wtxn.commit().map_err(db::DbError::from)?;
+                {
+                    let mut wtxn = self.db.write_txn()?;
+                    self.db.save_transaction(&mut wtxn, tx)?;
+                    wtxn.commit().map_err(db::DbError::from)?;
+                }
+
+                // import new address if the committee changed
+                if checkpoint.signed_committee_number != checkpoint.next_committee_number {
+                    // get the update subnet state from the database
+                    let subnet = self
+                        .db
+                        .get_subnet_state(msg.subnet_id)
+                        .map_err(MonitorError::DbError)?
+                        // Should never happen
+                        .ok_or(IpcValidateError::InvalidMsg(
+                            "Could not fetch subnet id after a checkpoint".to_string(),
+                        ))?;
+
+                    info!(
+                        "Committee changed for Subnet ID: {}, importing address.",
+                        msg.subnet_id
+                    );
+
+                    let (new_committee_addr, new_label) = subnet.committee_address_label();
+                    self.import_watchonly_address(new_committee_addr, new_label, block_time);
+                }
 
                 info!(
                     "Processed CheckpointSubnet for Subnet ID: {} Subnet Height: {} Checkpoint Number: {}",

--- a/src/bin/monitor.rs
+++ b/src/bin/monitor.rs
@@ -495,26 +495,36 @@ where
                 };
                 debug!("Found IPC message: {:?}", join_subnet_msg);
 
-                let mut bootstraped = false;
+                let genesis_info = self
+                    .db
+                    .get_subnet_genesis_info(join_subnet_msg.subnet_id)
+                    .map_err(|e| {
+                        error!("Error getting subnet info from Db: {}", e);
+                        MonitorError::DbError(e)
+                    })?
+                    .ok_or(ipc_lib::IpcValidateError::InvalidMsg(format!(
+                        "Subnet {} not found.",
+                        join_subnet_msg.subnet_id
+                    )))?;
+
+                let subnet_state = self
+                    .db
+                    .get_subnet_state(join_subnet_msg.subnet_id)
+                    .map_err(MonitorError::DbError)?;
+
+                join_subnet_msg.validate_for_subnet(&genesis_info, &subnet_state)?;
 
                 join_subnet_msg.validate()?;
                 if let Some(subnet) = join_subnet_msg.save_to_db(&self.db, block_height, txid)? {
                     // Subnet bootstrapped
                     let (committee_addr, label) = subnet.committee_address_label();
                     self.import_watchonly_address(committee_addr, label, block_time);
-                    bootstraped = true;
                 }
 
                 info!(
                     "Processed JoinSubnet for Subnet ID: {} Validator XPK: {} Collateral: {}",
                     join_subnet_msg.subnet_id, join_subnet_msg.pubkey, join_subnet_msg.collateral
                 );
-                if bootstraped {
-                    info!(
-                        "Subnet ID: {} has been bootstrapped",
-                        join_subnet_msg.subnet_id
-                    );
-                }
                 Ok(())
             }
 

--- a/src/bin/monitor.rs
+++ b/src/bin/monitor.rs
@@ -515,7 +515,9 @@ where
                 join_subnet_msg.validate_for_subnet(&genesis_info, &subnet_state)?;
 
                 join_subnet_msg.validate()?;
-                if let Some(subnet) = join_subnet_msg.save_to_db(&self.db, block_height, txid)? {
+                if let Some(subnet) =
+                    join_subnet_msg.save_to_db(&self.db, block_height, block_hash, txid)?
+                {
                     // Subnet bootstrapped
                     let (committee_addr, label) = subnet.committee_address_label();
                     self.import_watchonly_address(committee_addr, label, block_time);
@@ -560,6 +562,12 @@ where
                 // we need it available for any batch transfer messages
                 let mut wtxn = self.db.write_txn()?;
                 self.db.save_transaction(&mut wtxn, tx)?;
+                self.db.confirm_stake_changes(
+                    &mut wtxn,
+                    msg.subnet_id,
+                    block_height,
+                    block_hash,
+                )?;
                 wtxn.commit().map_err(db::DbError::from)?;
 
                 info!(

--- a/src/db.rs
+++ b/src/db.rs
@@ -239,7 +239,10 @@ impl SubnetCommittee {
         subnet_id: &SubnetId,
         validator: &SubnetValidator,
     ) -> Result<(), DbError> {
-        self.configuration_number += 1;
+        // Increase configuration number by 2
+        // since there is one stake change for the metadata (public key)
+        // and one stake change for the deposit
+        self.configuration_number += 2;
         self.validators.add_validator(validator)?;
         self.threshold = self.validators.threshold();
         self.multisig_address = self.validators.multisig_address(subnet_id);

--- a/src/db.rs
+++ b/src/db.rs
@@ -24,6 +24,8 @@ const CHECKPOINTS_KEY: &str = "checkpoints:";
 const TRANSACTIONS_KEY: &str = "transactions:";
 // committee:<subnet_id>:<committee_number>
 const COMMITTEE_KEY: &str = "committee:";
+// stake_changes:<subnet_id>:<configuration_number>
+const STAKE_CHANGES_KEY: &str = "stake_changes:";
 
 pub type Wtxn<'a> = &'a mut heed::RwTxn<'a>;
 
@@ -53,6 +55,14 @@ fn transaction_key(txid: &Txid) -> String {
 
 fn committee_key(subnet_id: SubnetId, committee_number: u64) -> String {
     format!("{COMMITTEE_KEY}:{}:{}", subnet_id, committee_number)
+}
+
+fn stake_changes_prefix(subnet_id: SubnetId) -> String {
+    format!("{STAKE_CHANGES_KEY}:{}", subnet_id)
+}
+
+fn stake_change_key(subnet_id: SubnetId, configuration_number: u64) -> String {
+    format!("{STAKE_CHANGES_KEY}:{}:{}", subnet_id, configuration_number)
 }
 
 #[derive(Serialize, Deserialize)]
@@ -237,7 +247,7 @@ pub struct SubnetCheckpoint {
     pub checkpoint_number: u64,
     /// The block hash of the child subnet at which the checkpoint was cut
     pub checkpoint_hash: bitcoin::hashes::sha256::Hash,
-    /// The block height of the checkpoint on Bitcoin
+    /// The block height of the checkpoint on the child subnet
     pub checkpoint_height: u64,
     /// The block height of the checkpoint on Bitcoin
     pub block_height: u64,
@@ -471,6 +481,52 @@ impl RootnetMessage {
     }
 }
 
+// Staking
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum StakingChange {
+    Deposit {
+        #[serde(with = "bitcoin::amount::serde::as_sat")]
+        amount: bitcoin::Amount,
+    },
+    Withdraw {
+        #[serde(with = "bitcoin::amount::serde::as_sat")]
+        amount: bitcoin::Amount,
+    },
+    Join {
+        pubkey: bitcoin::secp256k1::PublicKey,
+    },
+}
+
+/// Stake change event emmited on the Bitcoin chain
+///
+/// These events are saved in db as seen on the chain
+/// However they will be returned to the consumer only
+/// after there was a checkpoint on Bitcoin where the
+/// stake changes were actually made (like rotating to)
+/// another multisig or such)
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct StakeChangeRequest {
+    /// Change request
+    pub change: StakingChange,
+    /// XOnlyPublicKey of the validator making requesting stake change
+    pub validator_xpk: XOnlyPublicKey,
+    /// Configuration number is practically an incremental "nonce"
+    /// of a single change request/event
+    pub configuration_number: u64,
+
+    /// The block height of the Bitcoin block where the change request was recorded
+    pub block_height: u64,
+    /// The block hash of the Bitcoin block where the change request was recorded
+    pub block_hash: BlockHash,
+    /// The block height of the child subnet at which the checkpoint was
+    pub checkpoint_block_height: Option<u64>,
+    /// The block hash of the child subnet at which the checkpoint was
+    pub checkpoint_block_hash: Option<BlockHash>,
+    pub txid: Txid,
+}
+
 pub struct HeedDb {
     env: Env,
     monitor_info: HeedDatabase<Str, SerdeBincode<MonitorInfo>>,
@@ -482,6 +538,7 @@ pub struct HeedDb {
     rootnet_msgs_db: HeedDatabase<Str, SerdeJson<RootnetMessage>>,
     transactions_db: HeedDatabase<Str, SerdeBincode<Vec<u8>>>,
     committee_db: HeedDatabase<Str, SerdeBincode<SubnetCommittee>>,
+    stake_changes_db: HeedDatabase<Str, SerdeBincode<StakeChangeRequest>>,
 }
 
 impl HeedDb {
@@ -548,6 +605,9 @@ impl HeedDb {
             let committee_db = env
                 .open_database(&rtxn, Some("committee_db"))?
                 .ok_or(DbError::DbNotFound("committee_db".to_string()))?;
+            let stake_changes_db = env
+                .open_database(&rtxn, Some("stake_changes_db"))?
+                .ok_or(DbError::DbNotFound("stake_changes_db".to_string()))?;
             rtxn.commit()?;
 
             Ok(Self {
@@ -559,6 +619,7 @@ impl HeedDb {
                 rootnet_msgs_db,
                 transactions_db,
                 committee_db,
+                stake_changes_db,
             })
         } else {
             // In write mode, we can create the databases if they don't exist
@@ -570,6 +631,7 @@ impl HeedDb {
             let rootnet_msgs_db = env.create_database(&mut txn, Some("rootnet_msgs_db"))?;
             let transactions_db = env.create_database(&mut txn, Some("transactions_db"))?;
             let committee_db = env.create_database(&mut txn, Some("committee_db"))?;
+            let stake_changes_db = env.create_database(&mut txn, Some("stake_changes_db"))?;
             txn.commit()?;
 
             Ok(Self {
@@ -581,6 +643,7 @@ impl HeedDb {
                 rootnet_msgs_db,
                 transactions_db,
                 committee_db,
+                stake_changes_db,
             })
         }
     }
@@ -681,6 +744,50 @@ pub trait Database {
         committee_number: u64,
         committee: &SubnetCommittee,
     ) -> Result<(), DbError>;
+
+    // Stake changes
+    // Stake changes
+    fn get_stake_change(
+        &self,
+        subnet_id: SubnetId,
+        configuration_number: u64,
+    ) -> Result<Option<StakeChangeRequest>, DbError>;
+
+    fn get_all_stake_changes(
+        &self,
+        subnet_id: SubnetId,
+    ) -> Result<Vec<StakeChangeRequest>, DbError>;
+
+    fn get_stake_changes_by_height(
+        &self,
+        subnet_id: SubnetId,
+        block_height: u64,
+    ) -> Result<Vec<StakeChangeRequest>, DbError>;
+
+    fn get_last_stake_change_configuration_number(
+        &self,
+        subnet_id: SubnetId,
+    ) -> Result<Option<u64>, DbError>;
+
+    fn get_next_stake_change_configuration_number(
+        &self,
+        subnet_id: SubnetId,
+    ) -> Result<u64, DbError>;
+
+    fn add_stake_change(
+        &self,
+        txn: &mut RwTxn,
+        subnet_id: SubnetId,
+        stake_change: StakeChangeRequest,
+    ) -> Result<(), DbError>;
+
+    fn confirm_stake_changes(
+        &self,
+        txn: &mut RwTxn,
+        subnet_id: SubnetId,
+        confirmed_block_height: u64,
+        confirmed_block_hash: BlockHash,
+    ) -> Result<Vec<StakeChangeRequest>, DbError>;
 }
 
 #[async_trait]
@@ -973,6 +1080,143 @@ impl Database for HeedDb {
         let key = committee_key(subnet_id, committee_number);
         self.committee_db.put(txn, &key, committee)?;
         Ok(())
+    }
+
+    // Stake changes
+
+    fn get_stake_change(
+        &self,
+        subnet_id: SubnetId,
+        configuration_number: u64,
+    ) -> Result<Option<StakeChangeRequest>, DbError> {
+        let key = stake_change_key(subnet_id, configuration_number);
+        let txn = self.env.read_txn()?;
+        let change = self.stake_changes_db.get(&txn, &key)?;
+        Ok(change)
+    }
+
+    fn get_all_stake_changes(
+        &self,
+        subnet_id: SubnetId,
+    ) -> Result<Vec<StakeChangeRequest>, DbError> {
+        let prefix = stake_changes_prefix(subnet_id);
+        let txn = self.env.read_txn()?;
+
+        let changes_iter = self.stake_changes_db.prefix_iter(&txn, &prefix)?;
+
+        let changes = changes_iter
+            .map(|res| res.map(|(_, change)| change))
+            .collect::<Result<Vec<_>, _>>()?;
+
+        Ok(changes)
+    }
+
+    /// Returns all stake changes for a given subnet
+    /// for a given height, looking at *confirmed* block height
+    fn get_stake_changes_by_height(
+        &self,
+        subnet_id: SubnetId,
+        block_height: u64,
+    ) -> Result<Vec<StakeChangeRequest>, DbError> {
+        let prefix = stake_changes_prefix(subnet_id);
+        let txn = self.env.read_txn()?;
+
+        let changes_iter = self.stake_changes_db.prefix_iter(&txn, &prefix)?;
+
+        let changes = changes_iter
+            .map(|res| res.map(|(_, change)| change))
+            .filter_map(|res| match res {
+                Ok(change) => {
+                    if change
+                        .checkpoint_block_height
+                        .is_some_and(|cbh| cbh == block_height)
+                    {
+                        Some(Ok(change))
+                    } else {
+                        None
+                    }
+                }
+                Err(e) => Some(Err(e)),
+            })
+            .collect::<Result<Vec<_>, _>>()?;
+
+        Ok(changes)
+    }
+
+    fn get_last_stake_change_configuration_number(
+        &self,
+        subnet_id: SubnetId,
+    ) -> Result<Option<u64>, DbError> {
+        let prefix = stake_changes_prefix(subnet_id);
+        let txn = self.env.read_txn()?;
+        let changes_iter = self.stake_changes_db.prefix_iter(&txn, &prefix)?;
+        let count: u64 = changes_iter
+            .count()
+            .try_into()
+            .map_err(|_| DbError::TypeConversionError("max stake changes reached".to_string()))?;
+
+        if count == 0 {
+            return Ok(None);
+        }
+
+        Ok(Some(count - 1))
+    }
+
+    fn get_next_stake_change_configuration_number(
+        &self,
+        subnet_id: SubnetId,
+    ) -> Result<u64, DbError> {
+        let last_number = self.get_last_stake_change_configuration_number(subnet_id)?;
+        let next_number = match last_number {
+            Some(n) => n + 1,
+            None => 0,
+        };
+
+        Ok(next_number)
+    }
+
+    fn add_stake_change(
+        &self,
+        txn: &mut RwTxn,
+        subnet_id: SubnetId,
+        stake_change: StakeChangeRequest,
+    ) -> Result<(), DbError> {
+        let key = stake_change_key(subnet_id, stake_change.configuration_number);
+        trace!("Add stake change: {stake_change:#?}");
+        self.stake_changes_db.put(txn, &key, &stake_change)?;
+        Ok(())
+    }
+
+    fn confirm_stake_changes(
+        &self,
+        txn: &mut RwTxn,
+        subnet_id: SubnetId,
+        confirmed_block_height: u64,
+        confirmed_block_hash: BlockHash,
+    ) -> Result<Vec<StakeChangeRequest>, DbError> {
+        // Get all stake changes for the subnet
+        let stake_changes = self.get_all_stake_changes(subnet_id)?;
+
+        // Filter unconfirmed stake changes
+        let mut updated_changes = Vec::new();
+
+        for mut change in stake_changes {
+            // Check if the stake change is unconfirmed
+            if change.checkpoint_block_height.is_none() {
+                // Set the confirmation details
+                change.checkpoint_block_height = Some(confirmed_block_height);
+                change.checkpoint_block_hash = Some(confirmed_block_hash);
+
+                // Update in the database
+                let key = stake_change_key(subnet_id, change.configuration_number);
+                self.stake_changes_db.put(txn, &key, &change)?;
+
+                // Add to the list of updated changes
+                updated_changes.push(change);
+            }
+        }
+
+        Ok(updated_changes)
     }
 }
 

--- a/src/db.rs
+++ b/src/db.rs
@@ -22,6 +22,8 @@ const ROOTNET_MSGS_KEY: &str = "rootnet_msgs:";
 const CHECKPOINTS_KEY: &str = "checkpoints:";
 // transactions:<txid>
 const TRANSACTIONS_KEY: &str = "transactions:";
+// committee:<subnet_id>:<committee_number>
+const COMMITTEE_KEY: &str = "committee:";
 
 pub type Wtxn<'a> = &'a mut heed::RwTxn<'a>;
 
@@ -47,6 +49,10 @@ fn checkpoints_key(subnet_id: SubnetId, number: u64) -> String {
 
 fn transaction_key(txid: &Txid) -> String {
     format!("{TRANSACTIONS_KEY}:{}", txid)
+}
+
+fn committee_key(subnet_id: SubnetId, committee_number: u64) -> String {
+    format!("{COMMITTEE_KEY}:{}:{}", subnet_id, committee_number)
 }
 
 #[derive(Serialize, Deserialize)]
@@ -259,7 +265,7 @@ pub struct SubnetState {
     pub committee_number: u64,
     /// The current commitee
     pub committee: SubnetCommittee,
-    /// The next commitee, if it differs
+    /// The next commitee, Some if it differs
     pub next_committee: Option<SubnetCommittee>,
     /// The number of the last checkpoint
     pub last_checkpoint_number: Option<u64>,
@@ -475,6 +481,7 @@ pub struct HeedDb {
     // There's a conflict of bincode and `serde(tag = "type")` for RootnetMessage
     rootnet_msgs_db: HeedDatabase<Str, SerdeJson<RootnetMessage>>,
     transactions_db: HeedDatabase<Str, SerdeBincode<Vec<u8>>>,
+    committee_db: HeedDatabase<Str, SerdeBincode<SubnetCommittee>>,
 }
 
 impl HeedDb {
@@ -538,6 +545,9 @@ impl HeedDb {
             let transactions_db = env
                 .open_database(&rtxn, Some("transactions_db"))?
                 .ok_or(DbError::DbNotFound("transactions_db".to_string()))?;
+            let committee_db = env
+                .open_database(&rtxn, Some("committee_db"))?
+                .ok_or(DbError::DbNotFound("committee_db".to_string()))?;
             rtxn.commit()?;
 
             Ok(Self {
@@ -548,6 +558,7 @@ impl HeedDb {
                 checkpoints_db,
                 rootnet_msgs_db,
                 transactions_db,
+                committee_db,
             })
         } else {
             // In write mode, we can create the databases if they don't exist
@@ -558,6 +569,7 @@ impl HeedDb {
             let checkpoints_db = env.create_database(&mut txn, Some("checkpoints_db"))?;
             let rootnet_msgs_db = env.create_database(&mut txn, Some("rootnet_msgs_db"))?;
             let transactions_db = env.create_database(&mut txn, Some("transactions_db"))?;
+            let committee_db = env.create_database(&mut txn, Some("committee_db"))?;
             txn.commit()?;
 
             Ok(Self {
@@ -568,6 +580,7 @@ impl HeedDb {
                 checkpoints_db,
                 rootnet_msgs_db,
                 transactions_db,
+                committee_db,
             })
         }
     }
@@ -653,6 +666,21 @@ pub trait Database {
     // Transaction storage
     fn get_transaction(&self, txid: &Txid) -> Result<Option<bitcoin::Transaction>, DbError>;
     fn save_transaction(&self, txn: &mut RwTxn, tx: &bitcoin::Transaction) -> Result<(), DbError>;
+
+    // Committees
+    fn get_committee(
+        &self,
+        subnet_id: SubnetId,
+        committee_number: u64,
+    ) -> Result<Option<SubnetCommittee>, DbError>;
+
+    fn save_committee(
+        &self,
+        txn: &mut RwTxn,
+        subnet_id: SubnetId,
+        committee_number: u64,
+        committee: &SubnetCommittee,
+    ) -> Result<(), DbError>;
 }
 
 #[async_trait]
@@ -919,6 +947,31 @@ impl Database for HeedDb {
         let tx_bytes = bitcoin::consensus::serialize(tx);
         self.transactions_db.put(txn, &key, &tx_bytes)?;
 
+        Ok(())
+    }
+
+    // Committees
+
+    fn get_committee(
+        &self,
+        subnet_id: SubnetId,
+        committee_number: u64,
+    ) -> Result<Option<SubnetCommittee>, DbError> {
+        let key = committee_key(subnet_id, committee_number);
+        let txn = self.env.read_txn()?;
+        let committee = self.committee_db.get(&txn, &key)?;
+        Ok(committee)
+    }
+
+    fn save_committee(
+        &self,
+        txn: &mut RwTxn,
+        subnet_id: SubnetId,
+        committee_number: u64,
+        committee: &SubnetCommittee,
+    ) -> Result<(), DbError> {
+        let key = committee_key(subnet_id, committee_number);
+        self.committee_db.put(txn, &key, committee)?;
         Ok(())
     }
 }
@@ -1352,5 +1405,89 @@ mod tests {
         assert!(subnet_state.committee.is_validator(&pubkey1));
         assert!(!subnet_state.committee.is_validator(&pubkey2));
         assert!(subnet_state.committee.is_validator(&pubkey3));
+    }
+
+    #[test]
+    fn test_different_power_different_multisig() {
+        // Setup: Create a subnet ID
+        let subnet_id = create_rand_subnet_id();
+
+        // Create validators
+        let secp = bitcoin::secp256k1::Secp256k1::new();
+        let (secret_key1, _) = secp.generate_keypair(&mut rand::thread_rng());
+        let (secret_key2, _) = secp.generate_keypair(&mut rand::thread_rng());
+        let pubkey1 = XOnlyPublicKey::from_keypair(&secret_key1.keypair(&secp)).0;
+        let pubkey2 = XOnlyPublicKey::from_keypair(&secret_key2.keypair(&secp)).0;
+
+        // Create first set of validators with certain powers
+        let validator1_set1 = SubnetValidator {
+            pubkey: pubkey1,
+            subnet_address: create_rand_addr(),
+            power: 10, // Power of 10 for first set
+            collateral: Amount::from_sat(1_000_000),
+            backup_address: Address::from_str("bcrt1qpufku8sca56kmxylyd2233mfmnr9eyc4wdsdmd")
+                .unwrap(),
+            ip: "127.0.0.1:8000".parse().unwrap(),
+            join_txid: create_rand_txid(),
+        };
+
+        let validator2_set1 = SubnetValidator {
+            pubkey: pubkey2,
+            subnet_address: create_rand_addr(),
+            power: 15, // Power of 15 for first set
+            collateral: Amount::from_sat(2_000_000),
+            backup_address: Address::from_str("bcrt1qpufku8sca56kmxylyd2233mfmnr9eyc4wdsdmd")
+                .unwrap(),
+            ip: "127.0.0.1:8001".parse().unwrap(),
+            join_txid: create_rand_txid(),
+        };
+
+        // Create second set of validators with the same pubkeys but different powers
+        let validator1_set2 = SubnetValidator {
+            pubkey: pubkey1,
+            subnet_address: create_rand_addr(),
+            power: 20, // Power of 20 for second set
+            collateral: Amount::from_sat(1_000_000),
+            backup_address: Address::from_str("bcrt1qpufku8sca56kmxylyd2233mfmnr9eyc4wdsdmd")
+                .unwrap(),
+            ip: "127.0.0.1:8000".parse().unwrap(),
+            join_txid: create_rand_txid(),
+        };
+
+        let validator2_set2 = SubnetValidator {
+            pubkey: pubkey2,
+            subnet_address: create_rand_addr(),
+            power: 25, // Power of 25 for second set
+            collateral: Amount::from_sat(2_000_000),
+            backup_address: Address::from_str("bcrt1qpufku8sca56kmxylyd2233mfmnr9eyc4wdsdmd")
+                .unwrap(),
+            ip: "127.0.0.1:8001".parse().unwrap(),
+            join_txid: create_rand_txid(),
+        };
+
+        // Create the two committees
+        let mut validators_set1 = Vec::new();
+        validators_set1.push(validator1_set1);
+        validators_set1.push(validator2_set1);
+
+        let mut validators_set2 = Vec::new();
+        validators_set2.push(validator1_set2);
+        validators_set2.push(validator2_set2);
+
+        let committee1 = validators_set1.to_committee(&subnet_id);
+        let committee2 = validators_set2.to_committee(&subnet_id);
+
+        // Verify both committees have the same validators (by pubkey)
+        assert_eq!(committee1.pubkeys(), committee2.pubkeys());
+
+        // Verify the committees have different total powers
+        assert_eq!(committee1.total_power(), 25); // 10 + 15
+        assert_eq!(committee2.total_power(), 45); // 20 + 25
+
+        // Verify the committees have different thresholds
+        assert_ne!(committee1.threshold, committee2.threshold);
+
+        // Verify the multisig addresses are different
+        assert_ne!(committee1.multisig_address, committee2.multisig_address);
     }
 }

--- a/src/db.rs
+++ b/src/db.rs
@@ -335,6 +335,13 @@ impl SubnetState {
     }
 
     pub fn rotate_to_committee(&mut self, new_committee: SubnetCommittee) {
+        trace!(
+            "subnet id {} rotating committees. prev={:?} next={:?}",
+            self.id,
+            self.committee,
+            new_committee
+        );
+
         if self.committee == new_committee {
             return;
         }
@@ -1255,9 +1262,10 @@ impl Database for HeedDb {
                 self.stake_changes_db.put(txn, &key, &change)?;
 
                 // Update the last confirmed change if this one has a higher configuration number
-                if last_confirmed.as_ref().map_or(true, |last| {
-                    change.configuration_number > last.configuration_number
-                }) {
+                if last_confirmed
+                    .as_ref()
+                    .is_none_or(|last| change.configuration_number > last.configuration_number)
+                {
                     last_confirmed = Some(change.clone());
                 }
 

--- a/src/db.rs
+++ b/src/db.rs
@@ -510,8 +510,10 @@ pub enum StakingChange {
 pub struct StakeChangeRequest {
     /// Change request
     pub change: StakingChange,
-    /// XOnlyPublicKey of the validator making requesting stake change
+    /// XOnlyPublicKey of the validator requesting stake change
     pub validator_xpk: XOnlyPublicKey,
+    /// The ethereum address of the validator pubkey
+    pub validator_subnet_address: alloy_primitives::Address,
     /// Configuration number is practically an incremental "nonce"
     /// of a single change request/event
     pub configuration_number: u64,

--- a/src/db.rs
+++ b/src/db.rs
@@ -156,6 +156,16 @@ pub struct SubnetCommittee {
     pub multisig_address: Address<NetworkUnchecked>,
 }
 
+impl PartialEq for SubnetCommittee {
+    fn eq(&self, other: &Self) -> bool {
+        // this should suffice as we have the keys and the
+        // threshold in the script_pubkey for which we derive the address
+        self.multisig_address == other.multisig_address
+    }
+}
+
+impl Eq for SubnetCommittee {}
+
 impl SubnetCommittee {
     pub fn size(&self) -> u16 {
         self.validators
@@ -278,6 +288,18 @@ impl SubnetState {
 
     pub fn is_validator(&self, pubkey: &XOnlyPublicKey) -> bool {
         self.committee.is_validator(pubkey)
+    }
+
+    pub fn is_waiting_validator(&self, pubkey: &XOnlyPublicKey) -> bool {
+        self.next_committee
+            .as_ref()
+            .is_some_and(|nc| nc.is_validator(pubkey))
+    }
+
+    pub fn needs_rotation(&self) -> bool {
+        self.next_committee
+            .as_ref()
+            .is_some_and(|nc| self.committee != *nc)
     }
 
     pub fn rotate_to_next_committee(&mut self) -> Result<(), DbError> {
@@ -1225,5 +1247,110 @@ mod tests {
 
         // Verify committee size didn't change after failed addition
         assert_eq!(committee.validators.len(), 3);
+    }
+
+    #[test]
+    fn test_subnet_state_rotation() {
+        // Setup: Create a subnet ID
+        let subnet_id = create_rand_subnet_id();
+
+        // Create validators for the current committee
+        let secp = bitcoin::secp256k1::Secp256k1::new();
+        let (secret_key1, _) = secp.generate_keypair(&mut rand::thread_rng());
+        let (secret_key2, _) = secp.generate_keypair(&mut rand::thread_rng());
+        let pubkey1 = XOnlyPublicKey::from_keypair(&secret_key1.keypair(&secp)).0;
+        let pubkey2 = XOnlyPublicKey::from_keypair(&secret_key2.keypair(&secp)).0;
+
+        let validator1 = SubnetValidator {
+            pubkey: pubkey1,
+            subnet_address: create_rand_addr(),
+            power: 10,
+            collateral: Amount::from_sat(1_000_000),
+            backup_address: Address::from_str("bcrt1qpufku8sca56kmxylyd2233mfmnr9eyc4wdsdmd")
+                .unwrap(),
+            ip: "127.0.0.1:8000".parse().unwrap(),
+            join_txid: create_rand_txid(),
+        };
+
+        let validator2 = SubnetValidator {
+            pubkey: pubkey2,
+            subnet_address: create_rand_addr(),
+            power: 15,
+            collateral: Amount::from_sat(2_000_000),
+            backup_address: Address::from_str("bcrt1qpufku8sca56kmxylyd2233mfmnr9eyc4wdsdmd")
+                .unwrap(),
+            ip: "127.0.0.1:8001".parse().unwrap(),
+            join_txid: create_rand_txid(),
+        };
+
+        // Create validators for the next committee (including a new one)
+        let (secret_key3, _) = secp.generate_keypair(&mut rand::thread_rng());
+        let pubkey3 = XOnlyPublicKey::from_keypair(&secret_key3.keypair(&secp)).0;
+
+        let validator3 = SubnetValidator {
+            pubkey: pubkey3,
+            subnet_address: create_rand_addr(),
+            power: 20,
+            collateral: Amount::from_sat(3_000_000),
+            backup_address: Address::from_str("bcrt1qpufku8sca56kmxylyd2233mfmnr9eyc4wdsdmd")
+                .unwrap(),
+            ip: "127.0.0.1:8002".parse().unwrap(),
+            join_txid: create_rand_txid(),
+        };
+
+        // Create current committee with validators 1 and 2
+        let mut current_validators = Vec::new();
+        current_validators.push(validator1.clone());
+        current_validators.push(validator2.clone());
+        let current_committee = current_validators.to_committee(&subnet_id);
+
+        // Create next committee with validators 1 and 3
+        let mut next_validators = Vec::new();
+        next_validators.push(validator1.clone());
+        next_validators.push(validator3.clone());
+        let next_committee = next_validators.to_committee(&subnet_id);
+
+        // Create subnet state
+        let mut subnet_state = SubnetState {
+            id: subnet_id,
+            committee_number: 1,
+            committee: current_committee.clone(),
+            next_committee: Some(next_committee.clone()),
+            last_checkpoint_number: None,
+        };
+
+        // Verify needs_rotation returns true when committees differ
+        assert!(subnet_state.needs_rotation());
+
+        // Verify original state
+        assert_eq!(subnet_state.committee_number, 1);
+        assert!(subnet_state.committee.is_validator(&pubkey1));
+        assert!(subnet_state.committee.is_validator(&pubkey2));
+        assert!(!subnet_state.committee.is_validator(&pubkey3));
+
+        // Perform rotation
+        subnet_state.rotate_to_next_committee().unwrap();
+
+        // Verify committee was updated
+        assert_eq!(subnet_state.committee_number, 2); // Committee number incremented
+        assert!(subnet_state.committee.is_validator(&pubkey1));
+        assert!(!subnet_state.committee.is_validator(&pubkey2)); // No longer in committee
+        assert!(subnet_state.committee.is_validator(&pubkey3)); // New validator added
+
+        // Verify next_committee was consumed
+        assert!(subnet_state.next_committee.is_none());
+
+        // Verify needs_rotation now returns false
+        assert!(!subnet_state.needs_rotation());
+
+        // Verify error when trying to rotate with no next committee
+        let result = subnet_state.rotate_to_next_committee();
+        assert!(result.is_err());
+
+        // Verify state didn't change after failed rotation
+        assert_eq!(subnet_state.committee_number, 2);
+        assert!(subnet_state.committee.is_validator(&pubkey1));
+        assert!(!subnet_state.committee.is_validator(&pubkey2));
+        assert!(subnet_state.committee.is_validator(&pubkey3));
     }
 }

--- a/src/db.rs
+++ b/src/db.rs
@@ -1168,7 +1168,8 @@ impl Database for HeedDb {
         let last_number = self.get_last_stake_change_configuration_number(subnet_id)?;
         let next_number = match last_number {
             Some(n) => n + 1,
-            None => 0,
+            // Configuration number starts with 1
+            None => 1,
         };
 
         Ok(next_number)

--- a/src/db.rs
+++ b/src/db.rs
@@ -11,6 +11,9 @@ use serde::{Deserialize, Serialize};
 use std::{io, path::Path};
 use thiserror::Error;
 
+/// Genesis committee configuration number
+const GENESIS_COMMITTEE_CONF_NUM: u64 = 0;
+
 const LAST_PROCESSED_BLOCK_KEY: &str = "monitor:last_processed_block";
 // subnet_genesis_info:<subnet_id>
 const SUBNET_GENESIS_INFO_KEY: &str = "subnet_genesis_info:";
@@ -94,7 +97,7 @@ trait SubnetValidators {
     fn total_power(&self) -> Power;
     fn threshold(&self) -> Power;
     fn multisig_address(&self, subnet_id: &SubnetId) -> Address<NetworkUnchecked>;
-    fn to_committee(&self, subnet_id: &SubnetId) -> SubnetCommittee;
+    fn to_committee(&self, subnet_id: &SubnetId, configuration_number: u64) -> SubnetCommittee;
 
     fn add_validator(&mut self, validator: &SubnetValidator) -> Result<(), DbError>;
     #[allow(unused)]
@@ -120,8 +123,9 @@ impl SubnetValidators for Vec<SubnetValidator> {
         multisig_address.into_unchecked()
     }
 
-    fn to_committee(&self, subnet_id: &SubnetId) -> SubnetCommittee {
+    fn to_committee(&self, subnet_id: &SubnetId, configuration_number: u64) -> SubnetCommittee {
         SubnetCommittee {
+            configuration_number,
             threshold: self.threshold(),
             validators: self.to_vec(),
             multisig_address: self.multisig_address(subnet_id),
@@ -164,6 +168,8 @@ impl SubnetValidators for Vec<SubnetValidator> {
 /// The committee of a subnet
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct SubnetCommittee {
+    /// The configuration number id of this committee
+    pub configuration_number: u64,
     /// The threshold for the multisig
     pub threshold: Power,
     /// The current list of validators, with their balances
@@ -233,6 +239,7 @@ impl SubnetCommittee {
         subnet_id: &SubnetId,
         validator: &SubnetValidator,
     ) -> Result<(), DbError> {
+        self.configuration_number += 1;
         self.validators.add_validator(validator)?;
         self.threshold = self.validators.threshold();
         self.multisig_address = self.validators.multisig_address(subnet_id);
@@ -261,6 +268,8 @@ pub struct SubnetCheckpoint {
     pub signed_committee_number: u64,
     /// The number of the next committee (different if rotation happened)
     pub next_committee_number: u64,
+    /// The next committee configuration number
+    pub next_configuration_number: u64,
 }
 
 /// The current state of a subnet
@@ -275,8 +284,15 @@ pub struct SubnetState {
     pub committee_number: u64,
     /// The current commitee
     pub committee: SubnetCommittee,
-    /// The next commitee, Some if it differs
-    pub next_committee: Option<SubnetCommittee>,
+    /// The waiting commitee, Some if it differ
+    ///
+    /// Waiting committee is the current committee plus
+    /// any stake change requests that are pending
+    /// Keep in mind that upon a checkpoint, not all
+    /// stake changes are guaranteed to be applied
+    /// We keep this waiting committee to check for
+    /// double-joins and such.
+    pub waiting_committee: Option<SubnetCommittee>,
     /// The number of the last checkpoint
     pub last_checkpoint_number: Option<u64>,
 }
@@ -307,19 +323,36 @@ impl SubnetState {
     }
 
     pub fn is_waiting_validator(&self, pubkey: &XOnlyPublicKey) -> bool {
-        self.next_committee
+        self.waiting_committee
             .as_ref()
             .is_some_and(|nc| nc.is_validator(pubkey))
     }
 
     pub fn needs_rotation(&self) -> bool {
-        self.next_committee
+        self.waiting_committee
             .as_ref()
             .is_some_and(|nc| self.committee != *nc)
     }
 
-    pub fn rotate_to_next_committee(&mut self) -> Result<(), DbError> {
-        if let Some(next_committee) = self.next_committee.take() {
+    pub fn rotate_to_committee(&mut self, new_committee: SubnetCommittee) {
+        if self.committee == new_committee {
+            return;
+        }
+
+        if self
+            .waiting_committee
+            .as_ref()
+            .is_some_and(|wc| *wc == new_committee)
+        {
+            self.waiting_committee = None
+        }
+
+        self.committee = new_committee;
+        self.committee_number += 1;
+    }
+
+    pub fn rotate_to_waiting_committee(&mut self) -> Result<(), DbError> {
+        if let Some(next_committee) = self.waiting_committee.take() {
             self.committee = next_committee;
             self.committee_number += 1;
             Ok(())
@@ -417,8 +450,10 @@ impl SubnetGenesisInfo {
             id: self.subnet_id,
             committee_number: 1,
             last_checkpoint_number: None,
-            committee: self.genesis_validators.to_committee(&self.subnet_id),
-            next_committee: None,
+            committee: self
+                .genesis_validators
+                .to_committee(&self.subnet_id, GENESIS_COMMITTEE_CONF_NUM),
+            waiting_committee: None,
         }
     }
 
@@ -517,6 +552,8 @@ pub struct StakeChangeRequest {
     /// Configuration number is practically an incremental "nonce"
     /// of a single change request/event
     pub configuration_number: u64,
+    /// State of the committee after the change was applied
+    pub committee_after_change: SubnetCommittee,
 
     /// The block height of the Bitcoin block where the change request was recorded
     pub block_height: u64,
@@ -787,9 +824,10 @@ pub trait Database {
         &self,
         txn: &mut RwTxn,
         subnet_id: SubnetId,
+        max_configuration_number: u64,
         confirmed_block_height: u64,
         confirmed_block_hash: BlockHash,
-    ) -> Result<Vec<StakeChangeRequest>, DbError>;
+    ) -> Result<(Option<StakeChangeRequest>, Vec<StakeChangeRequest>), DbError>;
 }
 
 #[async_trait]
@@ -1168,8 +1206,7 @@ impl Database for HeedDb {
         let last_number = self.get_last_stake_change_configuration_number(subnet_id)?;
         let next_number = match last_number {
             Some(n) => n + 1,
-            // Configuration number starts with 1
-            None => 1,
+            None => GENESIS_COMMITTEE_CONF_NUM + 1,
         };
 
         Ok(next_number)
@@ -1191,18 +1228,24 @@ impl Database for HeedDb {
         &self,
         txn: &mut RwTxn,
         subnet_id: SubnetId,
+        max_configuration_number: u64,
         confirmed_block_height: u64,
         confirmed_block_hash: BlockHash,
-    ) -> Result<Vec<StakeChangeRequest>, DbError> {
+    ) -> Result<(Option<StakeChangeRequest>, Vec<StakeChangeRequest>), DbError> {
         // Get all stake changes for the subnet
         let stake_changes = self.get_all_stake_changes(subnet_id)?;
 
-        // Filter unconfirmed stake changes
-        let mut updated_changes = Vec::new();
+        // Filter unconfirmed stake changes that are up to the specified configuration number
+        let mut last_confirmed: Option<StakeChangeRequest> = None;
+        let mut confirmed_changes = Vec::new();
 
         for mut change in stake_changes {
-            // Check if the stake change is unconfirmed
-            if change.checkpoint_block_height.is_none() {
+            // Only process changes that:
+            // 1. Are not yet confirmed (checkpoint_block_height is None)
+            // 2. Have a configuration number <= max_configuration_number
+            if change.checkpoint_block_height.is_none()
+                && change.configuration_number <= max_configuration_number
+            {
                 // Set the confirmation details
                 change.checkpoint_block_height = Some(confirmed_block_height);
                 change.checkpoint_block_hash = Some(confirmed_block_hash);
@@ -1211,12 +1254,19 @@ impl Database for HeedDb {
                 let key = stake_change_key(subnet_id, change.configuration_number);
                 self.stake_changes_db.put(txn, &key, &change)?;
 
-                // Add to the list of updated changes
-                updated_changes.push(change);
+                // Update the last confirmed change if this one has a higher configuration number
+                if last_confirmed.as_ref().map_or(true, |last| {
+                    change.configuration_number > last.configuration_number
+                }) {
+                    last_confirmed = Some(change.clone());
+                }
+
+                // Add to the list of confirmed changes
+                confirmed_changes.push(change);
             }
         }
 
-        Ok(updated_changes)
+        Ok((last_confirmed, confirmed_changes))
     }
 }
 
@@ -1501,7 +1551,7 @@ mod tests {
         initial_validators.push(validator1);
         initial_validators.push(validator2);
 
-        let mut committee = initial_validators.to_committee(&subnet_id);
+        let mut committee = initial_validators.to_committee(&subnet_id, 0);
 
         // Verify initial state
         assert_eq!(committee.validators.len(), 2);
@@ -1599,20 +1649,20 @@ mod tests {
         let mut current_validators = Vec::new();
         current_validators.push(validator1.clone());
         current_validators.push(validator2.clone());
-        let current_committee = current_validators.to_committee(&subnet_id);
+        let current_committee = current_validators.to_committee(&subnet_id, 1);
 
         // Create next committee with validators 1 and 3
         let mut next_validators = Vec::new();
         next_validators.push(validator1.clone());
         next_validators.push(validator3.clone());
-        let next_committee = next_validators.to_committee(&subnet_id);
+        let next_committee = next_validators.to_committee(&subnet_id, 2);
 
         // Create subnet state
         let mut subnet_state = SubnetState {
             id: subnet_id,
             committee_number: 1,
             committee: current_committee.clone(),
-            next_committee: Some(next_committee.clone()),
+            waiting_committee: Some(next_committee.clone()),
             last_checkpoint_number: None,
         };
 
@@ -1626,7 +1676,7 @@ mod tests {
         assert!(!subnet_state.committee.is_validator(&pubkey3));
 
         // Perform rotation
-        subnet_state.rotate_to_next_committee().unwrap();
+        subnet_state.rotate_to_waiting_committee().unwrap();
 
         // Verify committee was updated
         assert_eq!(subnet_state.committee_number, 2); // Committee number incremented
@@ -1635,13 +1685,13 @@ mod tests {
         assert!(subnet_state.committee.is_validator(&pubkey3)); // New validator added
 
         // Verify next_committee was consumed
-        assert!(subnet_state.next_committee.is_none());
+        assert!(subnet_state.waiting_committee.is_none());
 
         // Verify needs_rotation now returns false
         assert!(!subnet_state.needs_rotation());
 
         // Verify error when trying to rotate with no next committee
-        let result = subnet_state.rotate_to_next_committee();
+        let result = subnet_state.rotate_to_waiting_committee();
         assert!(result.is_err());
 
         // Verify state didn't change after failed rotation
@@ -1718,8 +1768,8 @@ mod tests {
         validators_set2.push(validator1_set2);
         validators_set2.push(validator2_set2);
 
-        let committee1 = validators_set1.to_committee(&subnet_id);
-        let committee2 = validators_set2.to_committee(&subnet_id);
+        let committee1 = validators_set1.to_committee(&subnet_id, 0);
+        let committee2 = validators_set2.to_committee(&subnet_id, 0);
 
         // Verify both committees have the same validators (by pubkey)
         assert_eq!(committee1.pubkeys(), committee2.pubkeys());

--- a/src/db.rs
+++ b/src/db.rs
@@ -79,6 +79,10 @@ trait SubnetValidators {
     fn threshold(&self) -> Power;
     fn multisig_address(&self, subnet_id: &SubnetId) -> Address<NetworkUnchecked>;
     fn to_committee(&self, subnet_id: &SubnetId) -> SubnetCommittee;
+
+    fn add_validator(&mut self, validator: &SubnetValidator) -> Result<(), DbError>;
+    #[allow(unused)]
+    fn rm_validator(&mut self, validator_xpk: &XOnlyPublicKey) -> Result<SubnetValidator, DbError>;
 }
 
 impl SubnetValidators for Vec<SubnetValidator> {
@@ -105,6 +109,38 @@ impl SubnetValidators for Vec<SubnetValidator> {
             threshold: self.threshold(),
             validators: self.to_vec(),
             multisig_address: self.multisig_address(subnet_id),
+        }
+    }
+
+    fn add_validator(&mut self, validator: &SubnetValidator) -> Result<(), DbError> {
+        // Check if the validator already exists
+        if self.iter().any(|v| v.pubkey == validator.pubkey) {
+            return Err(DbError::InvalidChange(format!(
+                "Validator with public key {} already exists",
+                validator.pubkey
+            )));
+        }
+
+        // Add the validator
+        self.push(validator.clone());
+
+        Ok(())
+    }
+
+    fn rm_validator(&mut self, validator_xpk: &XOnlyPublicKey) -> Result<SubnetValidator, DbError> {
+        // Find the validator
+        let position = self.iter().position(|v| &v.pubkey == validator_xpk);
+
+        // Check if the validator exists
+        if let Some(pos) = position {
+            // Remove and return the validator
+            let validator = self.remove(pos);
+            Ok(validator)
+        } else {
+            Err(DbError::InvalidChange(format!(
+                "Validator with public key {} not found",
+                validator_xpk
+            )))
         }
     }
 }
@@ -165,6 +201,17 @@ impl SubnetCommittee {
     pub fn is_validator(&self, pubkey: &XOnlyPublicKey) -> bool {
         self.validators.iter().any(|v| &v.pubkey == pubkey)
     }
+
+    pub fn join_validator(
+        &mut self,
+        subnet_id: &SubnetId,
+        validator: &SubnetValidator,
+    ) -> Result<(), DbError> {
+        self.validators.add_validator(validator)?;
+        self.threshold = self.validators.threshold();
+        self.multisig_address = self.validators.multisig_address(subnet_id);
+        Ok(())
+    }
 }
 
 /// Subnet checkpoint
@@ -202,13 +249,15 @@ pub struct SubnetState {
     pub committee_number: u64,
     /// The current commitee
     pub committee: SubnetCommittee,
+    /// The next commitee, if it differs
+    pub next_committee: Option<SubnetCommittee>,
     /// The number of the last checkpoint
     pub last_checkpoint_number: Option<u64>,
 }
 
 impl SubnetState {
     /// Returns the total stake of the current committee
-    pub fn stake(&self) -> bitcoin::Amount {
+    pub fn total_collateral(&self) -> bitcoin::Amount {
         self.committee.validators.iter().map(|v| v.collateral).sum()
     }
 
@@ -229,6 +278,18 @@ impl SubnetState {
 
     pub fn is_validator(&self, pubkey: &XOnlyPublicKey) -> bool {
         self.committee.is_validator(pubkey)
+    }
+
+    pub fn rotate_to_next_committee(&mut self) -> Result<(), DbError> {
+        if let Some(next_committee) = self.next_committee.take() {
+            self.committee = next_committee;
+            self.committee_number += 1;
+            Ok(())
+        } else {
+            Err(DbError::InvalidChange(
+                "No next committee to rotate to".to_string(),
+            ))
+        }
     }
 }
 
@@ -319,6 +380,7 @@ impl SubnetGenesisInfo {
             committee_number: 1,
             last_checkpoint_number: None,
             committee: self.genesis_validators.to_committee(&self.subnet_id),
+            next_committee: None,
         }
     }
 
@@ -855,6 +917,10 @@ pub enum DbError {
     #[error("Key {0} could not be modified: {1}")]
     KeyModificationError(String, String),
 
+    /// Generic error that can be returned by our database
+    #[error("{0}")]
+    InvalidChange(String),
+
     #[error(transparent)]
     IoError(#[from] io::Error),
 
@@ -869,6 +935,7 @@ pub enum DbError {
 mod tests {
     use super::*;
     use bitcoin::{hashes::Hash, Amount, BlockHash, Txid};
+    use std::str::FromStr;
     use tempfile::tempdir;
 
     fn create_test_db() -> HeedDb {
@@ -1074,5 +1141,89 @@ mod tests {
         for (i, &nonce) in nonces.iter().enumerate() {
             assert_eq!(nonce, expected_first_nonce as u64 + i as u64);
         }
+    }
+
+    #[test]
+    fn test_subnet_committee_join_validator() {
+        // Setup: Create a subnet ID and initial committee
+        let subnet_id = create_rand_subnet_id();
+
+        // Create initial validators
+        let secp = bitcoin::secp256k1::Secp256k1::new();
+        let (secret_key1, _) = secp.generate_keypair(&mut rand::thread_rng());
+        let (secret_key2, _) = secp.generate_keypair(&mut rand::thread_rng());
+        let pubkey1 = XOnlyPublicKey::from_keypair(&secret_key1.keypair(&secp)).0;
+        let pubkey2 = XOnlyPublicKey::from_keypair(&secret_key2.keypair(&secp)).0;
+
+        let validator1 = SubnetValidator {
+            pubkey: pubkey1,
+            subnet_address: create_rand_addr(),
+            power: 10,
+            collateral: Amount::from_sat(1_000_000),
+            backup_address: Address::from_str("bcrt1qpufku8sca56kmxylyd2233mfmnr9eyc4wdsdmd")
+                .unwrap(),
+            ip: "127.0.0.1:8000".parse().unwrap(),
+            join_txid: create_rand_txid(),
+        };
+
+        let validator2 = SubnetValidator {
+            pubkey: pubkey2,
+            subnet_address: create_rand_addr(),
+            power: 15,
+            collateral: Amount::from_sat(2_000_000),
+            backup_address: Address::from_str("bcrt1qpufku8sca56kmxylyd2233mfmnr9eyc4wdsdmd")
+                .unwrap(),
+            ip: "127.0.0.1:8001".parse().unwrap(),
+            join_txid: create_rand_txid(),
+        };
+
+        // Create initial committee with two validators
+        let mut initial_validators = Vec::new();
+        initial_validators.push(validator1);
+        initial_validators.push(validator2);
+
+        let mut committee = initial_validators.to_committee(&subnet_id);
+
+        // Verify initial state
+        assert_eq!(committee.validators.len(), 2);
+        assert_eq!(committee.total_power(), 25); // 10 + 15
+        let initial_threshold = committee.threshold;
+        let initial_address = committee.multisig_address.clone();
+
+        // Create new validator to add
+        let (secret_key3, _) = secp.generate_keypair(&mut rand::thread_rng());
+        let pubkey3 = XOnlyPublicKey::from_keypair(&secret_key3.keypair(&secp)).0;
+
+        let validator3 = SubnetValidator {
+            pubkey: pubkey3,
+            subnet_address: create_rand_addr(),
+            power: 20,
+            collateral: Amount::from_sat(3_000_000),
+            backup_address: Address::from_str("bcrt1qpufku8sca56kmxylyd2233mfmnr9eyc4wdsdmd")
+                .unwrap(),
+            ip: "127.0.0.1:8002".parse().unwrap(),
+            join_txid: create_rand_txid(),
+        };
+
+        // Add the new validator
+        committee.join_validator(&subnet_id, &validator3).unwrap();
+
+        // Verify the validator was added
+        assert_eq!(committee.validators.len(), 3);
+        assert!(committee.is_validator(&pubkey3));
+
+        // Verify the power and threshold updated
+        assert_eq!(committee.total_power(), 45); // 10 + 15 + 20
+        assert!(committee.threshold > initial_threshold);
+
+        // Verify multisig address changed
+        assert_ne!(committee.multisig_address, initial_address);
+
+        // Try adding an existing validator (should fail)
+        let result = committee.join_validator(&subnet_id, &validator3);
+        assert!(result.is_err());
+
+        // Verify committee size didn't change after failed addition
+        assert_eq!(committee.validators.len(), 3);
     }
 }

--- a/src/db.rs
+++ b/src/db.rs
@@ -1114,7 +1114,7 @@ impl Database for HeedDb {
     }
 
     /// Returns all stake changes for a given subnet
-    /// for a given height, looking at *confirmed* block height
+    /// for a given height
     fn get_stake_changes_by_height(
         &self,
         subnet_id: SubnetId,
@@ -1129,10 +1129,7 @@ impl Database for HeedDb {
             .map(|res| res.map(|(_, change)| change))
             .filter_map(|res| match res {
                 Ok(change) => {
-                    if change
-                        .checkpoint_block_height
-                        .is_some_and(|cbh| cbh == block_height)
-                    {
+                    if change.block_height == block_height {
                         Some(Ok(change))
                     } else {
                         None

--- a/src/ipc_lib.rs
+++ b/src/ipc_lib.rs
@@ -560,12 +560,15 @@ impl IpcJoinSubnetMsg {
             let stake_change_configuration_number =
                 db.get_next_stake_change_configuration_number(self.subnet_id)?;
 
+            let validator_subnet_address = eth_addr_from_x_only_pubkey(self.pubkey);
+
             // Join
             let stake_change_join = db::StakeChangeRequest {
                 change: db::StakingChange::Join {
                     pubkey: self.pubkey.public_key(bitcoin::secp256k1::Parity::Even),
                 },
                 validator_xpk: self.pubkey,
+                validator_subnet_address,
                 block_height,
                 block_hash,
                 checkpoint_block_height: None,
@@ -579,6 +582,7 @@ impl IpcJoinSubnetMsg {
                     amount: self.collateral,
                 },
                 validator_xpk: self.pubkey,
+                validator_subnet_address,
                 block_height,
                 block_hash,
                 checkpoint_block_height: None,

--- a/src/ipc_lib.rs
+++ b/src/ipc_lib.rs
@@ -324,19 +324,10 @@ pub struct IpcJoinSubnetMsg {
 
 impl IpcJoinSubnetMsg {
     /// Validates the join subnet message, for the given genesis info
-    pub fn validate_for_genesis_info(
+    pub fn validate_pre_bootstrap(
         &self,
         genesis_info: &db::SubnetGenesisInfo,
     ) -> Result<(), IpcValidateError> {
-        // Check if the subnet is already bootstrapped
-        if genesis_info.bootstrapped {
-            // TODO handle when subnet already bootstrapped
-            return Err(IpcValidateError::InvalidMsg(format!(
-                "Subnet {} is already bootstrapped.",
-                self.subnet_id
-            )));
-        }
-
         // Check if the collateral is at least the minimum validator stake
         if self.collateral < genesis_info.create_subnet_msg.min_validator_stake {
             return Err(IpcValidateError::InvalidField(
@@ -368,11 +359,79 @@ impl IpcJoinSubnetMsg {
         {
             return Err(IpcValidateError::InvalidField(
                 "pubkey",
-                "Validator with this public key already registered in subnet".to_string(),
+                format!(
+                    "Validator with public key '{}' already registered in subnet",
+                    self.pubkey
+                ),
             ));
         }
 
         Ok(())
+    }
+
+    /// Validates the join subnet message, for the given genesis info
+    /// and current subnet state
+    pub fn validate_post_bootstrap(
+        &self,
+        genesis_info: &db::SubnetGenesisInfo,
+        subnet: &db::SubnetState,
+    ) -> Result<(), IpcValidateError> {
+        // Check if the collateral is at least the minimum validator stake
+        if self.collateral < genesis_info.create_subnet_msg.min_validator_stake {
+            return Err(IpcValidateError::InvalidField(
+                "collateral",
+                format!(
+                    "Collateral must be at least {}, supplied {}",
+                    genesis_info.create_subnet_msg.min_validator_stake, self.collateral,
+                ),
+            ));
+        }
+
+        // Check if the validator with this public key is already registered
+        if subnet.committee.is_validator(&self.pubkey) {
+            return Err(IpcValidateError::InvalidMsg(format!(
+                "Validator with public key '{}' already registered in subnet",
+                self.pubkey
+            )));
+        }
+
+        // Check if the validator with this public key is already registered
+        // and waiting in the next committee
+        if subnet
+            .next_committee
+            .as_ref()
+            .is_some_and(|c| c.is_validator(&self.pubkey))
+        {
+            return Err(IpcValidateError::InvalidMsg(format!(
+                "Validator with public key '{}' already registered in subnet, waiting for next committee",
+                self.pubkey
+            )));
+        }
+
+        Ok(())
+    }
+
+    /// Validates the join subnet message, for the given genesis info
+    pub fn validate_for_subnet(
+        &self,
+        genesis_info: &db::SubnetGenesisInfo,
+        subnet: &Option<db::SubnetState>,
+    ) -> Result<(), IpcValidateError> {
+        if let Some(subnet) = subnet {
+            if subnet.id != self.subnet_id {
+                return Err(IpcValidateError::InvalidField(
+                    "subnet_id",
+                    format!(
+                        "Subnet ID mismatch: expected {}, got {}",
+                        subnet.id, self.subnet_id
+                    ),
+                ));
+            }
+
+            self.validate_post_bootstrap(genesis_info, subnet)
+        } else {
+            self.validate_pre_bootstrap(genesis_info)
+        }
     }
 
     /// Submits the join subnet message to the Bitcoin network
@@ -422,7 +481,9 @@ impl IpcJoinSubnetMsg {
     }
 
     /// Modifies the database to account for the join subnet message
-    /// Returning SubnetState if the subnet is bootstrapped
+    /// Returning SubnetState *only* if the subnet is bootstrapped
+    ///
+    /// It will return None if processed for an already bootstrapped subnet
     pub fn save_to_db<D: db::Database>(
         &self,
         db: &D,
@@ -436,7 +497,12 @@ impl IpcJoinSubnetMsg {
                     self.subnet_id
                 )))?;
 
-        self.validate_for_genesis_info(&genesis_info)?;
+        let subnet_state = db.get_subnet_state(self.subnet_id).map_err(|e| {
+            error!("Error getting subnet info from Db: {}", e);
+            IpcValidateError::InvalidMsg(e.to_string())
+        })?;
+
+        self.validate_for_subnet(&genesis_info, &subnet_state)?;
 
         let subnet_address = eth_addr_from_x_only_pubkey(self.pubkey);
 
@@ -455,29 +521,76 @@ impl IpcJoinSubnetMsg {
             join_txid: txid,
         };
         trace!("Processing {self:?}, adding new validator {new_validator:?}");
-        genesis_info.genesis_validators.push(new_validator);
-
-        // Write to DB
-        let mut wtxn = db.write_txn()?;
 
         //
-        // Check if the subnet is bootstrapped
+        // Handle post-bootstrap case
         //
-        if genesis_info.enough_to_bootstrap() {
-            trace!("Subnet {} bootstrapped", self.subnet_id);
-            genesis_info.bootstrapped = true;
-            genesis_info.genesis_block_height = Some(block_height);
+        if let Some(mut subnet) = subnet_state {
+            if subnet.is_validator(&self.pubkey) {
+                return Err(IpcValidateError::InvalidField(
+                    "pubkey",
+                    format!(
+                        "Validator with public key '{}' already registered in subnet",
+                        self.pubkey
+                    ),
+                )
+                .into());
+            }
 
-            // Save the newly create subnet state
-            let subnet_state = genesis_info.to_subnet();
-            db.save_subnet_state(&mut wtxn, self.subnet_id, &subnet_state)?;
-            db.save_subnet_genesis_info(&mut wtxn, self.subnet_id, &genesis_info)?;
+            let mut next_commitee = subnet
+                .next_committee
+                .unwrap_or_else(|| subnet.committee.clone());
+
+            if next_commitee.is_validator(&self.pubkey) {
+                return Err(IpcValidateError::InvalidField(
+                    "pubkey",
+                    format!(
+						"Validator with public key '{}' already registered in subnet, waiting in next committee.",
+						self.pubkey
+					),
+                )
+                .into());
+            }
+
+            next_commitee.join_validator(&subnet.id, &new_validator)?;
+
+            subnet.next_committee = Some(next_commitee);
+
+            // Write to DB
+            let mut wtxn = db.write_txn()?;
+            db.save_subnet_state(&mut wtxn, self.subnet_id, &subnet)?;
             wtxn.commit()?;
-            Ok(Some(subnet_state))
-        } else {
-            db.save_subnet_genesis_info(&mut wtxn, self.subnet_id, &genesis_info)?;
-            wtxn.commit()?;
+
             Ok(None)
+        }
+        //
+        // Handle pre-bootstrap case
+        //
+        else {
+            genesis_info.genesis_validators.push(new_validator);
+
+            // Write to DB
+            let mut wtxn = db.write_txn()?;
+
+            //
+            // Check if the subnet is bootstrapped
+            //
+            if genesis_info.enough_to_bootstrap() {
+                info!("Subnet ID: {} has been bootstrapped", self.subnet_id);
+                genesis_info.bootstrapped = true;
+                genesis_info.genesis_block_height = Some(block_height);
+
+                // Save the newly create subnet state
+                let subnet_state = genesis_info.to_subnet();
+                db.save_subnet_state(&mut wtxn, self.subnet_id, &subnet_state)?;
+                db.save_subnet_genesis_info(&mut wtxn, self.subnet_id, &genesis_info)?;
+                wtxn.commit()?;
+                Ok(Some(subnet_state))
+            } else {
+                db.save_subnet_genesis_info(&mut wtxn, self.subnet_id, &genesis_info)?;
+                wtxn.commit()?;
+                Ok(None)
+            }
         }
     }
 }

--- a/src/ipc_lib.rs
+++ b/src/ipc_lib.rs
@@ -488,6 +488,7 @@ impl IpcJoinSubnetMsg {
         &self,
         db: &D,
         block_height: u64,
+        block_hash: bitcoin::BlockHash,
         txid: Txid,
     ) -> Result<Option<db::SubnetState>, IpcLibError> {
         let mut genesis_info =
@@ -556,9 +557,41 @@ impl IpcJoinSubnetMsg {
 
             subnet.next_committee = Some(next_commitee);
 
+            let stake_change_configuration_number =
+                db.get_next_stake_change_configuration_number(self.subnet_id)?;
+
+            // Join
+            let stake_change_join = db::StakeChangeRequest {
+                change: db::StakingChange::Join {
+                    pubkey: self.pubkey.public_key(bitcoin::secp256k1::Parity::Even),
+                },
+                validator_xpk: self.pubkey,
+                block_height,
+                block_hash,
+                checkpoint_block_height: None,
+                checkpoint_block_hash: None,
+                configuration_number: stake_change_configuration_number,
+                txid,
+            };
+            // Deposit
+            let stake_change = db::StakeChangeRequest {
+                change: db::StakingChange::Deposit {
+                    amount: self.collateral,
+                },
+                validator_xpk: self.pubkey,
+                block_height,
+                block_hash,
+                checkpoint_block_height: None,
+                checkpoint_block_hash: None,
+                configuration_number: stake_change_configuration_number + 1,
+                txid,
+            };
+
             // Write to DB
             let mut wtxn = db.write_txn()?;
             db.save_subnet_state(&mut wtxn, self.subnet_id, &subnet)?;
+            db.add_stake_change(&mut wtxn, self.subnet_id, stake_change_join)?;
+            db.add_stake_change(&mut wtxn, self.subnet_id, stake_change)?;
             wtxn.commit()?;
 
             Ok(None)

--- a/src/ipc_lib.rs
+++ b/src/ipc_lib.rs
@@ -1539,6 +1539,8 @@ impl IpcCheckpointSubnetMsg {
             self.subnet_id
         );
 
+        let committee_change_address = committee.address_checked();
+
         let mut tx_outs = vec![];
 
         //
@@ -1622,7 +1624,7 @@ impl IpcCheckpointSubnetMsg {
         let checkpoint_tx = multisig::construct_spend_unsigned_transaction(
             &committee_keys,
             committee.threshold,
-            &committee.address_checked(),
+            &committee_change_address,
             unspent,
             &tx_outs,
             &fee_rate,

--- a/src/ipc_lib.rs
+++ b/src/ipc_lib.rs
@@ -9,6 +9,7 @@ use log::error;
 use log::trace;
 use log::warn;
 use log::{debug, info};
+use num_traits::Zero;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::str::FromStr;
@@ -398,7 +399,7 @@ impl IpcJoinSubnetMsg {
         // Check if the validator with this public key is already registered
         // and waiting in the next committee
         if subnet
-            .next_committee
+            .waiting_committee
             .as_ref()
             .is_some_and(|c| c.is_validator(&self.pubkey))
         {
@@ -539,7 +540,7 @@ impl IpcJoinSubnetMsg {
             }
 
             let mut next_commitee = subnet
-                .next_committee
+                .waiting_committee
                 .unwrap_or_else(|| subnet.committee.clone());
 
             if next_commitee.is_validator(&self.pubkey) {
@@ -554,8 +555,7 @@ impl IpcJoinSubnetMsg {
             }
 
             next_commitee.join_validator(&subnet.id, &new_validator)?;
-
-            subnet.next_committee = Some(next_commitee);
+            subnet.waiting_committee = Some(next_commitee.clone());
 
             let stake_change_configuration_number =
                 db.get_next_stake_change_configuration_number(self.subnet_id)?;
@@ -569,11 +569,13 @@ impl IpcJoinSubnetMsg {
                 },
                 validator_xpk: self.pubkey,
                 validator_subnet_address,
+                configuration_number: stake_change_configuration_number,
+                committee_after_change: next_commitee.clone(),
+
                 block_height,
                 block_hash,
                 checkpoint_block_height: None,
                 checkpoint_block_hash: None,
-                configuration_number: stake_change_configuration_number,
                 txid,
             };
             // Deposit
@@ -583,11 +585,13 @@ impl IpcJoinSubnetMsg {
                 },
                 validator_xpk: self.pubkey,
                 validator_subnet_address,
+                configuration_number: stake_change_configuration_number + 1,
+                committee_after_change: next_commitee.clone(),
+
                 block_height,
                 block_hash,
                 checkpoint_block_height: None,
                 checkpoint_block_hash: None,
-                configuration_number: stake_change_configuration_number + 1,
                 txid,
             };
 
@@ -1195,6 +1199,8 @@ pub struct IpcCheckpointSubnetMsg {
     pub checkpoint_hash: bitcoin::hashes::sha256::Hash,
     /// The checkpoint height of child chain
     pub checkpoint_height: u64,
+    /// Committee configuration number
+    pub next_committee_configuration_number: u64,
     /// Withdrawals
     #[serde(default)]
     pub withdrawals: Vec<IpcWithdrawal>,
@@ -1286,18 +1292,22 @@ impl IpcCheckpointSubnetMsg {
     const MARKERS_LEN: usize = 2;
     // u64 length
     const HEIGHT_LEN: usize = std::mem::size_of::<u64>();
+    // u64 length
+    const COMMITTEE_CONF_LEN: usize = std::mem::size_of::<u64>();
     // The total length of the op_return data - helper
     const DATA_LEN: usize = IPC_TAG_LENGTH
         + SubnetId::INNER_LEN
         + bitcoin::hashes::sha256::Hash::LEN
         + Self::MARKERS_LEN
-        + Self::HEIGHT_LEN;
+        + Self::HEIGHT_LEN
+        + Self::COMMITTEE_CONF_LEN;
 
     const TAG_OFFSET: usize = 0;
     const TXID_OFFSET: usize = Self::TAG_OFFSET + IPC_TAG_LENGTH;
     const HASH_OFFSET: usize = Self::TXID_OFFSET + SubnetId::INNER_LEN;
     const HEIGHT_OFFSET: usize = Self::HASH_OFFSET + bitcoin::hashes::sha256::Hash::LEN;
     const MARKERS_OFFSET: usize = Self::HEIGHT_OFFSET + Self::HEIGHT_LEN;
+    const COMMITTEE_CONF_OFFSET: usize = Self::MARKERS_OFFSET + Self::MARKERS_LEN;
 
     fn make_metadata_tx_out(&self, fee_rate: bitcoin::FeeRate) -> bitcoin::TxOut {
         let mut op_return_data = [0u8; Self::DATA_LEN];
@@ -1321,6 +1331,10 @@ impl IpcCheckpointSubnetMsg {
         // Set marker values
         op_return_data[Self::MARKERS_OFFSET] = self.withdrawals.len().min(255) as u8; // Withdrawal count
         op_return_data[Self::MARKERS_OFFSET + 1] = self.transfers.len().min(255) as u8; // Transfer count
+
+        // Add committee configuration number
+        op_return_data[Self::COMMITTEE_CONF_OFFSET..]
+            .copy_from_slice(&self.next_committee_configuration_number.to_le_bytes());
 
         let push_bytes: &bitcoin::script::PushBytes =
             (&op_return_data[..]).try_into().expect("the size is okay");
@@ -1701,7 +1715,7 @@ impl IpcCheckpointSubnetMsg {
     ///
     /// The checkpoint transaction has:
     /// 1. An OP_RETURN output with metadata in the format:
-    ///    [checkpoint tag | 32-byte subnet ID txid | 32-byte checkpoint hash | 1-byte withdrawal count | 1-byte transfer count]
+    ///    [checkpoint tag | 32-byte subnet ID txid | 32-byte checkpoint hash | 1-byte withdrawal count | 1-byte transfer count | 8-byte committee configuration number]
     /// 2. Withdrawal outputs for each withdrawal
     /// 3. Optional batch transfer commit output if transfers exist
     /// 4. Transfer outputs for each transfer
@@ -1770,6 +1784,13 @@ impl IpcCheckpointSubnetMsg {
         // Extract marker values
         let withdrawals_count = op_return_data[Self::MARKERS_OFFSET] as usize;
         let transfers_count = op_return_data[Self::MARKERS_OFFSET + 1] as usize;
+
+        // Extract committee configuration number
+        let committee_conf_bytes = &op_return_data[Self::COMMITTEE_CONF_OFFSET..];
+        let next_committee_configuration_number =
+            u64::from_le_bytes(committee_conf_bytes.try_into().map_err(|_| {
+                err("Failed to convert committee configuration number bytes to u64".to_string())
+            })?);
 
         // Check if we have enough outputs for all the withdrawals and transfers
         let expected_outputs = 1 + // metadata
@@ -1863,6 +1884,7 @@ impl IpcCheckpointSubnetMsg {
             subnet_id,
             checkpoint_hash,
             checkpoint_height,
+            next_committee_configuration_number,
             withdrawals,
             transfers,
             change_address,
@@ -1879,8 +1901,8 @@ impl IpcCheckpointSubnetMsg {
         &self,
         db: &D,
         block_height: u64,
+        block_hash: bitcoin::BlockHash,
         txid: Txid,
-        // batch_transfer_txid: Option<Txid>,
     ) -> Result<db::SubnetCheckpoint, IpcLibError> {
         // Get the current subnet state
         let mut subnet_state = db.get_subnet_state(self.subnet_id)?.ok_or_else(|| {
@@ -1888,6 +1910,62 @@ impl IpcCheckpointSubnetMsg {
         })?;
 
         let checkpoint_number = subnet_state.last_checkpoint_number.map_or(0, |n| n + 1);
+        let last_committee_configuration_number = subnet_state.committee.configuration_number;
+
+        let stake_change = if
+        // If next_committee_configuration_number is zero, it "could mean" no change
+        self.next_committee_configuration_number.is_zero()
+            || self.next_committee_configuration_number == last_committee_configuration_number
+        {
+            // No committee rotation, no stake change
+            None
+        } else {
+            if self.next_committee_configuration_number < last_committee_configuration_number {
+                return Err(IpcValidateError::InvalidField(
+                    "next_committee_configuration_number",
+                    format!(
+                        "Next committee configuration number {} is less than the last one {}",
+                        self.next_committee_configuration_number,
+                        last_committee_configuration_number
+                    ),
+                )
+                .into());
+            }
+
+            let stake_change =
+                db.get_stake_change(self.subnet_id, self.next_committee_configuration_number)?;
+
+            if stake_change.is_none() {
+                return Err(IpcValidateError::InvalidField(
+                    "next_committee_configuration_number",
+                    format!(
+                        "Stake change for committee configuration number {} does not exist",
+                        self.next_committee_configuration_number
+                    ),
+                )
+                .into());
+            }
+
+            stake_change
+        };
+
+        let next_committee = stake_change.clone().map(|sc| sc.committee_after_change);
+
+        let (next_committee_number, next_configuration_number) =
+            if let Some(stake_change) = stake_change {
+                // Increment the committee number
+                // And use the new configuration number
+                (
+                    subnet_state.committee_number + 1,
+                    stake_change.configuration_number,
+                )
+            } else {
+                // No committee rotation, use the current committee number
+                (
+                    subnet_state.committee_number,
+                    subnet_state.committee.configuration_number,
+                )
+            };
 
         // Create a new checkpoint record
         let checkpoint = db::SubnetCheckpoint {
@@ -1900,12 +1978,17 @@ impl IpcCheckpointSubnetMsg {
             batch_transfer_txid: None,
             batch_transfer_block_height: None,
             signed_committee_number: subnet_state.committee_number,
-            // No committee rotation yet
-            next_committee_number: subnet_state.committee_number,
+            next_committee_number,
+            next_configuration_number,
         };
 
         // Update the checkpoint number in subnet state
         subnet_state.last_checkpoint_number = Some(checkpoint_number);
+
+        // Update subnet state with the new committee
+        if let Some(next_committee) = &next_committee {
+            subnet_state.rotate_to_committee(next_committee.clone());
+        }
 
         // Begin a database transaction
         let mut wtxn = db.write_txn()?;
@@ -1913,6 +1996,24 @@ impl IpcCheckpointSubnetMsg {
         db.save_subnet_state(&mut wtxn, self.subnet_id, &subnet_state)?;
         // Save the checkpoint record
         db.save_checkpoint(&mut wtxn, self.subnet_id, &checkpoint, checkpoint_number)?;
+        // Save new committee if changed
+        if let Some(next_committee) = &next_committee {
+            db.save_committee(
+                &mut wtxn,
+                self.subnet_id,
+                next_committee_number,
+                next_committee,
+            )?;
+
+            // Update the stake changes
+            db.confirm_stake_changes(
+                &mut wtxn,
+                self.subnet_id,
+                self.next_committee_configuration_number,
+                block_height,
+                block_hash,
+            )?;
+        }
 
         // Commit the transaction
         wtxn.commit()?;
@@ -3089,6 +3190,7 @@ mod checkpoint_msg_tests {
             withdrawals: vec![withdrawal],
             transfers: vec![transfer],
             change_address: Some(subnet_state.committee.multisig_address.clone()),
+            next_committee_configuration_number: 30, // arbitrary test number
         }
     }
 
@@ -3232,6 +3334,7 @@ mod checkpoint_msg_tests {
             withdrawals: vec![withdrawal, withdrawal2],
             transfers: vec![],
             change_address: Some(committee.multisig_address.clone()),
+            next_committee_configuration_number: 1,
         };
 
         let fee_rate = DEFAULT_BTC_FEE_RATE;
@@ -3310,6 +3413,7 @@ mod checkpoint_msg_tests {
             withdrawals: vec![],
             transfers: vec![],
             change_address: Some(committee.multisig_address.clone()),
+            next_committee_configuration_number: 1,
         };
 
         let fee_rate = DEFAULT_BTC_FEE_RATE;
@@ -3460,6 +3564,7 @@ mod checkpoint_msg_tests {
             withdrawals: vec![],
             transfers: vec![transfer1.clone(), transfer2.clone(), transfer3.clone()],
             change_address: Some(committee.multisig_address.clone()),
+            next_committee_configuration_number: 1,
         };
 
         let fee_rate = DEFAULT_BTC_FEE_RATE;

--- a/src/ipc_lib.rs
+++ b/src/ipc_lib.rs
@@ -1585,9 +1585,13 @@ impl IpcCheckpointSubnetMsg {
 
     /// Makes a unsigned checkpoint transaction that includes checkpoint data
     /// withdrawals and transfers
+    ///
+    /// When the next_committee is different from the current committee,
+    /// all of the UTXOs are exhausted.
     pub fn to_checkpoint_psbt(
         &self,
         committee: &db::SubnetCommittee,
+        next_committee: &db::SubnetCommittee,
         fee_rate: bitcoin::FeeRate,
         unspent: &[bitcoincore_rpc::json::ListUnspentResultEntry],
     ) -> Result<bitcoin::Psbt, IpcLibError> {
@@ -1596,7 +1600,9 @@ impl IpcCheckpointSubnetMsg {
             self.subnet_id
         );
 
-        let committee_change_address = committee.address_checked();
+        // Check if committee rotation is happening
+        let exhaust_unspent = committee != next_committee;
+        let committee_change_address = next_committee.address_checked();
 
         let mut tx_outs = vec![];
 
@@ -1683,6 +1689,7 @@ impl IpcCheckpointSubnetMsg {
             committee.threshold,
             &committee_change_address,
             unspent,
+            exhaust_unspent,
             &tx_outs,
             &fee_rate,
         )?;
@@ -1693,8 +1700,9 @@ impl IpcCheckpointSubnetMsg {
             &self.subnet_id,
             &committee_keys,
             committee.threshold,
-            &committee.address_checked(),
+            &committee_change_address,
             unspent,
+            exhaust_unspent,
             &tx_outs,
             &fee_rate,
         )?;
@@ -1946,6 +1954,11 @@ impl IpcCheckpointSubnetMsg {
                 .into());
             }
 
+            debug!(
+                "Processing stake changes for checkpoint. Up to stake change {:?}",
+                stake_change
+            );
+
             stake_change
         };
 
@@ -2019,8 +2032,8 @@ impl IpcCheckpointSubnetMsg {
         wtxn.commit()?;
 
         debug!(
-            "Saved checkpoint #{} for subnet {} with txid {}",
-            checkpoint_number, self.subnet_id, txid
+            "Saved checkpoint #{} for subnet {} with txid {}. Checkpoint = {:?}",
+            checkpoint_number, self.subnet_id, txid, checkpoint
         );
 
         Ok(checkpoint)
@@ -3228,7 +3241,7 @@ mod checkpoint_msg_tests {
 
         // Generate transactions
         let checkpoint_psbt = checkpoint_msg
-            .to_checkpoint_psbt(committee, fee_rate, &utxos)
+            .to_checkpoint_psbt(committee, committee, fee_rate, &utxos)
             .unwrap();
         let checkpoint_tx = checkpoint_psbt.unsigned_tx.clone();
 
@@ -3341,7 +3354,7 @@ mod checkpoint_msg_tests {
 
         // Generate transactions
         let checkpoint_psbt = checkpoint_msg
-            .to_checkpoint_psbt(committee, fee_rate, &utxos)
+            .to_checkpoint_psbt(committee, committee, fee_rate, &utxos)
             .unwrap();
         let checkpoint_tx = checkpoint_psbt.unsigned_tx.clone();
 
@@ -3420,7 +3433,7 @@ mod checkpoint_msg_tests {
 
         // Generate transactions
         let checkpoint_psbt = checkpoint_msg
-            .to_checkpoint_psbt(committee, fee_rate, &utxos)
+            .to_checkpoint_psbt(committee, committee, fee_rate, &utxos)
             .unwrap();
         let checkpoint_tx = checkpoint_psbt.unsigned_tx.clone();
 
@@ -3571,7 +3584,7 @@ mod checkpoint_msg_tests {
 
         // Generate transactions
         let checkpoint_psbt = checkpoint_msg
-            .to_checkpoint_psbt(committee, fee_rate, &utxos)
+            .to_checkpoint_psbt(committee, committee, fee_rate, &utxos)
             .unwrap();
         let checkpoint_tx = checkpoint_psbt.unsigned_tx.clone();
 

--- a/src/ipc_lib.rs
+++ b/src/ipc_lib.rs
@@ -584,6 +584,12 @@ impl IpcJoinSubnetMsg {
                 let subnet_state = genesis_info.to_subnet();
                 db.save_subnet_state(&mut wtxn, self.subnet_id, &subnet_state)?;
                 db.save_subnet_genesis_info(&mut wtxn, self.subnet_id, &genesis_info)?;
+                db.save_committee(
+                    &mut wtxn,
+                    self.subnet_id,
+                    subnet_state.committee_number,
+                    &subnet_state.committee,
+                )?;
                 wtxn.commit()?;
                 Ok(Some(subnet_state))
             } else {

--- a/src/multisig.rs
+++ b/src/multisig.rs
@@ -117,7 +117,10 @@ pub fn create_subnet_multisig_address(
 
 pub fn multisig_threshold(total_power: Power) -> Power {
     // TODO figure out threshold
-    (total_power / 2) + 1
+    // total_weight * 2 / 3 + 1
+    // see quorum_threshold in ipc
+    // (total_power / 2) + 1
+    total_power * 2 / 3 + 1
 }
 
 // TODO figure out scaling factor

--- a/src/multisig.rs
+++ b/src/multisig.rs
@@ -269,6 +269,7 @@ pub fn construct_spend_unsigned_transaction(
     threshold: Power,
     committee_change_address: &Address,
     unspent: &[bitcoincore_rpc::json::ListUnspentResultEntry],
+    exhaust_unspent: bool,
     tx_outs: &[TxOut],
     fee_rate: &FeeRate,
 ) -> Result<Transaction, MultisigError> {
@@ -284,58 +285,149 @@ pub fn construct_spend_unsigned_transaction(
 
     let non_dust_change_tx_out =
         bitcoin::TxOut::minimal_non_dust(committee_change_address.script_pubkey());
+    if exhaust_unspent {
+        // Use all UTXOs as inputs
+        if unspent.is_empty() {
+            return Err(MultisigError::CoinSelectionFailed(
+                "No UTXOs available".to_string(),
+            ));
+        }
 
-    // Create base outputs functionally by concatenating vectors
-    let outputs = [tx_outs, &[non_dust_change_tx_out]].concat();
+        // Calculate total input amount from all UTXOs
+        let total_input_amount = unspent.iter().map(|utxo| utxo.amount).sum::<Amount>();
 
-    // Calculate the total amount to spend, including the potential change output
-    // TODO: should we include the change output in the amount, even though
-    // we're not sure if it will be added?
-    let amount = outputs.iter().map(|tx_out| tx_out.value).sum::<Amount>();
+        // Calculate total output amount from specified tx_outs
+        let total_output_amount = tx_outs.iter().map(|tx_out| tx_out.value).sum::<Amount>();
 
-    // base transaction, assume a change output
-    let base_tx = Transaction {
-        version: bitcoin::transaction::Version::TWO,
-        lock_time: LockTime::ZERO,
-        input: vec![],
-        output: outputs,
-    };
-    let base_tx_weight = base_tx.weight();
+        // Ensure we have enough funds for the specified outputs
+        if total_input_amount < total_output_amount {
+            return Err(MultisigError::CoinSelectionFailed(
+                "Insufficient funds to cover outputs".to_string(),
+            ));
+        }
 
-    // coin selection from utxos
-    let (selected_utxos, change) = select_coins(
-        amount,
-        unspent,
-        *fee_rate,
-        base_tx_weight,
-        spending_weight_per_input,
-        committee_change_address,
-    )?;
+        // Create inputs from all UTXOs
+        let inputs = unspent
+            .iter()
+            .map(|utxo| TxIn {
+                previous_output: bitcoin::OutPoint {
+                    txid: utxo.txid,
+                    vout: utxo.vout,
+                },
+                script_sig: ScriptBuf::new(),
+                sequence: bitcoin::Sequence::MAX,
+                witness: Witness::new(),
+            })
+            .collect::<Vec<TxIn>>();
 
-    let inputs = selected_utxos
-        .iter()
-        .map(|utxo| TxIn {
-            previous_output: bitcoin::OutPoint {
-                txid: utxo.txid,
-                vout: utxo.vout,
+        // Start with the transaction containing all inputs and specified outputs
+        let mut spend_tx = Transaction {
+            version: bitcoin::transaction::Version::TWO,
+            lock_time: LockTime::ZERO,
+            input: inputs,
+            output: tx_outs.to_vec(),
+        };
+
+        // Create a tentative transaction with potential change output to estimate fees
+        let mut tentative_tx = spend_tx.clone();
+        tentative_tx.output.push(TxOut {
+            value: Amount::from_sat(1), // Placeholder value
+            script_pubkey: committee_change_address.script_pubkey(),
+        });
+
+        // Calculate fee with the correct witness weight
+        let fee = fee_rate
+            .fee_wu(
+                tentative_tx.weight()
+                    + Weight::from_witness_data_size(
+                        spend_witness_size as u64 * unspent.len() as u64,
+                    ),
+            )
+            .expect("fee calculation shouldn't overflow");
+
+        // Calculate remaining amount after outputs and fees
+        let remaining = match total_input_amount.checked_sub(total_output_amount) {
+            Some(remainder) => match remainder.checked_sub(fee) {
+                Some(after_fee) => after_fee,
+                None => {
+                    return Err(MultisigError::CoinSelectionFailed(
+                        "Insufficient funds to cover outputs and fees".to_string(),
+                    ))
+                }
             },
-            script_sig: ScriptBuf::new(),
-            sequence: bitcoin::Sequence::MAX,
-            witness: Witness::new(),
-        })
-        .collect::<Vec<TxIn>>();
+            None => {
+                return Err(MultisigError::CoinSelectionFailed(
+                    "Insufficient funds to cover outputs".to_string(),
+                ))
+            }
+        };
 
-    let mut spend_tx = Transaction {
-        version: bitcoin::transaction::Version::TWO,
-        lock_time: LockTime::ZERO,
-        input: inputs,
-        output: tx_outs.to_vec(),
-    };
-    if let Some(change_tx_out) = change {
-        spend_tx.output.push(change_tx_out);
+        // Only add the change output if it's above the dust threshold
+        if remaining > non_dust_change_tx_out.value {
+            spend_tx.output.push(TxOut {
+                value: remaining,
+                script_pubkey: committee_change_address.script_pubkey(),
+            });
+        } else {
+            trace!(
+                "Change amount {} is dust, not creating change output",
+                remaining
+            );
+            // The dust becomes an additional fee
+        }
+
+        debug!("Multisig Spend Transaction {:?}", &spend_tx);
+
+        Ok(spend_tx)
+    } else {
+        // Original behavior: select just enough UTXOs to cover the outputs
+        // Calculate the total amount to spend for the outputs
+        let amount = tx_outs.iter().map(|tx_out| tx_out.value).sum::<Amount>();
+
+        // base transaction, assume a change output
+        let base_tx = Transaction {
+            version: bitcoin::transaction::Version::TWO,
+            lock_time: LockTime::ZERO,
+            input: vec![],
+            output: [tx_outs, &[non_dust_change_tx_out]].concat(),
+        };
+        let base_tx_weight = base_tx.weight();
+
+        // coin selection from utxos
+        let (selected_utxos, change) = select_coins(
+            amount,
+            unspent,
+            *fee_rate,
+            base_tx_weight,
+            spending_weight_per_input,
+            committee_change_address,
+        )?;
+
+        let inputs = selected_utxos
+            .iter()
+            .map(|utxo| TxIn {
+                previous_output: bitcoin::OutPoint {
+                    txid: utxo.txid,
+                    vout: utxo.vout,
+                },
+                script_sig: ScriptBuf::new(),
+                sequence: bitcoin::Sequence::MAX,
+                witness: Witness::new(),
+            })
+            .collect::<Vec<TxIn>>();
+
+        let mut spend_tx = Transaction {
+            version: bitcoin::transaction::Version::TWO,
+            lock_time: LockTime::ZERO,
+            input: inputs,
+            output: tx_outs.to_vec(),
+        };
+        if let Some(change_tx_out) = change {
+            spend_tx.output.push(change_tx_out);
+        }
+
+        Ok(spend_tx)
     }
-
-    Ok(spend_tx)
 }
 
 /// Constructs a PSBT for spending a multisig output
@@ -347,6 +439,7 @@ pub fn construct_spend_psbt(
     committee_threshold: Power,
     committee_change_address: &Address,
     unspent: &[bitcoincore_rpc::json::ListUnspentResultEntry],
+    exhaust_unspent: bool,
     tx_outs: &[TxOut],
     fee_rate: &FeeRate,
 ) -> Result<bitcoin::Psbt, MultisigError> {
@@ -358,6 +451,7 @@ pub fn construct_spend_psbt(
         committee_threshold,
         committee_change_address,
         unspent,
+        exhaust_unspent,
         tx_outs,
         fee_rate,
     )?;
@@ -1475,6 +1569,7 @@ mod psbt_tests {
             2,                 // required signatures
             &multisig_address, // Use the same address for change
             &vec![utxo],
+            false,
             &[bitcoin::TxOut {
                 value: spend_amount,
                 script_pubkey: destination.script_pubkey(),
@@ -1632,6 +1727,7 @@ mod psbt_tests {
             2,                 // required signatures
             &multisig_address, // Use the same address for change
             &vec![utxo.clone()],
+            false,
             &[tx_out],
             &fee_rate,
         )
@@ -1822,6 +1918,7 @@ mod psbt_tests {
             2,                 // required signatures
             &multisig_address, // Use the same address for change
             &utxos,
+            false,
             &[tx_out],
             &fee_rate,
         )
@@ -2206,5 +2303,218 @@ mod multisig_weighted_tests {
             );
             println!("Test case 4 passed: Heavy (10) + Medium validator (5) = 15 power exceeds threshold");
         }
+    }
+}
+
+#[cfg(test)]
+mod exhaust_unspent_tests {
+    use super::*;
+    use crate::test_utils::{generate_keypairs, generate_subnet_id};
+    use bitcoin::Amount;
+    use bitcoincore_rpc::json::ListUnspentResultEntry;
+    use std::str::FromStr;
+
+    fn create_test_utxo(amount: u64, txid: &str, vout: u32) -> ListUnspentResultEntry {
+        ListUnspentResultEntry {
+            txid: txid.parse().unwrap(),
+            vout,
+            address: None,
+            label: None,
+            redeem_script: None,
+            witness_script: None,
+            script_pub_key: ScriptBuf::new(),
+            amount: Amount::from_sat(amount),
+            confirmations: 1,
+            spendable: true,
+            solvable: true,
+            descriptor: None,
+            safe: true,
+        }
+    }
+
+    #[test]
+    fn test_exhaust_unspent() {
+        let secp = Secp256k1::new();
+
+        // Create committee keys
+        let keypairs = generate_keypairs(3);
+        let committee_keys: Vec<WeightedKey> = keypairs
+            .iter()
+            .map(|kp| (kp.x_only_public_key().0, 1))
+            .collect();
+
+        // Generate subnet ID and address
+        let subnet_id = generate_subnet_id();
+        let network = bitcoin::Network::Regtest;
+        let committee_address = create_subnet_multisig_address(
+            &secp,
+            &subnet_id,
+            &committee_keys,
+            2, // threshold
+            network,
+        )
+        .unwrap();
+
+        // Create UTXOs with different amounts
+        let utxos = vec![
+            create_test_utxo(
+                5000,
+                "7224e1f11ddc838100abd123d23af0d02493001fdd746685dc539fe062b45e3e",
+                0,
+            ),
+            create_test_utxo(
+                3000,
+                "d7f3553b9631f48a2842a2cb6e0f2b6e344bf82d3ee78295a5361adc17b838b1",
+                0,
+            ),
+            create_test_utxo(
+                9000,
+                "f4184fc596403b9d638783cf57adfe4c75c605f6356fbc91338530e9831e9e16",
+                0,
+            ),
+        ];
+
+        // Calculate total input amount
+        let total_input_amount = utxos.iter().map(|utxo| utxo.amount).sum::<Amount>();
+
+        // Define output
+        let destination = Address::from_str("bcrt1qzswe5l7xyzvgfn4v9s96r3cxtlxhq87x2etpp7")
+            .unwrap()
+            .assume_checked();
+
+        let output_amount = Amount::from_sat(1000);
+        let tx_out = TxOut {
+            value: output_amount,
+            script_pubkey: destination.script_pubkey(),
+        };
+
+        let fee_rate = FeeRate::from_sat_per_vb(2).unwrap();
+
+        // Case 1: Normal spend (don't exhaust UTXOs)
+        let tx_normal = construct_spend_unsigned_transaction(
+            &committee_keys,
+            2, // threshold
+            &committee_address,
+            &utxos,
+            false, // don't exhaust
+            &[tx_out.clone()],
+            &fee_rate,
+        )
+        .unwrap();
+
+        // Should select just enough UTXOs to cover the output
+        assert!(
+            tx_normal.input.len() < utxos.len(),
+            "Normal spend should not use all UTXOs, used {} of {}",
+            tx_normal.input.len(),
+            utxos.len()
+        );
+
+        // Case 2: Exhaust UTXOs
+        let tx_exhaust = construct_spend_unsigned_transaction(
+            &committee_keys,
+            2, // threshold
+            &committee_address,
+            &utxos,
+            true, // exhaust all UTXOs
+            &[tx_out.clone()],
+            &fee_rate,
+        )
+        .unwrap();
+
+        // Should use all UTXOs
+        assert_eq!(
+            tx_exhaust.input.len(),
+            utxos.len(),
+            "Exhaust spend should use all UTXOs"
+        );
+
+        // Should have exactly one change output plus the specified output
+        assert_eq!(
+            tx_exhaust.output.len(),
+            2,
+            "Exhaust spend should have original output plus change"
+        );
+
+        // Verify the change goes to the committee address
+        assert_eq!(
+            tx_exhaust.output[1].script_pubkey,
+            committee_address.script_pubkey(),
+            "Change output has incorrect script pubkey"
+        );
+
+        // Verify change amount is approximately what we expect
+        // (total_inputs - output_amount - fees)
+        let change_output_amount = tx_exhaust.output[1].value;
+        let spent_amount = output_amount;
+        let fee_estimate = fee_rate.fee_wu(tx_exhaust.weight()).unwrap();
+
+        assert!(
+            change_output_amount < total_input_amount - spent_amount,
+            "Change amount should be less than total input minus spent amount"
+        );
+
+        // Check that the change plus output plus estimated fee is approximately equal to total input
+        let total_accounted_for = change_output_amount + spent_amount + fee_estimate;
+        let margin = Amount::from_sat(600); // Allow for a small margin of error in fee calculation
+
+        assert!(
+            total_accounted_for <= total_input_amount,
+            "Total outputs plus fee ({}) should not exceed total input ({})",
+            total_accounted_for,
+            total_input_amount
+        );
+
+        dbg!(&tx_exhaust);
+        dbg!(total_input_amount - total_accounted_for);
+
+        assert!(
+            total_input_amount - total_accounted_for <= margin,
+            "Difference between total input and (outputs + fee) should be small"
+        );
+
+        // Case 3: Exhaust UTXOs with multiple outputs
+        let tx_out2 = TxOut {
+            value: Amount::from_sat(2000),
+            script_pubkey: destination.script_pubkey(),
+        };
+
+        let tx_exhaust_multi = construct_spend_unsigned_transaction(
+            &committee_keys,
+            2, // threshold
+            &committee_address,
+            &utxos,
+            true, // exhaust all UTXOs
+            &[tx_out, tx_out2],
+            &fee_rate,
+        )
+        .unwrap();
+
+        // Should have exactly one change output plus the two specified outputs
+        assert_eq!(
+            tx_exhaust_multi.output.len(),
+            3,
+            "Exhaust spend with multiple outputs should have all outputs plus change"
+        );
+
+        // Verify change amount reflects all outputs
+        let total_outputs = tx_exhaust_multi
+            .output
+            .iter()
+            .filter(|out| out.script_pubkey != committee_address.script_pubkey())
+            .map(|out| out.value)
+            .sum::<Amount>();
+
+        let multi_change_output_amount = tx_exhaust_multi
+            .output
+            .iter()
+            .find(|out| out.script_pubkey == committee_address.script_pubkey())
+            .map(|out| out.value)
+            .unwrap();
+
+        assert!(
+            multi_change_output_amount < total_input_amount - total_outputs,
+            "Multi-output change amount should be less than total input minus all outputs"
+        );
     }
 }

--- a/src/provider/rpc.rs
+++ b/src/provider/rpc.rs
@@ -344,7 +344,10 @@ pub async fn get_rootnet_messages(
     data: Data<Arc<ServerData>>,
     Params(params): Params<GetRootnetMessagesParams>,
 ) -> Result<Vec<db::RootnetMessage>, JsonRpcError> {
-    info!("getrootnetmessages: {}", params.subnet_id);
+    info!(
+        "getrootnetmessages: {} at {}",
+        params.subnet_id, params.block_height
+    );
 
     // Check subnet exists
     data.db
@@ -910,6 +913,43 @@ pub async fn finalize_checkpoint_psbt(
     })
 }
 
+// Stake changes
+
+#[derive(Serialize, Deserialize)]
+pub struct GetStakeChangesParams {
+    subnet_id: SubnetId,
+    block_height: u64,
+}
+
+pub async fn get_stake_changes(
+    data: Data<Arc<ServerData>>,
+    Params(params): Params<GetStakeChangesParams>,
+) -> Result<Vec<db::StakeChangeRequest>, JsonRpcError> {
+    info!(
+        "getstakechanges: {} at {}",
+        params.subnet_id, params.block_height
+    );
+
+    // Check subnet exists
+    data.db
+        .get_subnet_state(params.subnet_id)
+        .map_err(|e| {
+            error!("Error getting subnet info from Db: {}", e);
+            RpcError::DbError(e)
+        })?
+        .ok_or(RpcError::InvalidParams(format!(
+            "Subnet {} not found.",
+            params.subnet_id
+        )))?;
+
+    data.db
+        .get_stake_changes_by_height(params.subnet_id, params.block_height)
+        .map_err(|e| {
+            error!("Error getting stake changes from Db: {}", e);
+            RpcError::DbError(e).into()
+        })
+}
+
 pub fn make_rpc_server(server_data: Arc<ServerData>) -> RpcServer {
     jsonrpc_v2::Server::new()
         .with_data(Data::new(server_data))
@@ -930,8 +970,10 @@ pub fn make_rpc_server(server_data: Arc<ServerData>) -> RpcServer {
         .with_method("genmultisigspendpsbt", gen_multisig_spend_psbt)
         // checkpoints
         .with_method("gencheckpointpsbt", gen_checkpoint_psbt)
-        .with_method("dev_multisignpsbt", dev_multisign_psbt) // dev only
+        .with_method("dev_multisignpsbt", dev_multisign_psbt) // TODO make dev only
         .with_method("finalizecheckpointpsbt", finalize_checkpoint_psbt)
         .with_method("getsubnetcheckpoint", get_subnet_checkpoint)
+        // stake changes
+        .with_method("getstakechanges", get_stake_changes)
         .finish()
 }

--- a/src/provider/rpc.rs
+++ b/src/provider/rpc.rs
@@ -180,10 +180,16 @@ pub async fn join_subnet(
             msg.subnet_id
         )))?;
 
-    msg.validate_for_genesis_info(&genesis_info).map_err(|e| {
-        error!("Error validating join msg for subnet info: {}", e);
-        RpcError::InvalidParams(e.to_string())
+    let subnet_state = data.db.get_subnet_state(msg.subnet_id).map_err(|e| {
+        error!("Error getting subnet info from Db: {}", e);
+        RpcError::DbError(e)
     })?;
+
+    msg.validate_for_subnet(&genesis_info, &subnet_state)
+        .map_err(|e| {
+            error!("Error validating join msg for subnet info: {}", e);
+            RpcError::InvalidParams(e.to_string())
+        })?;
 
     // TODO this check should be done in the Db
     let multisig_address = &genesis_info.multisig_address();

--- a/src/provider/rpc.rs
+++ b/src/provider/rpc.rs
@@ -12,6 +12,7 @@ use bitcoin::hashes::Hash;
 use bitcoincore_rpc::{Client, RpcApi};
 use jsonrpc_v2::{Data, Error as JsonRpcError, ErrorLike, MapRouter, Params};
 use log::{error, info, trace};
+use num_traits::Zero;
 use serde::{Deserialize, Serialize};
 use serde_json::json;
 use std::sync::Arc;
@@ -489,6 +490,7 @@ pub async fn gen_multisig_spend_psbt(
         commitee_threshold,
         &committee_address,
         &unspent,
+        false,
         &[bitcoin::TxOut {
             value: params.amount,
             script_pubkey: recipient.script_pubkey(),
@@ -603,8 +605,48 @@ pub async fn gen_checkpoint_psbt(
 
     let fee_rate = bitcoin_utils::get_fee_rate(&data.btc_watchonly_rpc, None, None);
 
+    // assume no change in the committee
+    let mut next_committee = subnet.committee.clone();
+    let current_committee_configuration = subnet.committee.configuration_number;
+
+    // update next_committee if the configuration number changed
+    if msg.next_committee_configuration_number > current_committee_configuration {
+        next_committee = data
+            .db
+            .get_stake_change(msg.subnet_id, msg.next_committee_configuration_number)
+            .map_err(|e| {
+                error!("Error getting stake change from Db: {}", e);
+                RpcError::DbError(e)
+            })?
+            .ok_or(RpcError::InvalidParams(format!(
+                "Stake change with configuration number {} not found.",
+                msg.next_committee_configuration_number
+            )))?
+            .committee_after_change;
+
+        info!(
+            "Rotating committee to configuration number {} multisig address {}",
+            msg.next_committee_configuration_number,
+            next_committee.address_checked()
+        );
+    }
+    // no change if the configuration number is zero or the same
+    else if msg.next_committee_configuration_number.is_zero()
+        || msg.next_committee_configuration_number == current_committee_configuration
+    {
+        trace!("gen_checkpoint_psbt: no change to the committee configuration")
+    }
+    // error if the configuration number is less than the current one, unexpected
+    else {
+        return Err(RpcError::InvalidParams(format!(
+            "Invalid next committee configuration number: {}",
+            msg.next_committee_configuration_number
+        ))
+        .into());
+    }
+
     let unsigned_psbt = msg
-        .to_checkpoint_psbt(&subnet.committee, fee_rate, &unspent)
+        .to_checkpoint_psbt(&subnet.committee, &next_committee, fee_rate, &unspent)
         .map_err(|e| {
             error!(
                 "Error generating checkpoint psbt for subnet_id={}: {}",

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -126,6 +126,7 @@ pub fn generate_subnet(n: usize) -> db::SubnetState {
     let multisig_address = multisig_address.as_unchecked();
 
     let committee = db::SubnetCommittee {
+        configuration_number: 0,
         validators,
         threshold: min_validators,
         multisig_address: multisig_address.clone(),
@@ -136,7 +137,7 @@ pub fn generate_subnet(n: usize) -> db::SubnetState {
         id: subnet_id,
         committee_number: 1,
         committee,
-        next_committee: None,
+        waiting_committee: None,
         last_checkpoint_number: None,
     }
 }

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -136,6 +136,7 @@ pub fn generate_subnet(n: usize) -> db::SubnetState {
         id: subnet_id,
         committee_number: 1,
         committee,
+        next_committee: None,
         last_checkpoint_number: None,
     }
 }


### PR DESCRIPTION
Allows validators to join post-bootstrap. So when we see a new join message on Bitcoin, we'll record the "staking change request". It's called a request since it'll only be applied/confirmed after a checkpoint transaction has been sent to Bitcoin, at which point we will do the committee rotation. Stake change requests will appear at the block height they were submitted, and optionally have a checkpoint block height if they were propagated  . They look something like this:

```json
{
  "jsonrpc": "2.0",
  "result": [
    {
      "change": {
        "join": {
          "pubkey": "02e327a66b169732bde49d827d90781327af558fc12d5cd2d5004e7551ec00c662"
        }
      },
      "validator_xpk": "e327a66b169732bde49d827d90781327af558fc12d5cd2d5004e7551ec00c662",
      "validator_subnet_address": "0xb628237ff4875b039ec1c3dedcf5fad93430ee4a",
      "block_height": 1194,
      "block_hash": "411ac1ea692f8b24bff70eb83491c3dde30472242d8ff2e26752fface983fb28",
      "checkpoint_block_height": 1201,
      "checkpoint_block_hash": "7e586c71b920f5db77e2b9a166fb76e6a620b4787dde82d4f43caed7d8b511d3",
      "configuration_number": 0,
      "txid": "bf03269140ff8e59c4521f288e0f8a76369ce324ba0edae0922ac30dd001e4b9"
    },
    {
      "change": {
        "deposit": {
          "amount": 200000000
        }
      },
      "validator_xpk": "e327a66b169732bde49d827d90781327af558fc12d5cd2d5004e7551ec00c662",
      "validator_subnet_address": "0xb628237ff4875b039ec1c3dedcf5fad93430ee4a",
      "block_height": 1194,
      "block_hash": "411ac1ea692f8b24bff70eb83491c3dde30472242d8ff2e26752fface983fb28",
      "checkpoint_block_height": 1201,
      "checkpoint_block_hash": "7e586c71b920f5db77e2b9a166fb76e6a620b4787dde82d4f43caed7d8b511d3",
      "configuration_number": 1,
      "txid": "bf03269140ff8e59c4521f288e0f8a76369ce324ba0edae0922ac30dd001e4b9"
    }
  ],
  "id": 1
}
```


You'll notice it doesn't have the `payload` bytes Subnet Manager in IPC expects. We would need to transfer this into the structure by:
1. Adding the appropriate `StakingOperation` tag.
2. Converting xonly-pubkey to fvm address.
3. ABI encoding the right data into the payload.

```rust
pub struct StakingChange {
    pub op: StakingOperation,
    pub payload: Vec<u8>,
    pub validator: Address,
}
```

This is because it's highly dependant on some IPC details like the Solidity contracts, and we want bitcoin-ipc to be as client-agnostic as possible. Also IPC already has all of the dependencies needed like fvm and ethers for abi-encoding.

Missing the actual committee rotation in checkpoints, I'll see if I'll open a new PR or use this one.


Closes #87 