### PR TITLE
Support stake/unstake for validators

### DIFF
--- a/internal/curl_reqs.md
+++ b/internal/curl_reqs.md
@@ -46,7 +46,7 @@ curl -X POST http://localhost:3040/api \
     "jsonrpc": "2.0",
     "method": "joinsubnet",
     "params": {
-			"subnet_id": "/b4/t410f3iid2fasqwb75plfaaoqbds4fwdu6btidyk7lwq",
+			"subnet_id": "/b4/t410ftevsylx6rsrfl6yymjxja3nnk7hwim3k47ip6iy",
 			"collateral": 20000000,
 			"ip": "66.222.44.55:8080",
 			"backup_address": "bcrt1q3fznspr3e02artm9df7tk827a2xhny2m4zzr6n",
@@ -64,11 +64,43 @@ curl -X POST http://localhost:3040/api \
     "jsonrpc": "2.0",
     "method": "joinsubnet",
     "params": {
-			"subnet_id": "/b4/t410f3iid2fasqwb75plfaaoqbds4fwdu6btidyk7lwq",
+			"subnet_id": "/b4/t410fertekptrvemo3wddyaht6v2pqykjdjieorit6ha",
 			"collateral": 20000000,
 			"ip": "66.222.44.55:8080",
 			"backup_address": "bcrt1q3fznspr3e02artm9df7tk827a2xhny2m4zzr6n",
 			"pubkey": "71ac1eb874233999e11cd050f388f1dd6da9b446180fdf9b06740419cc487b6f"
+    },
+    "id": 1
+}' | jq
+
+# stake more collateral
+
+curl -X POST http://localhost:3040/api \
+-H "Content-Type: application/json" \
+-H "Authorization: Bearer asda123123jhaskjdhgbjsjhdj" \
+-d '{
+    "jsonrpc": "2.0",
+    "method": "stakecollateral",
+    "params": {
+			"subnet_id": "/b4/t410ftevsylx6rsrfl6yymjxja3nnk7hwim3k47ip6iy",
+			"amount": 6500000,
+			"pubkey": "851c1bda327584479e98a7c28ea7adc097d290efd105310bcf714231bb99faf4"
+    },
+    "id": 1
+}' | jq
+
+# stake more collateral 2
+
+curl -X POST http://localhost:3040/api \
+-H "Content-Type: application/json" \
+-H "Authorization: Bearer asda123123jhaskjdhgbjsjhdj" \
+-d '{
+    "jsonrpc": "2.0",
+    "method": "stakecollateral",
+    "params": {
+			"subnet_id": "/b4/t410ftevsylx6rsrfl6yymjxja3nnk7hwim3k47ip6iy",
+			"amount": 6500000,
+			"pubkey": "e327a66b169732bde49d827d90781327af558fc12d5cd2d5004e7551ec00c662"
     },
     "id": 1
 }' | jq
@@ -140,7 +172,7 @@ curl -X POST http://localhost:3040/api \
     "jsonrpc": "2.0",
     "method": "getsubnet",
     "params": {
-			"subnet_id": "/b4/t410f3iid2fasqwb75plfaaoqbds4fwdu6btidyk7lwq"
+			"subnet_id": "/b4/t410fertekptrvemo3wddyaht6v2pqykjdjieorit6ha"
     },
     "id": 1
 }' | jq
@@ -193,8 +225,8 @@ curl -X POST http://localhost:3040/api \
     "jsonrpc": "2.0",
     "method": "getstakechanges",
     "params": {
-			"subnet_id": "/b4/t410f3iid2fasqwb75plfaaoqbds4fwdu6btidyk7lwq",
-			"block_height": 1298
+			"subnet_id": "/b4/t410fsl7k6jpo5br5ps4wdwmreulweon3ts3lrzbfjki",
+			"block_height": 124
     },
     "id": 1
 }' | jq

--- a/internal/curl_reqs.md
+++ b/internal/curl_reqs.md
@@ -46,7 +46,7 @@ curl -X POST http://localhost:3040/api \
     "jsonrpc": "2.0",
     "method": "joinsubnet",
     "params": {
-			"subnet_id": "/b4/t410fnt3bocognsddcsd4dvu3amu4tw3eokzvajwakaa",
+			"subnet_id": "/b4/t410fbbjlqjgx6cyr466yevwd4bp54mbpchkfafeuaby",
 			"collateral": 20000000,
 			"ip": "66.222.44.55:8080",
 			"backup_address": "bcrt1q3fznspr3e02artm9df7tk827a2xhny2m4zzr6n",
@@ -82,7 +82,7 @@ curl -X POST http://localhost:3040/api \
     "jsonrpc": "2.0",
     "method": "stakecollateral",
     "params": {
-			"subnet_id": "/b4/t410fnt3bocognsddcsd4dvu3amu4tw3eokzvajwakaa",
+			"subnet_id": "/b4/t410fbbjlqjgx6cyr466yevwd4bp54mbpchkfafeuaby",
 			"amount": 6500000,
 			"pubkey": "851c1bda327584479e98a7c28ea7adc097d290efd105310bcf714231bb99faf4"
     },
@@ -98,7 +98,7 @@ curl -X POST http://localhost:3040/api \
     "jsonrpc": "2.0",
     "method": "stakecollateral",
     "params": {
-			"subnet_id": "/b4/t410fnt3bocognsddcsd4dvu3amu4tw3eokzvajwakaa",
+			"subnet_id": "/b4/t410fbbjlqjgx6cyr466yevwd4bp54mbpchkfafeuaby",
 			"amount": 6500000,
 			"pubkey": "e327a66b169732bde49d827d90781327af558fc12d5cd2d5004e7551ec00c662"
     },
@@ -114,9 +114,8 @@ curl -X POST http://localhost:3040/api \
     "jsonrpc": "2.0",
     "method": "unstakecollateral",
     "params": {
-			"subnet_id": "/b4/t410fnt3bocognsddcsd4dvu3amu4tw3eokzvajwakaa",
-			"amount": 4500000,
-			"pubkey": "851c1bda327584479e98a7c28ea7adc097d290efd105310bcf714231bb99faf4"
+			"subnet_id": "/b4/t410fbbjlqjgx6cyr466yevwd4bp54mbpchkfafeuaby",
+			"amount": 4200000
     },
     "id": 1
 }' | jq
@@ -189,7 +188,7 @@ curl -X POST http://localhost:3040/api \
     "jsonrpc": "2.0",
     "method": "getsubnet",
     "params": {
-			"subnet_id": "/b4/t410fertekptrvemo3wddyaht6v2pqykjdjieorit6ha"
+			"subnet_id": "/b4/t410fbbjlqjgx6cyr466yevwd4bp54mbpchkfafeuaby"
     },
     "id": 1
 }' | jq
@@ -242,7 +241,7 @@ curl -X POST http://localhost:3040/api \
     "jsonrpc": "2.0",
     "method": "getstakechanges",
     "params": {
-			"subnet_id": "/b4/t410fnt3bocognsddcsd4dvu3amu4tw3eokzvajwakaa",
+			"subnet_id": "/b4/t410fbbjlqjgx6cyr466yevwd4bp54mbpchkfafeuaby",
 			"block_height": 162
     },
     "id": 1

--- a/internal/curl_reqs.md
+++ b/internal/curl_reqs.md
@@ -46,7 +46,7 @@ curl -X POST http://localhost:3040/api \
     "jsonrpc": "2.0",
     "method": "joinsubnet",
     "params": {
-			"subnet_id": "/b4/t410ftevsylx6rsrfl6yymjxja3nnk7hwim3k47ip6iy",
+			"subnet_id": "/b4/t410fnt3bocognsddcsd4dvu3amu4tw3eokzvajwakaa",
 			"collateral": 20000000,
 			"ip": "66.222.44.55:8080",
 			"backup_address": "bcrt1q3fznspr3e02artm9df7tk827a2xhny2m4zzr6n",
@@ -82,7 +82,7 @@ curl -X POST http://localhost:3040/api \
     "jsonrpc": "2.0",
     "method": "stakecollateral",
     "params": {
-			"subnet_id": "/b4/t410ftevsylx6rsrfl6yymjxja3nnk7hwim3k47ip6iy",
+			"subnet_id": "/b4/t410fnt3bocognsddcsd4dvu3amu4tw3eokzvajwakaa",
 			"amount": 6500000,
 			"pubkey": "851c1bda327584479e98a7c28ea7adc097d290efd105310bcf714231bb99faf4"
     },
@@ -98,12 +98,29 @@ curl -X POST http://localhost:3040/api \
     "jsonrpc": "2.0",
     "method": "stakecollateral",
     "params": {
-			"subnet_id": "/b4/t410ftevsylx6rsrfl6yymjxja3nnk7hwim3k47ip6iy",
+			"subnet_id": "/b4/t410fnt3bocognsddcsd4dvu3amu4tw3eokzvajwakaa",
 			"amount": 6500000,
 			"pubkey": "e327a66b169732bde49d827d90781327af558fc12d5cd2d5004e7551ec00c662"
     },
     "id": 1
 }' | jq
+
+# unstake more collateral
+
+curl -X POST http://localhost:3040/api \
+-H "Content-Type: application/json" \
+-H "Authorization: Bearer asda123123jhaskjdhgbjsjhdj" \
+-d '{
+    "jsonrpc": "2.0",
+    "method": "unstakecollateral",
+    "params": {
+			"subnet_id": "/b4/t410fnt3bocognsddcsd4dvu3amu4tw3eokzvajwakaa",
+			"amount": 4500000,
+			"pubkey": "851c1bda327584479e98a7c28ea7adc097d290efd105310bcf714231bb99faf4"
+    },
+    "id": 1
+}' | jq
+
 
 curl -X POST http://localhost:3030/api \
 -H "Content-Type: application/json" \
@@ -225,8 +242,8 @@ curl -X POST http://localhost:3040/api \
     "jsonrpc": "2.0",
     "method": "getstakechanges",
     "params": {
-			"subnet_id": "/b4/t410fsl7k6jpo5br5ps4wdwmreulweon3ts3lrzbfjki",
-			"block_height": 124
+			"subnet_id": "/b4/t410fnt3bocognsddcsd4dvu3amu4tw3eokzvajwakaa",
+			"block_height": 162
     },
     "id": 1
 }' | jq

--- a/src/bin/monitor.rs
+++ b/src/bin/monitor.rs
@@ -439,8 +439,18 @@ where
                 Ok(_) => {}
                 Err(e) => self.handle_ipc_msg_error(e)?,
             }
-        } else if let Ok(batch_transfer_msg) = ipc_lib::IpcBatchTransferMsg::from_tx(&self.db, tx) {
-            let ipc_message = IpcMessage::BatchTransfer(batch_transfer_msg);
+        } else if let Ok(msg) = ipc_lib::IpcBatchTransferMsg::from_tx(&self.db, tx) {
+            let ipc_message = IpcMessage::BatchTransfer(msg);
+
+            match self
+                .process_ipc_msg(block_height, block_hash, block_time, tx, txid, ipc_message)
+                .await
+            {
+                Ok(_) => {}
+                Err(e) => self.handle_ipc_msg_error(e)?,
+            }
+        } else if let Ok(msg) = ipc_lib::IpcStakeCollateralMsg::from_tx(&self.db, tx) {
+            let ipc_message = IpcMessage::StakeCollateral(msg);
 
             match self
                 .process_ipc_msg(block_height, block_hash, block_time, tx, txid, ipc_message)
@@ -634,6 +644,27 @@ where
                     msg.subnet_id, msg.checkpoint_txid, msg.transfers.len(),
                 );
 
+                Ok(())
+            }
+
+            IpcMessage::StakeCollateral(msg) => {
+                debug!("Found IPC message: {:?}", msg);
+                msg.validate()?;
+                msg.save_to_db(&self.db, block_height, block_hash, txid)?;
+                info!(
+                    "Processed StakeCollateral for Subnet ID: {} Validator XPK: {} Amount: {}",
+                    msg.subnet_id, msg.pubkey, msg.amount
+                );
+                Ok(())
+            }
+
+            IpcMessage::UnstakeCollateral(msg) => {
+                debug!("Found IPC message: {:?}", msg);
+                Ok(())
+            }
+
+            IpcMessage::LeaveSubnet(msg) => {
+                debug!("Found IPC message: {:?}", msg);
                 Ok(())
             }
         }

--- a/src/bin/monitor.rs
+++ b/src/bin/monitor.rs
@@ -673,7 +673,7 @@ where
                 msg.validate()?;
                 msg.save_to_db(&self.db, block_height, block_hash, txid)?;
                 info!(
-                    "Processed UnstakeCollateral for Subnet ID: {} Validator XPK: {} Amount: {}",
+                    "Processed UnstakeCollateral for Subnet ID: {} Validator XPK: {:?} Amount: {}",
                     msg.subnet_id, msg.pubkey, msg.amount
                 );
                 Ok(())

--- a/src/bin/monitor.rs
+++ b/src/bin/monitor.rs
@@ -459,6 +459,16 @@ where
                 Ok(_) => {}
                 Err(e) => self.handle_ipc_msg_error(e)?,
             }
+        } else if let Ok(msg) = ipc_lib::IpcUnstakeCollateralMsg::from_tx(&self.db, tx) {
+            let ipc_message = IpcMessage::UnstakeCollateral(msg);
+
+            match self
+                .process_ipc_msg(block_height, block_hash, block_time, tx, txid, ipc_message)
+                .await
+            {
+                Ok(_) => {}
+                Err(e) => self.handle_ipc_msg_error(e)?,
+            }
         }
 
         Ok(())
@@ -660,6 +670,12 @@ where
 
             IpcMessage::UnstakeCollateral(msg) => {
                 debug!("Found IPC message: {:?}", msg);
+                msg.validate()?;
+                msg.save_to_db(&self.db, block_height, block_hash, txid)?;
+                info!(
+                    "Processed UnstakeCollateral for Subnet ID: {} Validator XPK: {} Amount: {}",
+                    msg.subnet_id, msg.pubkey, msg.amount
+                );
                 Ok(())
             }
 

--- a/src/db.rs
+++ b/src/db.rs
@@ -1371,29 +1371,9 @@ pub enum DbError {
 #[cfg(test)]
 pub mod tests {
     use super::*;
-    use crate::test_utils::generate_subnet_id;
+    use crate::test_utils::*;
     use bitcoin::{hashes::Hash, key::Parity, Amount, BlockHash, Txid, XOnlyPublicKey};
     use std::str::FromStr;
-    use tempfile::tempdir;
-
-    pub fn create_test_db() -> HeedDb {
-        let temp_dir = tempdir().unwrap();
-        let db_path = temp_dir.path().to_str().unwrap();
-        tokio::runtime::Runtime::new()
-            .unwrap()
-            .block_on(HeedDb::new(db_path, false))
-            .unwrap()
-    }
-
-    pub fn create_rand_txid() -> Txid {
-        Txid::from_slice(&rand::random::<[u8; 32]>()).unwrap()
-    }
-    pub fn create_rand_blockhash() -> BlockHash {
-        BlockHash::from_slice(&rand::random::<[u8; 32]>()).unwrap()
-    }
-    pub fn create_rand_addr() -> alloy_primitives::Address {
-        alloy_primitives::Address::from_slice(&rand::random::<[u8; 20]>())
-    }
 
     fn create_test_rootnet_message(
         subnet_id: SubnetId,
@@ -1995,6 +1975,7 @@ pub mod tests {
     }
 
     #[test]
+    #[test_retry::retry(3)]
     fn test_stake_change_configuration_number() {
         let db = create_test_db();
         let subnet_id = generate_subnet_id();

--- a/src/db.rs
+++ b/src/db.rs
@@ -93,7 +93,7 @@ pub struct SubnetValidator {
     pub join_txid: bitcoin::Txid,
 }
 
-trait SubnetValidators {
+pub(crate) trait SubnetValidators {
     fn total_power(&self) -> Power;
     fn threshold(&self) -> Power;
     fn multisig_address(&self, subnet_id: &SubnetId) -> Address<NetworkUnchecked>;

--- a/src/db.rs
+++ b/src/db.rs
@@ -1864,13 +1864,8 @@ pub mod tests {
         };
 
         // Create the two committees
-        let mut validators_set1 = Vec::new();
-        validators_set1.push(validator1_set1);
-        validators_set1.push(validator2_set1);
-
-        let mut validators_set2 = Vec::new();
-        validators_set2.push(validator1_set2);
-        validators_set2.push(validator2_set2);
+        let validators_set1 = vec![validator1_set1, validator2_set1];
+        let validators_set2 = vec![validator1_set2, validator2_set2];
 
         let committee1 = validators_set1.to_committee(&subnet_id, 0);
         let committee2 = validators_set2.to_committee(&subnet_id, 0);
@@ -2073,7 +2068,7 @@ pub mod tests {
 
         // Initial check - should be GENESIS_COMMITTEE_CONF_NUM + 1
         let next_conf_num = db
-            .get_next_stake_change_configuration_number(subnet_id.clone())
+            .get_next_stake_change_configuration_number(subnet_id)
             .unwrap();
         assert_eq!(next_conf_num, GENESIS_COMMITTEE_CONF_NUM + 1);
 
@@ -2127,7 +2122,7 @@ pub mod tests {
 
         // Check the configuration number after adding validator
         let next_conf_num = db
-            .get_next_stake_change_configuration_number(subnet_id.clone())
+            .get_next_stake_change_configuration_number(subnet_id)
             .unwrap();
         assert_eq!(next_conf_num, GENESIS_COMMITTEE_CONF_NUM + 3);
 
@@ -2167,7 +2162,7 @@ pub mod tests {
 
         // Check the configuration number after modifying validator
         let next_conf_num = db
-            .get_next_stake_change_configuration_number(subnet_id.clone())
+            .get_next_stake_change_configuration_number(subnet_id)
             .unwrap();
         assert_eq!(next_conf_num, GENESIS_COMMITTEE_CONF_NUM + 4);
     }

--- a/src/db.rs
+++ b/src/db.rs
@@ -851,7 +851,7 @@ pub trait Database {
     ) -> Result<(), DbError>;
 
     // Stake changes
-    // Stake changes
+
     fn get_stake_change(
         &self,
         subnet_id: SubnetId,
@@ -859,6 +859,11 @@ pub trait Database {
     ) -> Result<Option<StakeChangeRequest>, DbError>;
 
     fn get_all_stake_changes(
+        &self,
+        subnet_id: SubnetId,
+    ) -> Result<Vec<StakeChangeRequest>, DbError>;
+
+    fn get_unconfirmed_stake_changes(
         &self,
         subnet_id: SubnetId,
     ) -> Result<Vec<StakeChangeRequest>, DbError>;
@@ -1243,6 +1248,32 @@ impl Database for HeedDb {
 
         let changes = changes_iter
             .map(|res| res.map(|(_, change)| change))
+            .collect::<Result<Vec<_>, _>>()?;
+
+        Ok(changes)
+    }
+
+    fn get_unconfirmed_stake_changes(
+        &self,
+        subnet_id: SubnetId,
+    ) -> Result<Vec<StakeChangeRequest>, DbError> {
+        let prefix = stake_changes_prefix(subnet_id);
+        let txn = self.env.read_txn()?;
+
+        let changes_iter = self.stake_changes_db.prefix_iter(&txn, &prefix)?;
+
+        let changes = changes_iter
+            .map(|res| res.map(|(_, change)| change))
+            .filter_map(|res| match res {
+                Ok(change) => {
+                    if change.checkpoint_block_height.is_none() {
+                        Some(Ok(change))
+                    } else {
+                        None
+                    }
+                }
+                Err(e) => Some(Err(e)),
+            })
             .collect::<Result<Vec<_>, _>>()?;
 
         Ok(changes)

--- a/src/db.rs
+++ b/src/db.rs
@@ -101,7 +101,10 @@ trait SubnetValidators {
 
     fn add_validator(&mut self, validator: &SubnetValidator) -> Result<(), DbError>;
     #[allow(unused)]
-    fn rm_validator(&mut self, validator_xpk: &XOnlyPublicKey) -> Result<SubnetValidator, DbError>;
+    fn remove_validator(
+        &mut self,
+        validator_xpk: &XOnlyPublicKey,
+    ) -> Result<SubnetValidator, DbError>;
 }
 
 impl SubnetValidators for Vec<SubnetValidator> {
@@ -147,7 +150,10 @@ impl SubnetValidators for Vec<SubnetValidator> {
         Ok(())
     }
 
-    fn rm_validator(&mut self, validator_xpk: &XOnlyPublicKey) -> Result<SubnetValidator, DbError> {
+    fn remove_validator(
+        &mut self,
+        validator_xpk: &XOnlyPublicKey,
+    ) -> Result<SubnetValidator, DbError> {
         // Find the validator
         let position = self.iter().position(|v| &v.pubkey == validator_xpk);
 
@@ -272,6 +278,25 @@ impl SubnetCommittee {
 
         // Replace the validator with the updated one
         self.validators[validator_position] = validator.clone();
+
+        // Update the committee's threshold and multisig address
+        self.threshold = self.validators.threshold();
+        self.multisig_address = self.validators.multisig_address(subnet_id);
+
+        Ok(())
+    }
+
+    pub fn remove_validator(
+        &mut self,
+        subnet_id: &SubnetId,
+        pubkey: &XOnlyPublicKey,
+    ) -> Result<(), DbError> {
+        // Increase configuration number by 1
+        // since there is one stake change for stake/unstake
+        self.configuration_number += 1;
+
+        // Remove the validator from the committee
+        self.validators.remove_validator(pubkey)?;
 
         // Update the committee's threshold and multisig address
         self.threshold = self.validators.threshold();

--- a/src/db.rs
+++ b/src/db.rs
@@ -234,7 +234,7 @@ impl SubnetCommittee {
         self.validators.iter().any(|v| &v.pubkey == pubkey)
     }
 
-    pub fn join_validator(
+    pub fn join_new_validator(
         &mut self,
         subnet_id: &SubnetId,
         validator: &SubnetValidator,
@@ -246,6 +246,37 @@ impl SubnetCommittee {
         self.validators.add_validator(validator)?;
         self.threshold = self.validators.threshold();
         self.multisig_address = self.validators.multisig_address(subnet_id);
+        Ok(())
+    }
+
+    pub fn modify_validator(
+        &mut self,
+        subnet_id: &SubnetId,
+        validator: &SubnetValidator,
+    ) -> Result<(), DbError> {
+        // Increase configuration number by 1
+        // since there is one stake change for stake/unstake
+        self.configuration_number += 1;
+
+        // Find the validator in the committee and update their information
+        let validator_position = self
+            .validators
+            .iter()
+            .position(|v| v.pubkey == validator.pubkey)
+            .ok_or_else(|| {
+                DbError::InvalidChange(format!(
+                    "Validator {} not found in committee",
+                    validator.pubkey
+                ))
+            })?;
+
+        // Replace the validator with the updated one
+        self.validators[validator_position] = validator.clone();
+
+        // Update the committee's threshold and multisig address
+        self.threshold = self.validators.threshold();
+        self.multisig_address = self.validators.multisig_address(subnet_id);
+
         Ok(())
     }
 }
@@ -816,7 +847,7 @@ pub trait Database {
     fn get_last_stake_change_configuration_number(
         &self,
         subnet_id: SubnetId,
-    ) -> Result<Option<u64>, DbError>;
+    ) -> Result<u64, DbError>;
 
     fn get_next_stake_change_configuration_number(
         &self,
@@ -933,6 +964,37 @@ impl Database for HeedDb {
                 return Ok(Some(subnet_state));
             }
         }
+
+        // TDOO reenable below functionality
+        // we probably want to know if this is an old multisig address and react
+        // appropriately, like ping old committee members to see if they are still
+        // active (if recent) or just ignore the msg
+        //
+        // // If not found in current committees, check old committees
+        // let iter = self.committee_db.iter(&txn)?;
+        // for item in iter {
+        //     let (key_str, committee) = item?;
+
+        //     // Check if this old committee's multisig address matches
+        //     if &committee.multisig_address == multisig_address {
+        //         // Parse the key to extract subnet ID and committee number
+        //         let parts: Vec<&str> = key_str.split(':').collect();
+        //         if parts.len() >= 3 {
+        //             // Format is "{COMMITTEE_KEY}:{subnet_id}:{committee_number}"
+        //             if let Ok(subnet_id) = parts[1].parse::<SubnetId>() {
+        //                 // Get the current subnet state for this subnet
+        //                 if let Some(subnet_state) = self.get_subnet_state(subnet_id)? {
+        //                     trace!(
+        //                            "Found multisig address {:?} in old committee (number unknown) for subnet {}",
+        //                            *multisig_address,
+        //                            subnet_id
+        //                        );
+        //                     return Ok(Some(subnet_state));
+        //                 }
+        //             }
+        //         }
+        //     }
+        // }
 
         Ok(None)
     }
@@ -1193,7 +1255,7 @@ impl Database for HeedDb {
     fn get_last_stake_change_configuration_number(
         &self,
         subnet_id: SubnetId,
-    ) -> Result<Option<u64>, DbError> {
+    ) -> Result<u64, DbError> {
         let prefix = stake_changes_prefix(subnet_id);
         let txn = self.env.read_txn()?;
         let changes_iter = self.stake_changes_db.prefix_iter(&txn, &prefix)?;
@@ -1203,10 +1265,10 @@ impl Database for HeedDb {
             .map_err(|_| DbError::TypeConversionError("max stake changes reached".to_string()))?;
 
         if count == 0 {
-            return Ok(None);
+            return Ok(GENESIS_COMMITTEE_CONF_NUM);
         }
 
-        Ok(Some(count - 1))
+        Ok(count)
     }
 
     fn get_next_stake_change_configuration_number(
@@ -1214,12 +1276,7 @@ impl Database for HeedDb {
         subnet_id: SubnetId,
     ) -> Result<u64, DbError> {
         let last_number = self.get_last_stake_change_configuration_number(subnet_id)?;
-        let next_number = match last_number {
-            Some(n) => n + 1,
-            None => GENESIS_COMMITTEE_CONF_NUM + 1,
-        };
-
-        Ok(next_number)
+        Ok(last_number + 1)
     }
 
     fn add_stake_change(
@@ -1312,13 +1369,14 @@ pub enum DbError {
 }
 
 #[cfg(test)]
-mod tests {
+pub mod tests {
     use super::*;
-    use bitcoin::{hashes::Hash, Amount, BlockHash, Txid};
+    use crate::test_utils::generate_subnet_id;
+    use bitcoin::{hashes::Hash, key::Parity, Amount, BlockHash, Txid, XOnlyPublicKey};
     use std::str::FromStr;
     use tempfile::tempdir;
 
-    fn create_test_db() -> HeedDb {
+    pub fn create_test_db() -> HeedDb {
         let temp_dir = tempdir().unwrap();
         let db_path = temp_dir.path().to_str().unwrap();
         tokio::runtime::Runtime::new()
@@ -1327,16 +1385,13 @@ mod tests {
             .unwrap()
     }
 
-    fn create_rand_subnet_id() -> SubnetId {
-        SubnetId::from_txid(&Txid::from_slice(&rand::random::<[u8; 32]>()).unwrap())
-    }
-    fn create_rand_txid() -> Txid {
+    pub fn create_rand_txid() -> Txid {
         Txid::from_slice(&rand::random::<[u8; 32]>()).unwrap()
     }
-    fn create_rand_blockhash() -> BlockHash {
+    pub fn create_rand_blockhash() -> BlockHash {
         BlockHash::from_slice(&rand::random::<[u8; 32]>()).unwrap()
     }
-    fn create_rand_addr() -> alloy_primitives::Address {
+    pub fn create_rand_addr() -> alloy_primitives::Address {
         alloy_primitives::Address::from_slice(&rand::random::<[u8; 20]>())
     }
 
@@ -1367,7 +1422,7 @@ mod tests {
     #[test_retry::retry(3)]
     fn test_rootnet_message_nonce() {
         let db = create_test_db();
-        let subnet_id = create_rand_subnet_id();
+        let subnet_id = generate_subnet_id();
         let block_height = 100;
 
         let ro_txn = db.env.read_txn().unwrap();
@@ -1462,7 +1517,7 @@ mod tests {
     #[test_retry::retry(3)]
     fn test_rootnet_message_nonce_many_messages() {
         let db = create_test_db();
-        let subnet_id = create_rand_subnet_id();
+        let subnet_id = generate_subnet_id();
         // Total number of messages
         let total_message_count = 100;
 
@@ -1526,7 +1581,7 @@ mod tests {
     #[test]
     fn test_subnet_committee_join_validator() {
         // Setup: Create a subnet ID and initial committee
-        let subnet_id = create_rand_subnet_id();
+        let subnet_id = generate_subnet_id();
 
         // Create initial validators
         let secp = bitcoin::secp256k1::Secp256k1::new();
@@ -1586,7 +1641,9 @@ mod tests {
         };
 
         // Add the new validator
-        committee.join_validator(&subnet_id, &validator3).unwrap();
+        committee
+            .join_new_validator(&subnet_id, &validator3)
+            .unwrap();
 
         // Verify the validator was added
         assert_eq!(committee.validators.len(), 3);
@@ -1600,7 +1657,7 @@ mod tests {
         assert_ne!(committee.multisig_address, initial_address);
 
         // Try adding an existing validator (should fail)
-        let result = committee.join_validator(&subnet_id, &validator3);
+        let result = committee.join_new_validator(&subnet_id, &validator3);
         assert!(result.is_err());
 
         // Verify committee size didn't change after failed addition
@@ -1610,7 +1667,7 @@ mod tests {
     #[test]
     fn test_subnet_state_rotation() {
         // Setup: Create a subnet ID
-        let subnet_id = create_rand_subnet_id();
+        let subnet_id = generate_subnet_id();
 
         // Create validators for the current committee
         let secp = bitcoin::secp256k1::Secp256k1::new();
@@ -1715,7 +1772,7 @@ mod tests {
     #[test]
     fn test_different_power_different_multisig() {
         // Setup: Create a subnet ID
-        let subnet_id = create_rand_subnet_id();
+        let subnet_id = generate_subnet_id();
 
         // Create validators
         let secp = bitcoin::secp256k1::Secp256k1::new();
@@ -1740,7 +1797,7 @@ mod tests {
             pubkey: pubkey2,
             subnet_address: create_rand_addr(),
             power: 15, // Power of 15 for first set
-            collateral: Amount::from_sat(2_000_000),
+            collateral: Amount::from_sat(1_500_000),
             backup_address: Address::from_str("bcrt1qpufku8sca56kmxylyd2233mfmnr9eyc4wdsdmd")
                 .unwrap(),
             ip: "127.0.0.1:8001".parse().unwrap(),
@@ -1794,5 +1851,287 @@ mod tests {
 
         // Verify the multisig addresses are different
         assert_ne!(committee1.multisig_address, committee2.multisig_address);
+    }
+
+    #[test]
+    fn test_committee_modify_validator() {
+        // Setup: Create a subnet ID and initial committee
+        let subnet_id = generate_subnet_id();
+
+        // Create secp context for key generation
+        let secp = bitcoin::secp256k1::Secp256k1::new();
+
+        // Create two validators
+        let (secret_key1, _) = secp.generate_keypair(&mut rand::thread_rng());
+        let (secret_key2, _) = secp.generate_keypair(&mut rand::thread_rng());
+        let pubkey1 = XOnlyPublicKey::from_keypair(&secret_key1.keypair(&secp)).0;
+        let pubkey2 = XOnlyPublicKey::from_keypair(&secret_key2.keypair(&secp)).0;
+
+        // Create the first validator
+        let validator1 = SubnetValidator {
+            pubkey: pubkey1,
+            subnet_address: create_rand_addr(),
+            power: 10,
+            collateral: Amount::from_sat(1_000_000),
+            backup_address: Address::from_str("bcrt1qpufku8sca56kmxylyd2233mfmnr9eyc4wdsdmd")
+                .unwrap(),
+            ip: "127.0.0.1:8000".parse().unwrap(),
+            join_txid: Txid::all_zeros(),
+        };
+
+        // Create the second validator
+        let validator2 = SubnetValidator {
+            pubkey: pubkey2,
+            subnet_address: create_rand_addr(),
+            power: 15,
+            collateral: Amount::from_sat(2_000_000),
+            backup_address: Address::from_str("bcrt1qpufku8sca56kmxylyd2233mfmnr9eyc4wdsdmd")
+                .unwrap(),
+            ip: "127.0.0.1:8001".parse().unwrap(),
+            join_txid: Txid::all_zeros(),
+        };
+
+        // Create committee with two validators
+        let validators = vec![validator1.clone(), validator2.clone()];
+        let mut committee = validators.to_committee(&subnet_id, 1);
+
+        // Record the initial state
+        let initial_config_number = committee.configuration_number;
+        let initial_threshold = committee.threshold;
+        let initial_multisig = committee.multisig_address.clone();
+
+        // Create a modified version of validator1 with increased collateral and power
+        let mut modified_validator = validator1.clone();
+        modified_validator.collateral = Amount::from_sat(3_000_000);
+        modified_validator.power = 20;
+
+        // Modify the validator
+        let result = committee.modify_validator(&subnet_id, &modified_validator);
+        assert!(result.is_ok());
+
+        // Verify the committee state after modification
+        assert_eq!(committee.configuration_number, initial_config_number + 1);
+        assert_ne!(committee.threshold, initial_threshold);
+        assert_ne!(committee.multisig_address, initial_multisig);
+
+        // Check that the validator was updated correctly
+        let updated_validator = committee
+            .validators
+            .iter()
+            .find(|v| v.pubkey == pubkey1)
+            .unwrap();
+        assert_eq!(updated_validator.collateral, Amount::from_sat(3_000_000));
+        assert_eq!(updated_validator.power, 20);
+
+        // The second validator should remain unchanged
+        let unchanged_validator = committee
+            .validators
+            .iter()
+            .find(|v| v.pubkey == pubkey2)
+            .unwrap();
+        assert_eq!(unchanged_validator.collateral, Amount::from_sat(2_000_000));
+        assert_eq!(unchanged_validator.power, 15);
+    }
+
+    #[test]
+    fn test_committee_join_new_validator() {
+        // Setup: Create a subnet ID and initial committee
+        let subnet_id = generate_subnet_id();
+
+        // Create secp context for key generation
+        let secp = bitcoin::secp256k1::Secp256k1::new();
+
+        // Create an initial validator
+        let (secret_key1, _) = secp.generate_keypair(&mut rand::thread_rng());
+        let pubkey1 = XOnlyPublicKey::from_keypair(&secret_key1.keypair(&secp)).0;
+
+        let validator1 = SubnetValidator {
+            pubkey: pubkey1,
+            subnet_address: create_rand_addr(),
+            power: 10,
+            collateral: Amount::from_sat(1_000_000),
+            backup_address: Address::from_str("bcrt1qpufku8sca56kmxylyd2233mfmnr9eyc4wdsdmd")
+                .unwrap(),
+            ip: "127.0.0.1:8000".parse().unwrap(),
+            join_txid: create_rand_txid(),
+        };
+
+        // Create committee with one validator
+        let mut committee = vec![validator1].to_committee(&subnet_id, 1);
+
+        // Record the initial state
+        let initial_config_number = committee.configuration_number;
+        let initial_validator_count = committee.validators.len();
+        let initial_power = committee.total_power();
+
+        // Create a new validator to join
+        let (secret_key2, _) = secp.generate_keypair(&mut rand::thread_rng());
+        let pubkey2 = XOnlyPublicKey::from_keypair(&secret_key2.keypair(&secp)).0;
+
+        let new_validator = SubnetValidator {
+            pubkey: pubkey2,
+            subnet_address: create_rand_addr(),
+            power: 15,
+            collateral: Amount::from_sat(2_000_000),
+            backup_address: Address::from_str("bcrt1qpufku8sca56kmxylyd2233mfmnr9eyc4wdsdmd")
+                .unwrap(),
+            ip: "127.0.0.1:8001".parse().unwrap(),
+            join_txid: create_rand_txid(),
+        };
+
+        // Join the new validator
+        let result = committee.join_new_validator(&subnet_id, &new_validator);
+        assert!(result.is_ok());
+
+        // Verify the committee state after joining
+        assert_eq!(committee.configuration_number, initial_config_number + 2); // Increases by 2
+        assert_eq!(committee.validators.len(), initial_validator_count + 1);
+        assert_eq!(committee.total_power(), initial_power + new_validator.power);
+
+        // Verify the new validator is in the committee
+        let joined_validator = committee.validators.iter().find(|v| v.pubkey == pubkey2);
+        assert!(joined_validator.is_some());
+        assert_eq!(joined_validator.unwrap().power, 15);
+    }
+
+    #[test]
+    fn test_stake_change_configuration_number() {
+        let db = create_test_db();
+        let subnet_id = generate_subnet_id();
+
+        // Create validators
+        let secp = bitcoin::secp256k1::Secp256k1::new();
+        let (secret_key1, _) = secp.generate_keypair(&mut rand::thread_rng());
+        let (secret_key2, _) = secp.generate_keypair(&mut rand::thread_rng());
+        let pubkey1 = XOnlyPublicKey::from_keypair(&secret_key1.keypair(&secp)).0;
+        let pubkey2 = XOnlyPublicKey::from_keypair(&secret_key2.keypair(&secp)).0;
+
+        let validator1 = SubnetValidator {
+            pubkey: pubkey1,
+            subnet_address: create_rand_addr(),
+            power: 10, // Power of 10 for first set
+            collateral: Amount::from_sat(1_000_000),
+            backup_address: Address::from_str("bcrt1qpufku8sca56kmxylyd2233mfmnr9eyc4wdsdmd")
+                .unwrap(),
+            ip: "127.0.0.1:8000".parse().unwrap(),
+            join_txid: create_rand_txid(),
+        };
+
+        let validator2 = SubnetValidator {
+            pubkey: pubkey2,
+            subnet_address: create_rand_addr(),
+            power: 15,
+            collateral: Amount::from_sat(2_000_000),
+            backup_address: Address::from_str("bcrt1qpufku8sca56kmxylyd2233mfmnr9eyc4wdsdmd")
+                .unwrap(),
+            ip: "127.0.0.1:8001".parse().unwrap(),
+            join_txid: create_rand_txid(),
+        };
+
+        // Create initial committee with two validators
+        let mut initial_validators = Vec::new();
+        initial_validators.push(validator1.clone());
+
+        let mut committee = initial_validators.to_committee(&subnet_id, 0);
+
+        // Initial check - should be GENESIS_COMMITTEE_CONF_NUM + 1
+        let next_conf_num = db
+            .get_next_stake_change_configuration_number(subnet_id.clone())
+            .unwrap();
+        assert_eq!(next_conf_num, GENESIS_COMMITTEE_CONF_NUM + 1);
+
+        // Join new validator (should increase configuration by 2)
+        committee
+            .join_new_validator(&subnet_id, &validator2)
+            .unwrap();
+
+        // Create a stake change request for joining
+        let join_request = StakeChangeRequest {
+            change: StakingChange::Join {
+                pubkey: validator2.pubkey.public_key(Parity::Even),
+            },
+            validator_xpk: validator2.pubkey,
+            validator_subnet_address: validator2.subnet_address,
+            configuration_number: GENESIS_COMMITTEE_CONF_NUM + 1, // First change is metadata
+            committee_after_change: committee.clone(),
+            block_height: 100,
+            block_hash: BlockHash::all_zeros(),
+            checkpoint_block_height: None,
+            checkpoint_block_hash: None,
+            txid: Txid::all_zeros(),
+        };
+
+        // Create a stake change request for initial deposit
+        let deposit_request = StakeChangeRequest {
+            change: StakingChange::Deposit {
+                amount: validator2.collateral,
+            },
+            validator_xpk: validator2.pubkey,
+            validator_subnet_address: validator2.subnet_address,
+            configuration_number: GENESIS_COMMITTEE_CONF_NUM + 2, // Second change is deposit
+            committee_after_change: committee.clone(),
+            block_height: 100,
+            block_hash: BlockHash::all_zeros(),
+            checkpoint_block_height: None,
+            checkpoint_block_hash: None,
+            txid: Txid::all_zeros(),
+        };
+
+        {
+            let mut wtxn = db.write_txn().unwrap();
+            // Store the join request
+            db.add_stake_change(&mut wtxn, subnet_id, join_request)
+                .unwrap();
+            // Store the deposit request
+            db.add_stake_change(&mut wtxn, subnet_id, deposit_request)
+                .unwrap();
+            wtxn.commit().unwrap();
+        }
+
+        // Check the configuration number after adding validator
+        let next_conf_num = db
+            .get_next_stake_change_configuration_number(subnet_id.clone())
+            .unwrap();
+        assert_eq!(next_conf_num, GENESIS_COMMITTEE_CONF_NUM + 3);
+
+        // Modify validator by increasing stake
+        let mut updated_validator = validator1.clone();
+        updated_validator.power = 20;
+        updated_validator.collateral = Amount::from_sat(2_000_000);
+
+        // Modify the validator in the committee
+        committee
+            .modify_validator(&subnet_id, &updated_validator)
+            .unwrap();
+
+        // Create a stake change request for the modification
+        let modify_request = StakeChangeRequest {
+            change: StakingChange::Deposit {
+                amount: Amount::from_sat(1_000_000), // Additional 0.01 BTC
+            },
+            validator_xpk: validator1.pubkey,
+            validator_subnet_address: validator1.subnet_address,
+            configuration_number: GENESIS_COMMITTEE_CONF_NUM + 3, // Third change
+            committee_after_change: committee.clone(),
+            block_height: 101,
+            block_hash: BlockHash::all_zeros(),
+            checkpoint_block_height: None,
+            checkpoint_block_hash: None,
+            txid: Txid::all_zeros(),
+        };
+
+        {
+            let mut wtxn = db.write_txn().unwrap();
+            // Store the join request
+            db.add_stake_change(&mut wtxn, subnet_id, modify_request)
+                .unwrap();
+            wtxn.commit().unwrap();
+        }
+
+        // Check the configuration number after modifying validator
+        let next_conf_num = db
+            .get_next_stake_change_configuration_number(subnet_id.clone())
+            .unwrap();
+        assert_eq!(next_conf_num, GENESIS_COMMITTEE_CONF_NUM + 4);
     }
 }

--- a/src/ipc_lib.rs
+++ b/src/ipc_lib.rs
@@ -1,4 +1,5 @@
 use bitcoin::address::NetworkUnchecked;
+
 use bitcoin::hashes::Hash;
 use bitcoin::key::constants::SCHNORR_PUBLIC_KEY_SIZE;
 use bitcoin::Amount;
@@ -1182,6 +1183,19 @@ pub struct IpcWithdrawal {
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct IpcUnstake {
+    /// The amount to unstake
+    #[serde(with = "bitcoin::amount::serde::as_sat")]
+    pub amount: Amount,
+    /// The address to send collateral to
+    /// For now, this is the same as the validator's
+    /// backup_address they specify upon joining
+    pub address: bitcoin::Address<NetworkUnchecked>,
+    /// The pubkey of the validator in question
+    pub pubkey: bitcoin::XOnlyPublicKey,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct IpcCrossSubnetTransfer {
     /// The amount to transfer
     #[serde(with = "bitcoin::amount::serde::as_sat")]
@@ -1214,6 +1228,9 @@ pub struct IpcCheckpointSubnetMsg {
     pub checkpoint_height: u64,
     /// Committee configuration number
     pub next_committee_configuration_number: u64,
+    /// Unstakes for validators leaving the subnet
+    #[serde(default)]
+    pub unstakes: Vec<IpcUnstake>,
     /// Withdrawals
     #[serde(default)]
     pub withdrawals: Vec<IpcWithdrawal>,
@@ -1237,7 +1254,35 @@ impl IpcValidate for IpcCheckpointSubnetMsg {
 
         // TODO validate that checkpoint height no duplicates?
 
-        // Ensure number of withdrawals and transfers doesn't exceed u8::MAX (255)
+        // Ensure number of unstakes, withdrawals and transfers doesn't exceed u8::MAX (255)
+        if self.unstakes.len() > u8::MAX as usize {
+            return Err(IpcValidateError::InvalidMsg(format!(
+                "Number of unstakes ({}) exceeds maximum allowed ({})",
+                self.unstakes.len(),
+                u8::MAX
+            )));
+        }
+
+        // Check if the unstakes are valid
+        for unstake in &self.unstakes {
+            if unstake.amount == Amount::ZERO {
+                return Err(IpcValidateError::InvalidField(
+                    "unstake.amount",
+                    "Unstake amount must be greater than zero".to_string(),
+                ));
+            }
+            if !unstake.address.is_valid_for_network(NETWORK) {
+                return Err(IpcValidateError::InvalidField(
+                    "unstake.address",
+                    format!(
+                        "Bitcoin address {:?} must be for the current network",
+                        unstake.address
+                    ),
+                ));
+            }
+        }
+
+        // Ensure number of withdrawals doesn't exceed u8::MAX (255)
         if self.withdrawals.len() > u8::MAX as usize {
             return Err(IpcValidateError::InvalidMsg(format!(
                 "Number of withdrawals ({}) exceeds maximum allowed ({})",
@@ -1301,8 +1346,8 @@ impl IpcValidate for IpcCheckpointSubnetMsg {
 }
 
 impl IpcCheckpointSubnetMsg {
-    // Length of the withdrawal + transfer markers, 1 byte each
-    const MARKERS_LEN: usize = 2;
+    // Length of the withdrawal + transfer + unstake markers, 1 byte each
+    const MARKERS_LEN: usize = 3;
     // u64 length
     const HEIGHT_LEN: usize = std::mem::size_of::<u64>();
     // u64 length
@@ -1344,6 +1389,7 @@ impl IpcCheckpointSubnetMsg {
         // Set marker values
         op_return_data[Self::MARKERS_OFFSET] = self.withdrawals.len().min(255) as u8; // Withdrawal count
         op_return_data[Self::MARKERS_OFFSET + 1] = self.transfers.len().min(255) as u8; // Transfer count
+        op_return_data[Self::MARKERS_OFFSET + 2] = self.unstakes.len().min(255) as u8; // Unstake count
 
         // Add committee configuration number
         op_return_data[Self::COMMITTEE_CONF_OFFSET..]
@@ -1365,7 +1411,7 @@ impl IpcCheckpointSubnetMsg {
 
     pub fn extract_markers_from_metadata_tx_out(
         tx_out: &bitcoin::TxOut,
-    ) -> Result<(u8, u8), IpcLibError> {
+    ) -> Result<(u8, u8, u8), IpcLibError> {
         let err = |msg: String| IpcLibError::MsgParseError(IPC_CHECKPOINT_TAG, msg);
 
         // Get OP_RETURN data from first output
@@ -1395,8 +1441,9 @@ impl IpcCheckpointSubnetMsg {
         // Extract the markers
         let withdrawal_count = op_return_data[Self::MARKERS_OFFSET];
         let transfer_count = op_return_data[Self::MARKERS_OFFSET + 1];
+        let unstake_count = op_return_data[Self::MARKERS_OFFSET + 2];
 
-        Ok((withdrawal_count, transfer_count))
+        Ok((withdrawal_count, transfer_count, unstake_count))
     }
 
     fn make_batched_transfer_data(&self) -> Result<Vec<u8>, IpcLibError> {
@@ -1550,10 +1597,10 @@ impl IpcCheckpointSubnetMsg {
             return None;
         }
 
-        // Calculate batch_transfer vout based on the number of withdrawals
-        // position after the metadata output and all withdrawal outputs
-        // i.e., 1 (metadata) + withdrawals.len() if present
-        let vout = 1 + self.withdrawals.len() as u32;
+        // Calculate batch_transfer vout based on the number of withdrawals and unstakes
+        // position after the metadata output, all withdrawal outputs and all unstake outputs
+        // i.e., 1 (metadata) + withdrawals.len() + unstakes.len() if present
+        let vout = 1 + self.withdrawals.len() as u32 + self.unstakes.len() as u32;
 
         Some(bitcoin::OutPoint { txid, vout })
     }
@@ -1633,6 +1680,23 @@ impl IpcCheckpointSubnetMsg {
             tx_outs.push(bitcoin::TxOut {
                 value: withdrawal.amount,
                 script_pubkey: withdrawal
+                    .address
+                    .clone()
+                    // safe to assume it's checked and panic otherwise
+                    // because of the validation beforehand
+                    .require_network(NETWORK)
+                    .expect("Address must be valid for network")
+                    .script_pubkey(),
+            });
+        }
+
+        //
+        // Add unstake outputs
+        //
+        for unstake in &self.unstakes {
+            tx_outs.push(bitcoin::TxOut {
+                value: unstake.amount,
+                script_pubkey: unstake
                     .address
                     .clone()
                     // safe to assume it's checked and panic otherwise
@@ -1805,6 +1869,7 @@ impl IpcCheckpointSubnetMsg {
         // Extract marker values
         let withdrawals_count = op_return_data[Self::MARKERS_OFFSET] as usize;
         let transfers_count = op_return_data[Self::MARKERS_OFFSET + 1] as usize;
+        let unstakes_count = op_return_data[Self::MARKERS_OFFSET + 2] as usize;
 
         // Extract committee configuration number
         let committee_conf_bytes = &op_return_data[Self::COMMITTEE_CONF_OFFSET..];
@@ -1813,9 +1878,10 @@ impl IpcCheckpointSubnetMsg {
                 err("Failed to convert committee configuration number bytes to u64".to_string())
             })?);
 
-        // Check if we have enough outputs for all the withdrawals and transfers
+        // Check if we have enough outputs for all the withdrawals, unstakes and transfers
         let expected_outputs = 1 + // metadata
                withdrawals_count + // withdrawals
+               unstakes_count + // unstakes
                (if transfers_count > 0 { 1 } else { 0 }) + // batch transfer commit (if needed)
                transfers_count; // transfers
 
@@ -1827,16 +1893,60 @@ impl IpcCheckpointSubnetMsg {
             )));
         }
 
+        let subnet = db
+            .get_subnet_state(subnet_id)?
+            .ok_or(err(format!("Subnet {} not found", subnet_id)))?;
+
         // Parse withdrawals
         let mut withdrawals = Vec::with_capacity(withdrawals_count);
         for i in 0..withdrawals_count {
             let txout = &tx.output[1 + i]; // 1-based index (after metadata)
             let amount = txout.value;
-            let address = bitcoin::Address::from_script(&txout.script_pubkey, NETWORK)
-                .map_err(|_| err(format!("Could not parse address from output {}", 1 + i)))?;
+            let address =
+                bitcoin::Address::from_script(&txout.script_pubkey, NETWORK).map_err(|_| {
+                    err(format!(
+                        "Could not parse address from withdrawal output {}",
+                        1 + i
+                    ))
+                })?;
             let address = address.into_unchecked();
 
             withdrawals.push(IpcWithdrawal { amount, address });
+        }
+
+        // Parse unstakes
+        let mut unstakes = Vec::with_capacity(unstakes_count);
+        for i in 0..unstakes_count {
+            let txout = &tx.output[1 + withdrawals_count + i]; // After metadata and withdrawals
+            let amount = txout.value;
+            let address =
+                bitcoin::Address::from_script(&txout.script_pubkey, NETWORK).map_err(|_| {
+                    err(format!(
+                        "Could not parse address from unstake output {}",
+                        1 + withdrawals_count + i
+                    ))
+                })?;
+            let address = address.into_unchecked();
+
+            let validator = subnet
+                .committee
+                .validators
+                .iter()
+                .find(|v| v.backup_address == address);
+
+            if validator.is_none() {
+                warn!("Subnet {} checkpoint: unstake present for a non-validator to address {}, skipping...", subnet_id, address.assume_checked());
+                continue;
+            }
+
+            let validator = validator.unwrap();
+            let pubkey = validator.pubkey;
+
+            unstakes.push(IpcUnstake {
+                amount,
+                address,
+                pubkey,
+            });
         }
 
         // Parse transfers
@@ -1844,8 +1954,8 @@ impl IpcCheckpointSubnetMsg {
 
         // If there are transfers, there should be a batch transfer commit output
         if transfers_count > 0 {
-            // Start after metadata + withdrawals + batch commit
-            let transfer_start_index = 1 + withdrawals_count + 1;
+            // Start after metadata + withdrawals + unstakes + batch commit
+            let transfer_start_index = 1 + withdrawals_count + unstakes_count + 1;
 
             for i in 0..transfers_count {
                 let txout = &tx.output[transfer_start_index + i];
@@ -1906,6 +2016,7 @@ impl IpcCheckpointSubnetMsg {
             checkpoint_hash,
             checkpoint_height,
             next_committee_configuration_number,
+            unstakes,
             withdrawals,
             transfers,
             change_address,
@@ -2238,7 +2349,7 @@ impl IpcBatchTransferMsg {
             )))?;
 
         // Extract withdrawal and transfer counts from checkpoint metadata
-        let (_withdrawal_count, transfer_count) =
+        let (_, _, transfer_count) =
             match IpcCheckpointSubnetMsg::extract_markers_from_metadata_tx_out(metadata_tx_out) {
                 Ok(counts) => counts,
                 Err(e) => {
@@ -3534,8 +3645,83 @@ mod prefund_msg_tests {
 #[cfg(test)]
 mod checkpoint_msg_tests {
     use super::*;
-    use crate::{db::Database, test_utils, DEFAULT_BTC_FEE_RATE};
+    use crate::{
+        db::Database,
+        test_utils::{self, create_test_db},
+        DEFAULT_BTC_FEE_RATE,
+    };
     use std::str::FromStr;
+
+    #[test]
+    fn test_checkpoint_with_unstakes() {
+        // Set up test database
+        let db = create_test_db();
+
+        // Create a test subnet
+        let subnet = test_utils::generate_subnet(3);
+        let committee = &subnet.committee;
+        let utxos = create_test_utxos(committee.address_checked().script_pubkey());
+
+        // dbg!(&subnet);
+
+        // Save subnets to database
+        {
+            let mut wtxn = db.write_txn().expect("Should create transaction");
+            db.save_subnet_state(&mut wtxn, subnet.id, &subnet)
+                .expect("Should save subnet");
+            wtxn.commit().unwrap();
+        }
+
+        // Create checkpoint message with unstakes
+        let mut checkpoint_msg = create_test_checkpoint_msg();
+        // Update subnet i
+        checkpoint_msg.subnet_id = subnet.id;
+        // Remove transfers for this test
+        checkpoint_msg.transfers.clear();
+        // Update unstake address
+        checkpoint_msg.unstakes.first_mut().unwrap().address = subnet
+            .committee
+            .validators
+            .first()
+            .unwrap()
+            .backup_address
+            .clone();
+
+        // Verify the test checkpoint message has unstakes
+        assert!(!checkpoint_msg.unstakes.is_empty());
+        let original_unstakes = checkpoint_msg.unstakes.clone();
+
+        // Generate the transaction
+        let checkpoint_psbt = checkpoint_msg
+            .to_checkpoint_psbt(committee, committee, DEFAULT_BTC_FEE_RATE, &utxos)
+            .expect("Should create checkpoint PSBT");
+
+        let checkpoint_tx = checkpoint_psbt.extract_tx().expect("must extract tx");
+
+        dbg!(&checkpoint_tx);
+
+        // Parse the transaction back to a checkpoint message
+        let parsed_msg = IpcCheckpointSubnetMsg::from_checkpoint_tx(&db, &checkpoint_tx)
+            .expect("Should parse checkpoint message");
+        dbg!(&parsed_msg);
+
+        // Verify unstakes were correctly serialized and deserialized
+        assert_eq!(parsed_msg.unstakes.len(), original_unstakes.len());
+        for (i, unstake) in parsed_msg.unstakes.iter().enumerate() {
+            assert_eq!(unstake.amount, original_unstakes[i].amount);
+            assert_eq!(unstake.address, original_unstakes[i].address);
+            // Note: pubkey is not preserved in the checkpoint transaction
+        }
+
+        // Verify metadata and markers
+        let (withdrawal_count, transfer_count, unstake_count) =
+            IpcCheckpointSubnetMsg::extract_markers_from_metadata_tx_out(&checkpoint_tx.output[0])
+                .expect("Should extract markers");
+
+        assert_eq!(withdrawal_count as usize, checkpoint_msg.withdrawals.len());
+        assert_eq!(transfer_count as usize, checkpoint_msg.transfers.len());
+        assert_eq!(unstake_count as usize, original_unstakes.len());
+    }
 
     fn create_test_checkpoint_msg() -> IpcCheckpointSubnetMsg {
         // Generate a subnet with 3 validators
@@ -3548,6 +3734,17 @@ mod checkpoint_msg_tests {
             "000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f",
         )
         .unwrap();
+
+        // Create an unstake
+        let unstake = IpcUnstake {
+            amount: Amount::from_sat(40000),
+            address: bitcoin::Address::from_str("bcrt1qgtzpfqlfkz4nhkpvz2enqtucm2pzhdvlssxnss")
+                .unwrap(),
+            pubkey: bitcoin::XOnlyPublicKey::from_str(
+                "b15f99928f2478a10c5739a03f5495d342e77352d624e7cc8ebfbded544f9ac0",
+            )
+            .unwrap(),
+        };
 
         // Create a withdrawal
         let withdrawal = IpcWithdrawal {
@@ -3571,6 +3768,7 @@ mod checkpoint_msg_tests {
             subnet_id: subnet_state.id,
             checkpoint_hash,
             checkpoint_height: 50,
+            unstakes: vec![unstake],
             withdrawals: vec![withdrawal],
             transfers: vec![transfer],
             change_address: Some(subnet_state.committee.multisig_address.clone()),
@@ -3656,8 +3854,14 @@ mod checkpoint_msg_tests {
             "Transfer count marker should be 1"
         );
 
-        // Should have at least 2 outputs (OP_RETURN + withdrawal)
-        assert_eq!(checkpoint_tx.output.len(), 5, "Should have 5 outputs");
+        // Check the unstake count marker
+        assert_eq!(
+            op_return_data[IpcCheckpointSubnetMsg::MARKERS_OFFSET + 2],
+            1,
+            "Unstake count marker should be 1"
+        );
+
+        assert_eq!(checkpoint_tx.output.len(), 6, "Should have 6 outputs");
 
         // Since we have transfers, we should have a batch transaction
         assert!(
@@ -3717,6 +3921,7 @@ mod checkpoint_msg_tests {
             checkpoint_height: 50,
             withdrawals: vec![withdrawal, withdrawal2],
             transfers: vec![],
+            unstakes: vec![],
             change_address: Some(committee.multisig_address.clone()),
             next_committee_configuration_number: 1,
         };
@@ -3796,6 +4001,7 @@ mod checkpoint_msg_tests {
             checkpoint_height: 50,
             withdrawals: vec![],
             transfers: vec![],
+            unstakes: vec![],
             change_address: Some(committee.multisig_address.clone()),
             next_committee_configuration_number: 1,
         };
@@ -3946,6 +4152,7 @@ mod checkpoint_msg_tests {
             checkpoint_hash,
             checkpoint_height: 50,
             withdrawals: vec![],
+            unstakes: vec![],
             transfers: vec![transfer1.clone(), transfer2.clone(), transfer3.clone()],
             change_address: Some(committee.multisig_address.clone()),
             next_committee_configuration_number: 1,
@@ -4054,7 +4261,7 @@ mod checkpoint_msg_tests {
 
     #[test]
     fn test_stake_collateral_from_tx() {
-        let db = crate::db::tests::create_test_db();
+        let db = crate::test_utils::create_test_db();
         let subnet_id = crate::test_utils::generate_subnet_id();
         let subnet_state = crate::db::SubnetState {
             id: subnet_id,

--- a/src/ipc_lib.rs
+++ b/src/ipc_lib.rs
@@ -1,7 +1,7 @@
 use bitcoin::address::NetworkUnchecked;
 
 use bitcoin::hashes::Hash;
-use bitcoin::key::constants::SCHNORR_PUBLIC_KEY_SIZE;
+use bitcoin::key::constants::{SCHNORR_PUBLIC_KEY_SIZE, SCHNORR_SIGNATURE_SIZE};
 use bitcoin::Amount;
 use bitcoin::Transaction;
 use bitcoin::Txid;
@@ -1395,6 +1395,7 @@ impl IpcCheckpointSubnetMsg {
         op_return_data[Self::COMMITTEE_CONF_OFFSET..]
             .copy_from_slice(&self.next_committee_configuration_number.to_le_bytes());
 
+        // Required to do since [u8; 77] for some reason doesn't implement pusbytes
         let push_bytes: &bitcoin::script::PushBytes =
             (&op_return_data[..]).try_into().expect("the size is okay");
 
@@ -2793,7 +2794,7 @@ impl IpcValidate for IpcStakeCollateralMsg {
         if self.amount == Amount::ZERO {
             return Err(IpcValidateError::InvalidField(
                 "amount",
-                "Amount amount must be greater than zero".to_string(),
+                "Amount must be greater than zero".to_string(),
             ));
         }
 
@@ -2811,13 +2812,13 @@ pub struct IpcUnstakeCollateralMsg {
     #[serde(with = "bitcoin::amount::serde::as_sat")]
     pub amount: bitcoin::Amount,
     /// The pubkey of the validator
-    pub pubkey: bitcoin::XOnlyPublicKey,
+    #[serde(skip_deserializing)]
+    pub pubkey: Option<bitcoin::XOnlyPublicKey>,
 }
 
 impl IpcUnstakeCollateralMsg {
     // The total length of the op_return data - helper
-    const DATA_LEN: usize =
-        IPC_TAG_LENGTH + SubnetId::INNER_LEN + Amount::SIZE + SCHNORR_PUBLIC_KEY_SIZE;
+    const DATA_LEN: usize = IPC_TAG_LENGTH + SCHNORR_SIGNATURE_SIZE + Amount::SIZE;
 
     pub fn validate_for_subnet(&self, subnet: &db::SubnetState) -> Result<(), IpcValidateError> {
         // should never happen
@@ -2832,11 +2833,22 @@ impl IpcUnstakeCollateralMsg {
         }
 
         // Check if the validator with this public key is already registered
-        if !subnet.committee.is_validator(&self.pubkey) {
-            return Err(IpcValidateError::InvalidMsg(format!(
-                "Validator with public key '{}' must already be a validator in subnet {}",
-                self.pubkey, self.subnet_id,
-            )));
+        // NOTE: don't remove
+        match self.pubkey {
+            Some(pubkey) => {
+                if !subnet.committee.is_validator(&pubkey) {
+                    return Err(IpcValidateError::InvalidMsg(format!(
+                        "Validator with public key '{}' must already be a validator in subnet {}",
+                        pubkey, self.subnet_id,
+                    )));
+                }
+            }
+            None => {
+                return Err(IpcValidateError::InvalidField(
+                    "pubkey",
+                    "Validator public key is required".to_string(),
+                ));
+            }
         }
 
         // Check if the amount is not more than the current collateral
@@ -2869,41 +2881,96 @@ impl IpcUnstakeCollateralMsg {
         Ok(())
     }
 
-    pub fn to_tx(&self, fee_rate: bitcoin::FeeRate) -> Result<Transaction, IpcLibError> {
+    /// See `make_signature` for information
+    fn make_signature_msg(
+        prev_txid: &Txid,
+        pubkey: &bitcoin::XOnlyPublicKey,
+        amount: &bitcoin::Amount,
+        subnet_id: &SubnetId,
+    ) -> bitcoin::secp256k1::Message {
+        let mut msg = Vec::new();
+        msg.extend_from_slice(prev_txid.as_byte_array().as_slice());
+        msg.extend_from_slice(&pubkey.serialize());
+        msg.extend_from_slice(&amount.to_sat().to_be_bytes());
+        msg.extend_from_slice(subnet_id.txid20().as_ref());
+
+        let msg = bitcoin::hashes::sha256::Hash::hash(&msg);
+        bitcoin::secp256k1::Message::from_digest(msg.to_byte_array())
+    }
+
+    /// Returns a signature to be embedded in the OP_RETURN output
+    /// Confirming it's valid and signed by the validator making the request
+    ///
+    /// The signature is signing the following message:
+    /// prev_txid || xpubkey || unstake_amount || subnet_id
+    ///
+    /// This is to prevent replay attacks, since the tx inputs
+    /// are not enforced or verified
+    pub(crate) fn make_signature(
+        &self,
+        prev_txid: &Txid,
+        secret_key: bitcoin::secp256k1::SecretKey,
+    ) -> bitcoin::secp256k1::schnorr::Signature {
+        let secp = bitcoin::secp256k1::Secp256k1::new();
+        let (pubkey, _) = secret_key.x_only_public_key(&secp);
+        let msg = Self::make_signature_msg(prev_txid, &pubkey, &self.amount, &self.subnet_id);
+
+        // Sign the message with the secret key
+        // and return the signature
+        secp.sign_schnorr(&msg, &secret_key.keypair(&secp))
+    }
+
+    pub fn to_tx(
+        &self,
+        fee_rate: bitcoin::FeeRate,
+        multisig_address: &bitcoin::Address,
+        signature: bitcoin::secp256k1::schnorr::Signature,
+    ) -> Result<Transaction, IpcLibError> {
         //
-        // Create the output: op_return with
-        // ipc tag, subnet_id, amount, xonly pubkey of validator
+        // Create the first output: op_return with
+        // ipc tag, schnorr signature, amount
         //
         let tag: [u8; IPC_TAG_LENGTH] = IPC_UNSTAKE_TAG
             .as_bytes()
             .try_into()
             .expect("IPC_UNSTAKE_TAG has incorrect length");
-        let subnet_id_txid: [u8; SubnetId::INNER_LEN] = self.subnet_id.txid20();
         let amount = self.amount.to_sat().to_be_bytes();
-        let pubkey: [u8; SCHNORR_PUBLIC_KEY_SIZE] = self.pubkey.serialize();
+
+        let sig_bytes = signature.as_ref();
 
         // Construct op_return data
         let mut op_return_data = [0u8; Self::DATA_LEN];
 
         op_return_data[0..IPC_TAG_LENGTH].copy_from_slice(&tag);
-        op_return_data[IPC_TAG_LENGTH..IPC_TAG_LENGTH + SubnetId::INNER_LEN]
-            .copy_from_slice(&subnet_id_txid);
-        op_return_data[IPC_TAG_LENGTH + SubnetId::INNER_LEN
-            ..IPC_TAG_LENGTH + SubnetId::INNER_LEN + Amount::SIZE]
-            .copy_from_slice(&amount);
-        op_return_data[IPC_TAG_LENGTH + SubnetId::INNER_LEN + Amount::SIZE..]
-            .copy_from_slice(&pubkey);
+        op_return_data[IPC_TAG_LENGTH..IPC_TAG_LENGTH + SCHNORR_SIGNATURE_SIZE]
+            .copy_from_slice(sig_bytes);
+        op_return_data[IPC_TAG_LENGTH + SCHNORR_SIGNATURE_SIZE..].copy_from_slice(&amount);
+
+        // Required to do since [u8; 78] for some reason doesn't implement pusbytes
+        let push_bytes: &bitcoin::script::PushBytes =
+            (&op_return_data[..]).try_into().expect("the size is okay");
 
         // Make op_return script and txout
-        let op_return_script = bitcoin_utils::make_op_return_script(op_return_data);
+        let op_return_script = bitcoin_utils::make_op_return_script(push_bytes);
         let data_value = op_return_script.minimal_non_dust_custom(fee_rate);
         let data_tx_out = bitcoin::TxOut {
             value: data_value,
             script_pubkey: op_return_script,
         };
 
+        //
+        // Create second output: amount sent to the subnet multisig address
+        //
+        let multisig_tx_out = bitcoin::TxOut {
+            // TODO check this dust calculation?
+            value: multisig_address
+                .script_pubkey()
+                .minimal_non_dust_custom(fee_rate),
+            script_pubkey: multisig_address.script_pubkey(),
+        };
+
         // Construct transaction
-        let tx_outs = vec![data_tx_out];
+        let tx_outs = vec![data_tx_out, multisig_tx_out];
         let tx = bitcoin_utils::create_tx_from_txouts(tx_outs);
         debug!("Unstake TX: {tx:?}");
 
@@ -2911,17 +2978,18 @@ impl IpcUnstakeCollateralMsg {
     }
 
     /// Parses an IpcUnstakeCollateralMsg from a Bitcoin transaction
-    pub fn from_tx<D: db::Database>(_db: &D, tx: &Transaction) -> Result<Self, IpcLibError> {
+    pub fn from_tx<D: db::Database>(db: &D, tx: &Transaction) -> Result<Self, IpcLibError> {
         use bitcoin::blockdata::script::Instruction;
 
         // Helper closure for error creation
         let err = |msg: String| IpcLibError::MsgParseError(IPC_UNSTAKE_TAG, msg);
 
-        // We expect at least one output:
-        // 1. OP_RETURN with IPC tag, subnet_id, amount and validator pubkey
-        if tx.output.is_empty() {
+        // We expect at least two outputs:
+        // 1. OP_RETURN with IPC tag, signature, and amount
+        // 2. Output to the subnet multisig address
+        if tx.output.len() < 2 {
             return Err(err(format!(
-                "Expected at least 1 output for unstake collateral message, found {}",
+                "Expected at least 2 outputs for unstake collateral message, found {}",
                 tx.output.len()
             )));
         }
@@ -2955,15 +3023,13 @@ impl IpcUnstakeCollateralMsg {
             )));
         }
 
-        // Extract subnet ID
-        let subnet_id_bytes = &op_return_data[IPC_TAG_LENGTH..IPC_TAG_LENGTH + SubnetId::INNER_LEN];
-        let mut txid20 = [0u8; SubnetId::INNER_LEN];
-        txid20.copy_from_slice(subnet_id_bytes);
-        let subnet_id = SubnetId::from_txid20(&txid20);
+        // Extract signature
+        let sig_bytes = &op_return_data[IPC_TAG_LENGTH..IPC_TAG_LENGTH + SCHNORR_SIGNATURE_SIZE];
+        let signature = bitcoin::secp256k1::schnorr::Signature::from_slice(sig_bytes)
+            .map_err(|e| err(format!("Invalid schnorr signature: {}", e)))?;
 
         // Extract amount
-        let amount_bytes = &op_return_data[IPC_TAG_LENGTH + SubnetId::INNER_LEN
-            ..IPC_TAG_LENGTH + SubnetId::INNER_LEN + Amount::SIZE];
+        let amount_bytes = &op_return_data[IPC_TAG_LENGTH + SCHNORR_SIGNATURE_SIZE..];
         let amount_sat = u64::from_be_bytes(
             amount_bytes
                 .try_into()
@@ -2971,31 +3037,125 @@ impl IpcUnstakeCollateralMsg {
         );
         let amount = Amount::from_sat(amount_sat);
 
-        // Extract validator pubkey
-        let pubkey_bytes = &op_return_data[IPC_TAG_LENGTH + SubnetId::INNER_LEN + Amount::SIZE..];
-        let pubkey = XOnlyPublicKey::from_slice(pubkey_bytes)
-            .map_err(|e| err(format!("Invalid validator pubkey: {}", e)))?;
+        let multisig_address = bitcoin::Address::from_script(&tx.output[1].script_pubkey, NETWORK)
+            .map_err(|_| err("Could not parse address from output 1".to_string()))?
+            .into_unchecked();
+
+        let subnet = match db.get_subnet_by_multisig_address(&multisig_address) {
+            Ok(Some(subnet)) => subnet,
+            Ok(None) => {
+                error!(
+                    "StakeCollateralMsg: Could not find subnet with multisig address {:?}.",
+                    multisig_address
+                );
+                return Err(err(format!(
+                    "StakeCollateralMsg: Could not find subnet with multisig address {:?}",
+                    multisig_address
+                )));
+            }
+            Err(e) => {
+                error!(
+	                "StakeCollateralMsg: Error while looking up subnet with multisig address {:?}: {}",
+	                multisig_address, e
+	            );
+                return Err(err(format!(
+                    "StakeCollateralMsg: Error while looking up subnet with multisig address {:?}: {}",
+                    multisig_address, e
+                )));
+            }
+        };
+
+        let secp = bitcoin::secp256k1::Secp256k1::new();
+
+        let prev_txid = tx
+            .input
+            .first()
+            .ok_or(err("No inputs in the transaction".to_string()))?
+            .previous_output
+            .txid;
+
+        let validator = subnet
+            .committee
+            .validators
+            .iter()
+            .find(|v| {
+                let msg = IpcUnstakeCollateralMsg::make_signature_msg(
+                    &prev_txid, &v.pubkey, &amount, &subnet.id,
+                );
+
+                // dbg!(prev_txid);
+                // dbg!(v.pubkey);
+                // dbg!(amount);
+                // dbg!(subnet.id);
+                // dbg!(msg);
+
+                secp.verify_schnorr(&signature, &msg, &v.pubkey).is_ok()
+            })
+            .ok_or(IpcValidateError::InvalidMsg(format!(
+                "Signature doesn't match any of the validators in the committee for subnet {}",
+                subnet.id
+            )))?;
+
+        debug!(
+            "Unstake request matches validator xpk {} from signature",
+            validator.pubkey
+        );
 
         // Construct the message
         Ok(Self {
-            subnet_id,
+            subnet_id: subnet.id,
             amount,
-            pubkey,
+            pubkey: Some(validator.pubkey),
         })
     }
 
-    pub fn submit_to_bitcoin(&self, rpc: &bitcoincore_rpc::Client) -> Result<Txid, IpcLibError> {
+    /// Submits the unstake transaction to Bitcoin
+    /// It accepts the current subnet multisig address to send some non-dust amount
+    /// to identify the subnet
+    ///
+    /// First output of the transaction includes the signature of the validator
+    /// thus we accept the secret key of the validator
+    ///
+    /// The signature also includes the prev_txid (of the first input) to prevent
+    /// replay attacks. This function first funds the tx
+    pub fn submit_to_bitcoin(
+        &self,
+        rpc: &bitcoincore_rpc::Client,
+        multisig_address: &bitcoin::Address,
+        secret_key: bitcoin::secp256k1::SecretKey,
+    ) -> Result<Txid, IpcLibError> {
         info!(
-            "Submitting unstake collateral msg to bitcoin. Validaor XPK = {} Amount={}",
-            self.pubkey, self.amount
+            "Submitting unstake collateral msg to bitcoin. Multisig address = {} Validator XPK = {:?} Amount={}",
+            multisig_address, self.pubkey, self.amount
         );
 
+        let signature = bitcoin::secp256k1::schnorr::Signature::from_slice(&[0; 64])
+            .expect("All-zero valid signature");
+
         let fee_rate = get_fee_rate(rpc, None, None);
-        let tx = self.to_tx(fee_rate)?;
+        let tx = self.to_tx(fee_rate, multisig_address, signature)?;
 
         // Construct, fund and sign the stake transaction
-        let tx = crate::wallet::fund_tx(rpc, tx, None)?;
-        trace!("Unstake msg funded TX: {tx:?}");
+        let mut tx = crate::wallet::fund_tx(rpc, tx, None)?;
+        trace!("Unstake msg funded TX (empty signature): {tx:?}");
+
+        let first_prev_txid = tx
+            .input
+            .first()
+            .ok_or(IpcLibError::MsgParseError(
+                IPC_UNSTAKE_TAG,
+                "No inputs in the transaction".to_string(),
+            ))?
+            .previous_output
+            .txid;
+
+        // Update the signature with the correct one
+        let signature = self.make_signature(&first_prev_txid, secret_key);
+        let tx_with_signature = self.to_tx(fee_rate, multisig_address, signature)?;
+
+        // Update our funded tx's first output which has the updated signature
+        tx.output[0] = tx_with_signature.output[0].clone();
+
         let tx = crate::wallet::sign_tx(rpc, tx)?;
         trace!("Unstake msg signed TX: {tx:?}");
 
@@ -3042,15 +3202,18 @@ impl IpcUnstakeCollateralMsg {
 
         self.validate_for_subnet(&subnet_state)?;
 
+        // checked before in validate_for_subnet
+        let pubkey = self.pubkey.expect("pubkey should be present");
+
         // we clone and modify the validator
         let mut validator = subnet_state
             .committee
             .validators
             .iter()
-            .find(|v| v.pubkey == self.pubkey)
+            .find(|v| v.pubkey == pubkey)
             .ok_or(IpcValidateError::InvalidMsg(format!(
                 "Validator with public key {} not part of committee",
-                self.pubkey
+                pubkey
             )))?
             .clone();
 
@@ -3078,10 +3241,10 @@ impl IpcUnstakeCollateralMsg {
 
         if new_power == 0 {
             // Remove the validator from the committee if power is zero
-            next_committee.remove_validator(&self.subnet_id, &self.pubkey)?;
+            next_committee.remove_validator(&self.subnet_id, &pubkey)?;
             info!(
                 "Subnet={} Removed validator {} from committee",
-                self.subnet_id, self.pubkey
+                self.subnet_id, pubkey
             );
         } else {
             // Modify the validator in the next committee
@@ -3099,7 +3262,7 @@ impl IpcUnstakeCollateralMsg {
             change: db::StakingChange::Withdraw {
                 amount: self.amount,
             },
-            validator_xpk: self.pubkey,
+            validator_xpk: pubkey,
             validator_subnet_address: validator.subnet_address,
             configuration_number: stake_change_configuration_number,
             committee_after_change: next_committee.clone(),
@@ -3137,7 +3300,7 @@ impl IpcValidate for IpcUnstakeCollateralMsg {
         if self.amount == Amount::ZERO {
             return Err(IpcValidateError::InvalidField(
                 "amount",
-                "Amount amount must be greater than zero".to_string(),
+                "Amount must be greater than zero".to_string(),
             ));
         }
 
@@ -4649,30 +4812,80 @@ mod checkpoint_msg_tests {
 
     #[test]
     fn test_unstake_collateral_from_tx() {
+        use crate::db::SubnetValidators;
         use crate::DEFAULT_BTC_FEE_RATE;
 
         let db = crate::test_utils::create_test_db();
-        use std::str::FromStr;
 
         // Create test data
-        let subnet_id = crate::test_utils::generate_subnet_id();
-        let validator_pubkey = bitcoin::XOnlyPublicKey::from_str(
-            "851c1bda327584479e98a7c28ea7adc097d290efd105310bcf714231bb99faf4",
-        )
-        .unwrap();
+        let mut subnet_state = crate::test_utils::generate_subnet(4);
+        let subnet_id = subnet_state.id;
+
+        let keypairs = crate::test_utils::generate_keypairs(1);
+        let keypair = keypairs.first().expect("should generate");
+        let (xpk, _) = keypair.x_only_public_key();
+
+        let prev_txid = bitcoin::Txid::all_zeros();
+
+        // Update the subnet to use our validator
+        subnet_state
+            .committee
+            .validators
+            .first_mut()
+            .unwrap()
+            .pubkey = xpk;
+
+        subnet_state.committee.multisig_address = subnet_state
+            .committee
+            .validators
+            .multisig_address(&subnet_id);
+
+        {
+            let mut wtxn = db.write_txn().unwrap();
+            db.save_subnet_state(&mut wtxn, subnet_id, &subnet_state)
+                .expect("saves subnet");
+            wtxn.commit().expect("commits transaction");
+        }
+
         let amount = bitcoin::Amount::from_sat(5500000);
 
         // Create the unstake message
         let unstake_msg = IpcUnstakeCollateralMsg {
             subnet_id,
             amount,
-            pubkey: validator_pubkey,
+            pubkey: Some(xpk),
         };
 
+        let msg =
+            IpcUnstakeCollateralMsg::make_signature_msg(&prev_txid, &xpk, &amount, &subnet_id);
+
+        dbg!(&subnet_state.committee);
+        dbg!(prev_txid);
+        dbg!(xpk);
+        dbg!(amount);
+        dbg!(subnet_id);
+        dbg!(msg);
+
+        let signature = unstake_msg.make_signature(&prev_txid, keypair.secret_key());
+
         // Generate a transaction from the message
-        let tx = unstake_msg
-            .to_tx(DEFAULT_BTC_FEE_RATE)
+        let mut tx = unstake_msg
+            .to_tx(
+                DEFAULT_BTC_FEE_RATE,
+                &subnet_state.committee.multisig_address.assume_checked(),
+                signature,
+            )
             .expect("Should create transaction");
+
+        tx.input = vec![bitcoin::TxIn {
+            previous_output: bitcoin::OutPoint {
+                txid: prev_txid,
+                vout: 0,
+            },
+            script_sig: bitcoin::ScriptBuf::new(),
+            sequence: bitcoin::Sequence::MAX,
+            witness: bitcoin::Witness::new(),
+        }];
 
         // Test parsing the transaction back into a message
         let parsed_msg =
@@ -4681,7 +4894,7 @@ mod checkpoint_msg_tests {
         // Verify the parsed message matches the original
         assert_eq!(parsed_msg.subnet_id, subnet_id);
         assert_eq!(parsed_msg.amount, amount);
-        assert_eq!(parsed_msg.pubkey, validator_pubkey);
+        assert_eq!(parsed_msg.pubkey, Some(xpk));
 
         // Print debug info
         println!("Original subnet_id: {}", subnet_id);
@@ -4700,6 +4913,92 @@ mod checkpoint_msg_tests {
 
         assert_eq!(parsed_msg_from_hex.subnet_id, subnet_id);
         assert_eq!(parsed_msg_from_hex.amount, amount);
-        assert_eq!(parsed_msg_from_hex.pubkey, validator_pubkey);
+        assert_eq!(parsed_msg_from_hex.pubkey, Some(xpk));
+    }
+
+    #[test]
+    fn test_unstake_collateral_unknown_signature() {
+        use crate::DEFAULT_BTC_FEE_RATE;
+
+        let db = crate::test_utils::create_test_db();
+
+        // Create test data
+        let subnet_state = crate::test_utils::generate_subnet(4);
+        let subnet_id = subnet_state.id;
+
+        // Intentionaly don't add this validator to the subnet committee
+        let keypairs = crate::test_utils::generate_keypairs(1);
+        let keypair = keypairs.first().expect("should generate");
+        let (xpk, _) = keypair.x_only_public_key();
+
+        let prev_txid = bitcoin::Txid::all_zeros();
+
+        {
+            let mut wtxn = db.write_txn().unwrap();
+            db.save_subnet_state(&mut wtxn, subnet_id, &subnet_state)
+                .expect("saves subnet");
+            wtxn.commit().expect("commits transaction");
+        }
+
+        let amount = bitcoin::Amount::from_sat(5500000);
+
+        // Create the unstake message
+        let unstake_msg = IpcUnstakeCollateralMsg {
+            subnet_id,
+            amount,
+            pubkey: Some(xpk),
+        };
+
+        let msg =
+            IpcUnstakeCollateralMsg::make_signature_msg(&prev_txid, &xpk, &amount, &subnet_id);
+
+        dbg!(&subnet_state.committee);
+        dbg!(prev_txid);
+        dbg!(xpk);
+        dbg!(amount);
+        dbg!(subnet_id);
+        dbg!(msg);
+
+        let signature = unstake_msg.make_signature(&prev_txid, keypair.secret_key());
+
+        // Generate a transaction from the message
+        let mut tx = unstake_msg
+            .to_tx(
+                DEFAULT_BTC_FEE_RATE,
+                &subnet_state.committee.multisig_address.assume_checked(),
+                signature,
+            )
+            .expect("Should create transaction");
+
+        tx.input = vec![bitcoin::TxIn {
+            previous_output: bitcoin::OutPoint {
+                txid: prev_txid,
+                vout: 0,
+            },
+            script_sig: bitcoin::ScriptBuf::new(),
+            sequence: bitcoin::Sequence::MAX,
+            witness: bitcoin::Witness::new(),
+        }];
+
+        // Test parsing the transaction back into a message
+        let parsed_msg = IpcUnstakeCollateralMsg::from_tx(&db, &tx);
+        assert!(parsed_msg.is_err());
+
+        let expected_error_msg = format!(
+            "Signature doesn't match any of the validators in the committee for subnet {}",
+            subnet_id
+        );
+
+        if let Err(IpcLibError::IpcValidateError(crate::ipc_lib::IpcValidateError::InvalidMsg(
+            msg,
+        ))) = parsed_msg
+        {
+            assert_eq!(msg, expected_error_msg);
+        } else {
+            panic!(
+                "Expected IpcValidateError::InvalidMsg but got: {:?}",
+                parsed_msg
+            );
+        }
     }
 }

--- a/src/ipc_lib.rs
+++ b/src/ipc_lib.rs
@@ -1228,15 +1228,15 @@ pub struct IpcCheckpointSubnetMsg {
     pub checkpoint_height: u64,
     /// Committee configuration number
     pub next_committee_configuration_number: u64,
-    /// Unstakes for validators leaving the subnet
-    #[serde(default)]
-    pub unstakes: Vec<IpcUnstake>,
     /// Withdrawals
     #[serde(default)]
     pub withdrawals: Vec<IpcWithdrawal>,
     /// Cross-subnet transfers
     #[serde(default)]
     pub transfers: Vec<IpcCrossSubnetTransfer>,
+    /// Unstakes for validators leaving the subnet
+    #[serde(default, skip_deserializing)]
+    pub unstakes: Vec<IpcUnstake>,
     /// Optional change address (multisig)
     #[serde(skip_deserializing)]
     pub change_address: Option<bitcoin::Address<NetworkUnchecked>>,
@@ -1691,23 +1691,6 @@ impl IpcCheckpointSubnetMsg {
         }
 
         //
-        // Add unstake outputs
-        //
-        for unstake in &self.unstakes {
-            tx_outs.push(bitcoin::TxOut {
-                value: unstake.amount,
-                script_pubkey: unstake
-                    .address
-                    .clone()
-                    // safe to assume it's checked and panic otherwise
-                    // because of the validation beforehand
-                    .require_network(NETWORK)
-                    .expect("Address must be valid for network")
-                    .script_pubkey(),
-            });
-        }
-
-        //
         // Add batched transfer output commit tx, if present
         //
         let has_transfers = !self.transfers.is_empty();
@@ -1753,6 +1736,23 @@ impl IpcCheckpointSubnetMsg {
                         .script_pubkey(),
                 });
             }
+        }
+
+        //
+        // Add unstake outputs
+        //
+        for unstake in &self.unstakes {
+            tx_outs.push(bitcoin::TxOut {
+                value: unstake.amount,
+                script_pubkey: unstake
+                    .address
+                    .clone()
+                    // safe to assume it's checked and panic otherwise
+                    // because of the validation beforehand
+                    .require_network(NETWORK)
+                    .expect("Address must be valid for network")
+                    .script_pubkey(),
+            });
         }
 
         //
@@ -2349,7 +2349,7 @@ impl IpcBatchTransferMsg {
             )))?;
 
         // Extract withdrawal and transfer counts from checkpoint metadata
-        let (_, _, transfer_count) =
+        let (_, transfer_count, _) =
             match IpcCheckpointSubnetMsg::extract_markers_from_metadata_tx_out(metadata_tx_out) {
                 Ok(counts) => counts,
                 Err(e) => {

--- a/src/ipc_lib.rs
+++ b/src/ipc_lib.rs
@@ -2820,9 +2820,13 @@ impl IpcUnstakeCollateralMsg {
     // The total length of the op_return data - helper
     const DATA_LEN: usize = IPC_TAG_LENGTH + SCHNORR_SIGNATURE_SIZE + Amount::SIZE;
 
-    pub fn validate_for_subnet(&self, subnet: &db::SubnetState) -> Result<(), IpcValidateError> {
+    pub fn validate_for_subnet(
+        &self,
+        genesis_info: &db::SubnetGenesisInfo,
+        subnet: &db::SubnetState,
+    ) -> Result<(), IpcValidateError> {
         // should never happen
-        if subnet.id != self.subnet_id {
+        if subnet.id != self.subnet_id || genesis_info.subnet_id != self.subnet_id {
             return Err(IpcValidateError::InvalidField(
                 "subnet_id",
                 format!(
@@ -2839,7 +2843,7 @@ impl IpcUnstakeCollateralMsg {
 
         // Check if the validator with this public key is already registered
         // NOTE: mandatory check here
-        match self.pubkey {
+        let pubkey = match self.pubkey {
             Some(pubkey) => {
                 if !committee.is_validator(&pubkey) {
                     return Err(IpcValidateError::InvalidMsg(format!(
@@ -2847,6 +2851,8 @@ impl IpcUnstakeCollateralMsg {
                         pubkey, self.subnet_id,
                     )));
                 }
+
+                pubkey
             }
             None => {
                 return Err(IpcValidateError::InvalidField(
@@ -2854,7 +2860,7 @@ impl IpcUnstakeCollateralMsg {
                     "Validator public key is required".to_string(),
                 ));
             }
-        }
+        };
 
         // Check if the amount is not more than the current collateral
         if self.amount > subnet.total_collateral() {
@@ -2865,8 +2871,45 @@ impl IpcUnstakeCollateralMsg {
             )));
         }
 
-        // TODO check rest of collateral is not < min
-        // TODO check if validator is leaving?
+        // Check rest of collateral is not less than the minimum required
+        // for a validator to participate in the committee
+        let validator = committee
+            .validators
+            .iter()
+            .find(|v| v.pubkey == pubkey)
+            .ok_or(IpcValidateError::InvalidMsg(format!(
+                "Validator with public key {} not part of committee",
+                pubkey
+            )))?;
+
+        let new_collateral =
+            validator
+                .collateral
+                .checked_sub(self.amount)
+                .ok_or(IpcValidateError::InvalidMsg(format!(
+                    "Amount {} is greater than current validator collateral {}",
+                    self.amount, validator.collateral
+                )))?;
+
+        let (_, sufficient_to_participate) = match multisig::collateral_to_power(
+            &new_collateral,
+            &genesis_info.create_subnet_msg.min_validator_stake,
+        ) {
+            Ok(power) => (power, true),
+            Err(crate::multisig::MultisigError::InsufficientCollateral) => (0, false),
+            Err(_) => {
+                return Err(IpcValidateError::InvalidMsg(
+                    "Collateral too high".to_string(),
+                ))
+            }
+        };
+
+        if !sufficient_to_participate {
+            return Err(IpcValidateError::InvalidMsg(format!(
+				"Validator with public key {} has insufficient collateral to participate in the committee after unstaking {}. Please unstake all.",
+				pubkey, self.amount
+			)));
+        }
 
         // TODO Check diff of the collateral
         // TODO this is a temporary solution, should revisit
@@ -3205,7 +3248,7 @@ impl IpcUnstakeCollateralMsg {
                 IpcValidateError::InvalidMsg(format!("Subnet {} not found.", self.subnet_id))
             })?;
 
-        self.validate_for_subnet(&subnet_state)?;
+        self.validate_for_subnet(&genesis_info, &subnet_state)?;
 
         // checked before in validate_for_subnet
         let pubkey = self.pubkey.expect("pubkey should be present");
@@ -3240,8 +3283,6 @@ impl IpcUnstakeCollateralMsg {
         // The amount user specified to unstake
         // in case the remaining collateral is too low, we will withdraw all
         // of the funds
-        let mut withdraw_amount = self.amount;
-
         let (new_power, sufficient_to_participate) = match multisig::collateral_to_power(
             &new_collateral,
             &genesis_info.create_subnet_msg.min_validator_stake,
@@ -3257,9 +3298,6 @@ impl IpcUnstakeCollateralMsg {
             .unwrap_or_else(|| subnet_state.committee.clone());
 
         if new_power == 0 || !sufficient_to_participate {
-            // If power is insufficient to be in committee,
-            // withdraw all the collateral
-            withdraw_amount = validator.collateral;
             // Remove the validator from the committee if power is zero
             next_committee.remove_validator(&self.subnet_id, &pubkey)?;
             info!(
@@ -3286,7 +3324,7 @@ impl IpcUnstakeCollateralMsg {
         // Create a stake change request to track this change
         let stake_change = db::StakeChangeRequest {
             change: db::StakingChange::Withdraw {
-                amount: withdraw_amount,
+                amount: self.amount,
             },
             validator_xpk: pubkey,
             validator_subnet_address: validator.subnet_address,

--- a/src/ipc_lib.rs
+++ b/src/ipc_lib.rs
@@ -2499,6 +2499,7 @@ impl IpcStakeCollateralMsg {
         }
 
         // Check diff of the collateral
+        // TODO this is a temporary solution, should revisit
         let curr_collateral = subnet.total_collateral();
         let new_collateral = curr_collateral + self.amount;
         let diff = ((new_collateral.to_sat() as f64 - curr_collateral.to_sat() as f64)
@@ -2524,7 +2525,7 @@ impl IpcStakeCollateralMsg {
         // Create the first output: op_return with
         // ipc tag, xonly pubkey of validator
         //
-        let fund_tag: [u8; IPC_TAG_LENGTH] = IPC_STAKE_TAG
+        let tag: [u8; IPC_TAG_LENGTH] = IPC_STAKE_TAG
             .as_bytes()
             .try_into()
             .expect("IPC_STAKE_TAG has incorrect length");
@@ -2533,7 +2534,7 @@ impl IpcStakeCollateralMsg {
         // Construct op_return data
         let mut op_return_data = [0u8; Self::DATA_LEN];
 
-        op_return_data[0..IPC_TAG_LENGTH].copy_from_slice(&fund_tag);
+        op_return_data[0..IPC_TAG_LENGTH].copy_from_slice(&tag);
         op_return_data[IPC_TAG_LENGTH..].copy_from_slice(&pubkey);
 
         // Make op_return script and txout
@@ -2556,10 +2557,10 @@ impl IpcStakeCollateralMsg {
         // Construct transaction
 
         let tx_outs = vec![data_tx_out, stake_tx_out];
-        let fund_tx = bitcoin_utils::create_tx_from_txouts(tx_outs);
-        debug!("Fund TX: {fund_tx:?}");
+        let tx = bitcoin_utils::create_tx_from_txouts(tx_outs);
+        debug!("Stake TX: {tx:?}");
 
-        Ok(fund_tx)
+        Ok(tx)
     }
 
     /// Parses an IpcStakeCollateralMsg from a Bitcoin transaction
@@ -2663,24 +2664,24 @@ impl IpcStakeCollateralMsg {
         );
 
         let fee_rate = get_fee_rate(rpc, None, None);
-        let stake_tx = self.to_tx(fee_rate, multisig_address)?;
+        let tx = self.to_tx(fee_rate, multisig_address)?;
 
         // Construct, fund and sign the stake transaction
-        let stake_tx = crate::wallet::fund_tx(rpc, stake_tx, None)?;
-        trace!("Fund msg funded TX: {stake_tx:?}");
-        let stake_tx = crate::wallet::sign_tx(rpc, stake_tx)?;
-        trace!("Fund msg signed TX: {stake_tx:?}");
+        let tx = crate::wallet::fund_tx(rpc, tx, None)?;
+        trace!("Stake msg funded TX: {tx:?}");
+        let tx = crate::wallet::sign_tx(rpc, tx)?;
+        trace!("Stake msg signed TX: {tx:?}");
 
         // Submit the stake transaction to the mempool
 
-        let stake_txid = stake_tx.compute_txid();
-        match submit_to_mempool(rpc, vec![stake_tx]) {
+        let txid = tx.compute_txid();
+        match submit_to_mempool(rpc, vec![tx]) {
             Ok(_) => {
                 info!(
-                    "Submitted stake collateral msg for subnet_id={} stake_txid={} amount={}",
-                    self.subnet_id, stake_txid, self.amount
+                    "Submitted stake collateral msg for subnet_id={} txid={} amount={}",
+                    self.subnet_id, txid, self.amount
                 );
-                Ok(stake_txid)
+                Ok(txid)
             }
             Err(e) => Err(IpcLibError::BitcoinUtilsError(e)),
         }
@@ -2801,7 +2802,348 @@ impl IpcValidate for IpcStakeCollateralMsg {
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
-pub struct IpcUnstakeCollateralMsg {}
+pub struct IpcUnstakeCollateralMsg {
+    /// The subnet id of the subnet to stake
+    /// This is derived from 2nd output
+    /// that is sent to the subnet multisig address
+    pub subnet_id: SubnetId,
+    /// The amount to remove from the validator stake
+    #[serde(with = "bitcoin::amount::serde::as_sat")]
+    pub amount: bitcoin::Amount,
+    /// The pubkey of the validator
+    pub pubkey: bitcoin::XOnlyPublicKey,
+}
+
+impl IpcUnstakeCollateralMsg {
+    // The total length of the op_return data - helper
+    const DATA_LEN: usize =
+        IPC_TAG_LENGTH + SubnetId::INNER_LEN + Amount::SIZE + SCHNORR_PUBLIC_KEY_SIZE;
+
+    pub fn validate_for_subnet(&self, subnet: &db::SubnetState) -> Result<(), IpcValidateError> {
+        // should never happen
+        if subnet.id != self.subnet_id {
+            return Err(IpcValidateError::InvalidField(
+                "subnet_id",
+                format!(
+                    "Subnet ID mismatch: expected {}, got {}",
+                    subnet.id, self.subnet_id
+                ),
+            ));
+        }
+
+        // Check if the validator with this public key is already registered
+        if !subnet.committee.is_validator(&self.pubkey) {
+            return Err(IpcValidateError::InvalidMsg(format!(
+                "Validator with public key '{}' must already be a validator in subnet {}",
+                self.pubkey, self.subnet_id,
+            )));
+        }
+
+        // Check if the amount is not more than the current collateral
+        if self.amount > subnet.total_collateral() {
+            return Err(IpcValidateError::InvalidMsg(format!(
+                "Unstake amount {} is greater than current collateral {}",
+                self.amount,
+                subnet.total_collateral()
+            )));
+        }
+
+        // TODO check rest of collateral is not < min
+        // TODO check if validator is leaving?
+
+        // TODO Check diff of the collateral
+        // TODO this is a temporary solution, should revisit
+        // let curr_collateral = subnet.total_collateral();
+        // let new_collateral = curr_collateral + self.amount;
+        // let diff = ((new_collateral.to_sat() as f64 - curr_collateral.to_sat() as f64)
+        //     / curr_collateral.to_sat() as f64)
+        //     * 100.0;
+
+        // if diff < Self::MIN_STAKE_DIFF {
+        //     return Err(IpcValidateError::InvalidMsg(format!(
+        //         "Stake addition must change the total collateral by at least {:.2}%. Current change: {:.2}%",
+        //         Self::MIN_STAKE_DIFF, diff
+        //     )));
+        // }
+
+        Ok(())
+    }
+
+    pub fn to_tx(&self, fee_rate: bitcoin::FeeRate) -> Result<Transaction, IpcLibError> {
+        //
+        // Create the output: op_return with
+        // ipc tag, subnet_id, amount, xonly pubkey of validator
+        //
+        let tag: [u8; IPC_TAG_LENGTH] = IPC_UNSTAKE_TAG
+            .as_bytes()
+            .try_into()
+            .expect("IPC_UNSTAKE_TAG has incorrect length");
+        let subnet_id_txid: [u8; SubnetId::INNER_LEN] = self.subnet_id.txid20();
+        let amount = self.amount.to_sat().to_be_bytes();
+        let pubkey: [u8; SCHNORR_PUBLIC_KEY_SIZE] = self.pubkey.serialize();
+
+        // Construct op_return data
+        let mut op_return_data = [0u8; Self::DATA_LEN];
+
+        op_return_data[0..IPC_TAG_LENGTH].copy_from_slice(&tag);
+        op_return_data[IPC_TAG_LENGTH..IPC_TAG_LENGTH + SubnetId::INNER_LEN]
+            .copy_from_slice(&subnet_id_txid);
+        op_return_data[IPC_TAG_LENGTH + SubnetId::INNER_LEN
+            ..IPC_TAG_LENGTH + SubnetId::INNER_LEN + Amount::SIZE]
+            .copy_from_slice(&amount);
+        op_return_data[IPC_TAG_LENGTH + SubnetId::INNER_LEN + Amount::SIZE..]
+            .copy_from_slice(&pubkey);
+
+        // Make op_return script and txout
+        let op_return_script = bitcoin_utils::make_op_return_script(op_return_data);
+        let data_value = op_return_script.minimal_non_dust_custom(fee_rate);
+        let data_tx_out = bitcoin::TxOut {
+            value: data_value,
+            script_pubkey: op_return_script,
+        };
+
+        // Construct transaction
+        let tx_outs = vec![data_tx_out];
+        let tx = bitcoin_utils::create_tx_from_txouts(tx_outs);
+        debug!("Unstake TX: {tx:?}");
+
+        Ok(tx)
+    }
+
+    /// Parses an IpcUnstakeCollateralMsg from a Bitcoin transaction
+    pub fn from_tx<D: db::Database>(_db: &D, tx: &Transaction) -> Result<Self, IpcLibError> {
+        use bitcoin::blockdata::script::Instruction;
+
+        // Helper closure for error creation
+        let err = |msg: String| IpcLibError::MsgParseError(IPC_UNSTAKE_TAG, msg);
+
+        // We expect at least one output:
+        // 1. OP_RETURN with IPC tag, subnet_id, amount and validator pubkey
+        if tx.output.is_empty() {
+            return Err(err(format!(
+                "Expected at least 1 output for unstake collateral message, found {}",
+                tx.output.len()
+            )));
+        }
+
+        // Get OP_RETURN data from first output
+        let op_return_data = tx.output[0]
+            .script_pubkey
+            .instructions_minimal()
+            .find_map(|ins| match ins {
+                Ok(Instruction::PushBytes(data)) => Some(data.as_bytes()),
+                _ => None,
+            })
+            .ok_or_else(|| err("First output must be OP_RETURN with pushdata".into()))?;
+
+        // Check data length
+        if op_return_data.len() != Self::DATA_LEN {
+            return Err(err(format!(
+                "Invalid OP_RETURN data length: expected {}, got {}",
+                Self::DATA_LEN,
+                op_return_data.len()
+            )));
+        }
+
+        // Check IPC tag
+        let tag_bytes = &op_return_data[0..IPC_TAG_LENGTH];
+        let expected_tag = IPC_UNSTAKE_TAG.as_bytes();
+        if tag_bytes != expected_tag {
+            return Err(err(format!(
+                "Invalid IPC tag: expected {:?}, got {:?}",
+                expected_tag, tag_bytes
+            )));
+        }
+
+        // Extract subnet ID
+        let subnet_id_bytes = &op_return_data[IPC_TAG_LENGTH..IPC_TAG_LENGTH + SubnetId::INNER_LEN];
+        let mut txid20 = [0u8; SubnetId::INNER_LEN];
+        txid20.copy_from_slice(subnet_id_bytes);
+        let subnet_id = SubnetId::from_txid20(&txid20);
+
+        // Extract amount
+        let amount_bytes = &op_return_data[IPC_TAG_LENGTH + SubnetId::INNER_LEN
+            ..IPC_TAG_LENGTH + SubnetId::INNER_LEN + Amount::SIZE];
+        let amount_sat = u64::from_be_bytes(
+            amount_bytes
+                .try_into()
+                .map_err(|_| err("Could not parse amount from OP_RETURN data".to_string()))?,
+        );
+        let amount = Amount::from_sat(amount_sat);
+
+        // Extract validator pubkey
+        let pubkey_bytes = &op_return_data[IPC_TAG_LENGTH + SubnetId::INNER_LEN + Amount::SIZE..];
+        let pubkey = XOnlyPublicKey::from_slice(pubkey_bytes)
+            .map_err(|e| err(format!("Invalid validator pubkey: {}", e)))?;
+
+        // Construct the message
+        Ok(Self {
+            subnet_id,
+            amount,
+            pubkey,
+        })
+    }
+
+    pub fn submit_to_bitcoin(&self, rpc: &bitcoincore_rpc::Client) -> Result<Txid, IpcLibError> {
+        info!(
+            "Submitting unstake collateral msg to bitcoin. Validaor XPK = {} Amount={}",
+            self.pubkey, self.amount
+        );
+
+        let fee_rate = get_fee_rate(rpc, None, None);
+        let tx = self.to_tx(fee_rate)?;
+
+        // Construct, fund and sign the stake transaction
+        let tx = crate::wallet::fund_tx(rpc, tx, None)?;
+        trace!("Unstake msg funded TX: {tx:?}");
+        let tx = crate::wallet::sign_tx(rpc, tx)?;
+        trace!("Unstake msg signed TX: {tx:?}");
+
+        // Submit the unstake transaction to the mempool
+
+        let txid = tx.compute_txid();
+        match submit_to_mempool(rpc, vec![tx]) {
+            Ok(_) => {
+                info!(
+                    "Submitted unstake collateral msg for subnet_id={} txid={} amount={}",
+                    self.subnet_id, txid, self.amount
+                );
+                Ok(txid)
+            }
+            Err(e) => Err(IpcLibError::BitcoinUtilsError(e)),
+        }
+    }
+
+    pub fn save_to_db<D: db::Database>(
+        &self,
+        db: &D,
+        block_height: u64,
+        block_hash: bitcoin::BlockHash,
+        txid: Txid,
+    ) -> Result<(), IpcLibError> {
+        let genesis_info =
+            db.get_subnet_genesis_info(self.subnet_id)?
+                .ok_or(IpcValidateError::InvalidMsg(format!(
+                    "subnet id={} does not exist",
+                    self.subnet_id
+                )))?;
+
+        let mut subnet_state = db
+            .get_subnet_state(self.subnet_id)
+            .map_err(|e| {
+                error!("Error getting subnet info from Db: {}", e);
+                IpcValidateError::InvalidMsg(e.to_string())
+            })?
+            // should never happen
+            .ok_or_else(|| {
+                error!("Subnet {} not found, unexpected", self.subnet_id);
+                IpcValidateError::InvalidMsg(format!("Subnet {} not found.", self.subnet_id))
+            })?;
+
+        self.validate_for_subnet(&subnet_state)?;
+
+        // we clone and modify the validator
+        let mut validator = subnet_state
+            .committee
+            .validators
+            .iter()
+            .find(|v| v.pubkey == self.pubkey)
+            .ok_or(IpcValidateError::InvalidMsg(format!(
+                "Validator with public key {} not part of committee",
+                self.pubkey
+            )))?
+            .clone();
+
+        let new_collateral =
+            validator
+                .collateral
+                .checked_sub(self.amount)
+                .ok_or(IpcValidateError::InvalidMsg(format!(
+                    "Amount {} is greater than current collateral {}",
+                    self.amount, validator.collateral
+                )))?;
+
+        let new_power = multisig::collateral_to_power(
+            &new_collateral,
+            &genesis_info.create_subnet_msg.min_validator_stake,
+        )?;
+
+        validator.collateral = new_collateral;
+        validator.power = new_power;
+
+        // Update the next committee or create one if it doesn't exist
+        let mut next_committee = subnet_state
+            .waiting_committee
+            .unwrap_or_else(|| subnet_state.committee.clone());
+
+        if new_power == 0 {
+            // Remove the validator from the committee if power is zero
+            next_committee.remove_validator(&self.subnet_id, &self.pubkey)?;
+            info!(
+                "Subnet={} Removed validator {} from committee",
+                self.subnet_id, self.pubkey
+            );
+        } else {
+            // Modify the validator in the next committee
+            next_committee.modify_validator(&self.subnet_id, &validator)?;
+        }
+
+        // Update the subnet state with the modified next committee
+        subnet_state.waiting_committee = Some(next_committee.clone());
+
+        let stake_change_configuration_number =
+            db.get_next_stake_change_configuration_number(self.subnet_id)?;
+
+        // Create a stake change request to track this change
+        let stake_change = db::StakeChangeRequest {
+            change: db::StakingChange::Withdraw {
+                amount: self.amount,
+            },
+            validator_xpk: self.pubkey,
+            validator_subnet_address: validator.subnet_address,
+            configuration_number: stake_change_configuration_number,
+            committee_after_change: next_committee.clone(),
+            block_height,
+            block_hash,
+            checkpoint_block_height: None,
+            checkpoint_block_hash: None,
+            txid,
+        };
+
+        let mut wtxn = db.write_txn()?;
+
+        // Save the updated subnet state to the database
+        db.save_subnet_state(&mut wtxn, self.subnet_id, &subnet_state)?;
+        // Add the stake change to the database
+        db.add_stake_change(&mut wtxn, self.subnet_id, stake_change)?;
+
+        wtxn.commit()?;
+
+        Ok(())
+    }
+}
+
+impl IpcValidate for IpcUnstakeCollateralMsg {
+    fn validate(&self) -> Result<(), IpcValidateError> {
+        // Check subnet_id is not all zeros
+        if self.subnet_id == SubnetId::default() {
+            return Err(IpcValidateError::InvalidField(
+                "subnet_id",
+                "Subnet ID cannot be all zeros".to_string(),
+            ));
+        }
+
+        // Check collateral is not zero
+        if self.amount == Amount::ZERO {
+            return Err(IpcValidateError::InvalidField(
+                "amount",
+                "Amount amount must be greater than zero".to_string(),
+            ));
+        }
+
+        Ok(())
+    }
+}
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct IpcLeaveSubnetMsg {}
@@ -4303,5 +4645,61 @@ mod checkpoint_msg_tests {
         );
 
         dbg!(&msg);
+    }
+
+    #[test]
+    fn test_unstake_collateral_from_tx() {
+        use crate::DEFAULT_BTC_FEE_RATE;
+
+        let db = crate::test_utils::create_test_db();
+        use std::str::FromStr;
+
+        // Create test data
+        let subnet_id = crate::test_utils::generate_subnet_id();
+        let validator_pubkey = bitcoin::XOnlyPublicKey::from_str(
+            "851c1bda327584479e98a7c28ea7adc097d290efd105310bcf714231bb99faf4",
+        )
+        .unwrap();
+        let amount = bitcoin::Amount::from_sat(5500000);
+
+        // Create the unstake message
+        let unstake_msg = IpcUnstakeCollateralMsg {
+            subnet_id,
+            amount,
+            pubkey: validator_pubkey,
+        };
+
+        // Generate a transaction from the message
+        let tx = unstake_msg
+            .to_tx(DEFAULT_BTC_FEE_RATE)
+            .expect("Should create transaction");
+
+        // Test parsing the transaction back into a message
+        let parsed_msg =
+            IpcUnstakeCollateralMsg::from_tx(&db, &tx).expect("Should parse tx as msg");
+
+        // Verify the parsed message matches the original
+        assert_eq!(parsed_msg.subnet_id, subnet_id);
+        assert_eq!(parsed_msg.amount, amount);
+        assert_eq!(parsed_msg.pubkey, validator_pubkey);
+
+        // Print debug info
+        println!("Original subnet_id: {}", subnet_id);
+        println!("Parsed subnet_id  : {}", parsed_msg.subnet_id);
+
+        // Test with hexadecimal transaction (easier to debug if needed)
+        let serialized_tx = bitcoin::consensus::serialize(&tx);
+        let hex_tx = hex::encode(&serialized_tx);
+        println!("Transaction hex: {}", hex_tx);
+
+        let tx_from_hex: bitcoin::Transaction =
+            bitcoin::consensus::deserialize(&hex::decode(hex_tx).unwrap()).unwrap();
+
+        let parsed_msg_from_hex = IpcUnstakeCollateralMsg::from_tx(&db, &tx_from_hex)
+            .expect("Should parse tx from hex as msg");
+
+        assert_eq!(parsed_msg_from_hex.subnet_id, subnet_id);
+        assert_eq!(parsed_msg_from_hex.amount, amount);
+        assert_eq!(parsed_msg_from_hex.pubkey, validator_pubkey);
     }
 }

--- a/src/ipc_lib.rs
+++ b/src/ipc_lib.rs
@@ -2832,11 +2832,16 @@ impl IpcUnstakeCollateralMsg {
             ));
         }
 
+        let committee = subnet
+            .waiting_committee
+            .clone()
+            .unwrap_or(subnet.committee.clone());
+
         // Check if the validator with this public key is already registered
-        // NOTE: don't remove
+        // NOTE: mandatory check here
         match self.pubkey {
             Some(pubkey) => {
-                if !subnet.committee.is_validator(&pubkey) {
+                if !committee.is_validator(&pubkey) {
                     return Err(IpcValidateError::InvalidMsg(format!(
                         "Validator with public key '{}' must already be a validator in subnet {}",
                         pubkey, self.subnet_id,
@@ -3205,9 +3210,13 @@ impl IpcUnstakeCollateralMsg {
         // checked before in validate_for_subnet
         let pubkey = self.pubkey.expect("pubkey should be present");
 
+        let committee = subnet_state
+            .waiting_committee
+            .clone()
+            .unwrap_or(subnet_state.committee.clone());
+
         // we clone and modify the validator
-        let mut validator = subnet_state
-            .committee
+        let mut validator = committee
             .validators
             .iter()
             .find(|v| v.pubkey == pubkey)
@@ -3226,29 +3235,46 @@ impl IpcUnstakeCollateralMsg {
                     self.amount, validator.collateral
                 )))?;
 
-        let new_power = multisig::collateral_to_power(
+        use crate::multisig::MultisigError;
+
+        // The amount user specified to unstake
+        // in case the remaining collateral is too low, we will withdraw all
+        // of the funds
+        let mut withdraw_amount = self.amount;
+
+        let (new_power, sufficient_to_participate) = match multisig::collateral_to_power(
             &new_collateral,
             &genesis_info.create_subnet_msg.min_validator_stake,
-        )?;
-
-        validator.collateral = new_collateral;
-        validator.power = new_power;
+        ) {
+            Ok(power) => (power, true),
+            Err(MultisigError::InsufficientCollateral) => (0, false),
+            Err(e) => return Err(e.into()),
+        };
 
         // Update the next committee or create one if it doesn't exist
         let mut next_committee = subnet_state
             .waiting_committee
             .unwrap_or_else(|| subnet_state.committee.clone());
 
-        if new_power == 0 {
+        if new_power == 0 || !sufficient_to_participate {
+            // If power is insufficient to be in committee,
+            // withdraw all the collateral
+            withdraw_amount = validator.collateral;
             // Remove the validator from the committee if power is zero
             next_committee.remove_validator(&self.subnet_id, &pubkey)?;
             info!(
-                "Subnet={} Removed validator {} from committee",
-                self.subnet_id, pubkey
+                "Subnet={} Validator XPK {} left the committee by withdrawing {} collateral",
+                self.subnet_id, pubkey, self.amount
             );
         } else {
             // Modify the validator in the next committee
+            validator.collateral = new_collateral;
+            validator.power = new_power;
             next_committee.modify_validator(&self.subnet_id, &validator)?;
+            info!(
+                "Subnet={} Validator XPK {} updated collateral to {}",
+                self.subnet_id, pubkey, self.amount
+            );
         }
 
         // Update the subnet state with the modified next committee
@@ -3260,7 +3286,7 @@ impl IpcUnstakeCollateralMsg {
         // Create a stake change request to track this change
         let stake_change = db::StakeChangeRequest {
             change: db::StakingChange::Withdraw {
-                amount: self.amount,
+                amount: withdraw_amount,
             },
             validator_xpk: pubkey,
             validator_subnet_address: validator.subnet_address,

--- a/src/ipc_lib.rs
+++ b/src/ipc_lib.rs
@@ -4158,6 +4158,7 @@ mod checkpoint_msg_tests {
     use std::str::FromStr;
 
     #[test]
+    #[test_retry::retry(3)]
     fn test_checkpoint_with_unstakes() {
         // Set up test database
         let db = create_test_db();
@@ -4983,6 +4984,112 @@ mod checkpoint_msg_tests {
         // Test parsing the transaction back into a message
         let parsed_msg = IpcUnstakeCollateralMsg::from_tx(&db, &tx);
         assert!(parsed_msg.is_err());
+
+        let expected_error_msg = format!(
+            "Signature doesn't match any of the validators in the committee for subnet {}",
+            subnet_id
+        );
+
+        if let Err(IpcLibError::IpcValidateError(crate::ipc_lib::IpcValidateError::InvalidMsg(
+            msg,
+        ))) = parsed_msg
+        {
+            assert_eq!(msg, expected_error_msg);
+        } else {
+            panic!(
+                "Expected IpcValidateError::InvalidMsg but got: {:?}",
+                parsed_msg
+            );
+        }
+    }
+
+    #[test]
+    fn test_unstake_collateral_replay_attack() {
+        use crate::db::SubnetValidators;
+        use crate::DEFAULT_BTC_FEE_RATE;
+
+        let db = crate::test_utils::create_test_db();
+
+        // Create test data
+        let mut subnet_state = crate::test_utils::generate_subnet(4);
+        let subnet_id = subnet_state.id;
+
+        let keypairs = crate::test_utils::generate_keypairs(1);
+        let keypair = keypairs.first().expect("should generate");
+        let (xpk, _) = keypair.x_only_public_key();
+
+        let prev_txid = bitcoin::Txid::all_zeros();
+
+        // Update the subnet to use our validator
+        subnet_state
+            .committee
+            .validators
+            .first_mut()
+            .unwrap()
+            .pubkey = xpk;
+
+        subnet_state.committee.multisig_address = subnet_state
+            .committee
+            .validators
+            .multisig_address(&subnet_id);
+
+        {
+            let mut wtxn = db.write_txn().unwrap();
+            db.save_subnet_state(&mut wtxn, subnet_id, &subnet_state)
+                .expect("saves subnet");
+            wtxn.commit().expect("commits transaction");
+        }
+
+        let amount = bitcoin::Amount::from_sat(5500000);
+
+        // Create the unstake message
+        let unstake_msg = IpcUnstakeCollateralMsg {
+            subnet_id,
+            amount,
+            pubkey: Some(xpk),
+        };
+
+        let msg =
+            IpcUnstakeCollateralMsg::make_signature_msg(&prev_txid, &xpk, &amount, &subnet_id);
+
+        dbg!(&subnet_state.committee);
+        dbg!(prev_txid);
+        dbg!(xpk);
+        dbg!(amount);
+        dbg!(subnet_id);
+        dbg!(msg);
+
+        let signature = unstake_msg.make_signature(&prev_txid, keypair.secret_key());
+
+        // Generate a transaction from the message
+        let mut tx = unstake_msg
+            .to_tx(
+                DEFAULT_BTC_FEE_RATE,
+                &subnet_state.committee.multisig_address.assume_checked(),
+                signature,
+            )
+            .expect("Should create transaction");
+
+        tx.input = vec![bitcoin::TxIn {
+            previous_output: bitcoin::OutPoint {
+                // Intentionally set to a different txid to simulate a replay attack
+                txid: Txid::from_str(
+                    "5e66f5f4e961aa5aa35d226c100e1931d5f4ee99e149a3a9549edad279f77236",
+                )
+                .expect("valid txid"),
+                vout: 0,
+            },
+            script_sig: bitcoin::ScriptBuf::new(),
+            sequence: bitcoin::Sequence::MAX,
+            witness: bitcoin::Witness::new(),
+        }];
+
+        // Test parsing the transaction back into a message
+        let parsed_msg = IpcUnstakeCollateralMsg::from_tx(&db, &tx);
+        assert!(parsed_msg.is_err());
+
+        // Even though our validator is in the committee, the prev_txid is different
+        // it will not match the signature
 
         let expected_error_msg = format!(
             "Signature doesn't match any of the validators in the committee for subnet {}",

--- a/src/ipc_lib.rs
+++ b/src/ipc_lib.rs
@@ -1,5 +1,6 @@
 use bitcoin::address::NetworkUnchecked;
 use bitcoin::hashes::Hash;
+use bitcoin::key::constants::SCHNORR_PUBLIC_KEY_SIZE;
 use bitcoin::Amount;
 use bitcoin::Transaction;
 use bitcoin::Txid;
@@ -49,6 +50,9 @@ pub const IPC_FUND_SUBNET_TAG: &str = "IPCFND";
 pub const IPC_CHECKPOINT_TAG: &str = "IPCCPT";
 pub const IPC_TRANSFER_TAG: &str = "IPCTFR";
 pub const IPC_DELETE_SUBNET_TAG: &str = "IPCDEL";
+pub const IPC_STAKE_TAG: &str = "IPCSTK";
+pub const IPC_UNSTAKE_TAG: &str = "IPCUST";
+pub const IPC_LEAVE_SUBNET_TAG: &str = "IPCLVE";
 
 // Static assertion to verify tag lengths at compile time
 const _: () = {
@@ -59,6 +63,9 @@ const _: () = {
     assert!(IPC_CHECKPOINT_TAG.len() == IPC_TAG_LENGTH);
     assert!(IPC_TRANSFER_TAG.len() == IPC_TAG_LENGTH);
     assert!(IPC_DELETE_SUBNET_TAG.len() == IPC_TAG_LENGTH);
+    assert!(IPC_STAKE_TAG.len() == IPC_TAG_LENGTH);
+    assert!(IPC_UNSTAKE_TAG.len() == IPC_TAG_LENGTH);
+    assert!(IPC_LEAVE_SUBNET_TAG.len() == IPC_TAG_LENGTH);
 };
 
 // Define the IPC tags enum
@@ -70,6 +77,9 @@ pub enum IpcTag {
     FundSubnet,
     CheckpointSubnet,
     BatchTransfer,
+    StakeCollateral,
+    UnstakeCollateral,
+    LeaveSubnet,
 }
 
 impl IpcTag {
@@ -81,6 +91,9 @@ impl IpcTag {
             Self::FundSubnet => IPC_FUND_SUBNET_TAG,
             Self::CheckpointSubnet => IPC_CHECKPOINT_TAG,
             Self::BatchTransfer => IPC_TRANSFER_TAG,
+            Self::StakeCollateral => IPC_STAKE_TAG,
+            Self::UnstakeCollateral => IPC_UNSTAKE_TAG,
+            Self::LeaveSubnet => IPC_LEAVE_SUBNET_TAG,
         }
     }
 }
@@ -539,11 +552,11 @@ impl IpcJoinSubnetMsg {
                 .into());
             }
 
-            let mut next_commitee = subnet
+            let mut next_committee = subnet
                 .waiting_committee
                 .unwrap_or_else(|| subnet.committee.clone());
 
-            if next_commitee.is_validator(&self.pubkey) {
+            if next_committee.is_validator(&self.pubkey) {
                 return Err(IpcValidateError::InvalidField(
                     "pubkey",
                     format!(
@@ -554,8 +567,8 @@ impl IpcJoinSubnetMsg {
                 .into());
             }
 
-            next_commitee.join_validator(&subnet.id, &new_validator)?;
-            subnet.waiting_committee = Some(next_commitee.clone());
+            next_committee.join_new_validator(&subnet.id, &new_validator)?;
+            subnet.waiting_committee = Some(next_committee.clone());
 
             let stake_change_configuration_number =
                 db.get_next_stake_change_configuration_number(self.subnet_id)?;
@@ -570,7 +583,7 @@ impl IpcJoinSubnetMsg {
                 validator_xpk: self.pubkey,
                 validator_subnet_address,
                 configuration_number: stake_change_configuration_number,
-                committee_after_change: next_commitee.clone(),
+                committee_after_change: next_committee.clone(),
 
                 block_height,
                 block_hash,
@@ -586,7 +599,7 @@ impl IpcJoinSubnetMsg {
                 validator_xpk: self.pubkey,
                 validator_subnet_address,
                 configuration_number: stake_change_configuration_number + 1,
-                committee_after_change: next_commitee.clone(),
+                committee_after_change: next_committee.clone(),
 
                 block_height,
                 block_hash,
@@ -2335,6 +2348,353 @@ impl IpcBatchTransferMsg {
     }
 }
 
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct IpcStakeCollateralMsg {
+    /// The subnet id of the subnet to stake
+    /// This is derived from 2nd output
+    /// that is sent to the subnet multisig address
+    pub subnet_id: SubnetId,
+    /// The amount to add to the validator stake
+    #[serde(with = "bitcoin::amount::serde::as_sat")]
+    pub amount: bitcoin::Amount,
+    /// The pubkey of the validator
+    pub pubkey: bitcoin::XOnlyPublicKey,
+}
+
+impl IpcStakeCollateralMsg {
+    const MIN_STAKE_DIFF: f64 = 5.0;
+
+    // The total length of the op_return data - helper
+    const DATA_LEN: usize = IPC_TAG_LENGTH + SCHNORR_PUBLIC_KEY_SIZE;
+
+    pub fn validate_for_subnet(&self, subnet: &db::SubnetState) -> Result<(), IpcValidateError> {
+        // should never happen
+        if subnet.id != self.subnet_id {
+            return Err(IpcValidateError::InvalidField(
+                "subnet_id",
+                format!(
+                    "Subnet ID mismatch: expected {}, got {}",
+                    subnet.id, self.subnet_id
+                ),
+            ));
+        }
+
+        // Check if the validator with this public key is already registered
+        if !subnet.committee.is_validator(&self.pubkey) {
+            return Err(IpcValidateError::InvalidMsg(format!(
+                "Validator with public key '{}' must already be a validator in subnet {}",
+                self.pubkey, self.subnet_id,
+            )));
+        }
+
+        // Check diff of the collateral
+        let curr_collateral = subnet.total_collateral();
+        let new_collateral = curr_collateral + self.amount;
+        let diff = ((new_collateral.to_sat() as f64 - curr_collateral.to_sat() as f64)
+            / curr_collateral.to_sat() as f64)
+            * 100.0;
+
+        if diff < Self::MIN_STAKE_DIFF {
+            return Err(IpcValidateError::InvalidMsg(format!(
+                "Stake addition must change the total collateral by at least {:.2}%. Current change: {:.2}%",
+                Self::MIN_STAKE_DIFF, diff
+            )));
+        }
+
+        Ok(())
+    }
+
+    pub fn to_tx(
+        &self,
+        fee_rate: bitcoin::FeeRate,
+        multisig_address: &bitcoin::Address,
+    ) -> Result<Transaction, IpcLibError> {
+        //
+        // Create the first output: op_return with
+        // ipc tag, xonly pubkey of validator
+        //
+        let fund_tag: [u8; IPC_TAG_LENGTH] = IPC_STAKE_TAG
+            .as_bytes()
+            .try_into()
+            .expect("IPC_STAKE_TAG has incorrect length");
+        let pubkey: [u8; SCHNORR_PUBLIC_KEY_SIZE] = self.pubkey.serialize();
+
+        // Construct op_return data
+        let mut op_return_data = [0u8; Self::DATA_LEN];
+
+        op_return_data[0..IPC_TAG_LENGTH].copy_from_slice(&fund_tag);
+        op_return_data[IPC_TAG_LENGTH..].copy_from_slice(&pubkey);
+
+        // Make op_return script and txout
+        let op_return_script = bitcoin_utils::make_op_return_script(op_return_data);
+        let data_value = op_return_script.minimal_non_dust_custom(fee_rate);
+        let data_tx_out = bitcoin::TxOut {
+            value: data_value,
+            script_pubkey: op_return_script,
+        };
+
+        //
+        // Create second output: pre-fund + pre-release script
+        //
+
+        let stake_tx_out = bitcoin::TxOut {
+            value: self.amount,
+            script_pubkey: multisig_address.script_pubkey(),
+        };
+
+        // Construct transaction
+
+        let tx_outs = vec![data_tx_out, stake_tx_out];
+        let fund_tx = bitcoin_utils::create_tx_from_txouts(tx_outs);
+        debug!("Fund TX: {fund_tx:?}");
+
+        Ok(fund_tx)
+    }
+
+    /// Parses an IpcStakeCollateralMsg from a Bitcoin transaction
+    pub fn from_tx<D: db::Database>(db: &D, tx: &Transaction) -> Result<Self, IpcLibError> {
+        use bitcoin::blockdata::script::Instruction;
+
+        // Helper closure for error creation
+        let err = |msg: String| IpcLibError::MsgParseError(IPC_STAKE_TAG, msg);
+
+        // We expect minimum two outputs:
+        // 1. OP_RETURN with IPC tag and validator pubkey
+        // 2. Amount sent to the multisig address
+        if tx.output.len() < 2 {
+            return Err(err(format!(
+                "Expected at least 2 outputs for stake collateral message, found {}",
+                tx.output.len()
+            )));
+        }
+
+        // Get OP_RETURN data from first output
+        let op_return_data = tx.output[0]
+            .script_pubkey
+            .instructions_minimal()
+            .find_map(|ins| match ins {
+                Ok(Instruction::PushBytes(data)) => Some(data.as_bytes()),
+                _ => None,
+            })
+            .ok_or_else(|| err("First output must be OP_RETURN with pushdata".into()))?;
+
+        // Check data length
+        if op_return_data.len() != Self::DATA_LEN {
+            return Err(err(format!(
+                "Invalid OP_RETURN data length: expected {}, got {}",
+                Self::DATA_LEN,
+                op_return_data.len()
+            )));
+        }
+
+        // Check IPC tag
+        let tag_bytes = &op_return_data[0..IPC_TAG_LENGTH];
+        let expected_tag = IPC_STAKE_TAG.as_bytes();
+        if tag_bytes != expected_tag {
+            return Err(err(format!(
+                "Invalid IPC tag: expected {:?}, got {:?}",
+                expected_tag, tag_bytes
+            )));
+        }
+
+        // Extract validator pubkey
+        let pubkey_bytes = &op_return_data[IPC_TAG_LENGTH..];
+        let pubkey = XOnlyPublicKey::from_slice(pubkey_bytes)
+            .map_err(|e| err(format!("Invalid validator pubkey: {}", e)))?;
+
+        // Extract stake amount from the second output
+        let amount = tx.output[1].value;
+
+        let multisig_address = bitcoin::Address::from_script(&tx.output[1].script_pubkey, NETWORK)
+            .map_err(|_| err("Could not parse address from output 1".to_string()))?
+            .into_unchecked();
+
+        let subnet_id = match db.get_subnet_by_multisig_address(&multisig_address) {
+            Ok(Some(subnet)) => subnet.id,
+            Ok(None) => {
+                error!(
+                    "StakeCollateralMsg: Could not find subnet with multisig address {:?}.",
+                    multisig_address
+                );
+                return Err(err(format!(
+                    "StakeCollateralMsg: Could not find subnet with multisig address {:?}",
+                    multisig_address
+                )));
+            }
+            Err(e) => {
+                error!(
+	                "StakeCollateralMsg: Error while looking up subnet with multisig address {:?}: {}",
+	                multisig_address, e
+	            );
+                return Err(err(format!(
+                    "StakeCollateralMsg: Error while looking up subnet with multisig address {:?}: {}",
+                    multisig_address, e
+                )));
+            }
+        };
+
+        // Construct the message
+        Ok(Self {
+            subnet_id,
+            amount,
+            pubkey,
+        })
+    }
+
+    pub fn submit_to_bitcoin(
+        &self,
+        rpc: &bitcoincore_rpc::Client,
+        multisig_address: &bitcoin::Address,
+    ) -> Result<Txid, IpcLibError> {
+        info!(
+            "Submitting stake collateral msg to bitcoin. Multisig address = {}. Amount={}",
+            multisig_address, self.amount
+        );
+
+        let fee_rate = get_fee_rate(rpc, None, None);
+        let stake_tx = self.to_tx(fee_rate, multisig_address)?;
+
+        // Construct, fund and sign the stake transaction
+        let stake_tx = crate::wallet::fund_tx(rpc, stake_tx, None)?;
+        trace!("Fund msg funded TX: {stake_tx:?}");
+        let stake_tx = crate::wallet::sign_tx(rpc, stake_tx)?;
+        trace!("Fund msg signed TX: {stake_tx:?}");
+
+        // Submit the stake transaction to the mempool
+
+        let stake_txid = stake_tx.compute_txid();
+        match submit_to_mempool(rpc, vec![stake_tx]) {
+            Ok(_) => {
+                info!(
+                    "Submitted stake collateral msg for subnet_id={} stake_txid={} amount={}",
+                    self.subnet_id, stake_txid, self.amount
+                );
+                Ok(stake_txid)
+            }
+            Err(e) => Err(IpcLibError::BitcoinUtilsError(e)),
+        }
+    }
+
+    pub fn save_to_db<D: db::Database>(
+        &self,
+        db: &D,
+        block_height: u64,
+        block_hash: bitcoin::BlockHash,
+        txid: Txid,
+    ) -> Result<(), IpcLibError> {
+        let genesis_info =
+            db.get_subnet_genesis_info(self.subnet_id)?
+                .ok_or(IpcValidateError::InvalidMsg(format!(
+                    "subnet id={} does not exist",
+                    self.subnet_id
+                )))?;
+
+        let mut subnet_state = db
+            .get_subnet_state(self.subnet_id)
+            .map_err(|e| {
+                error!("Error getting subnet info from Db: {}", e);
+                IpcValidateError::InvalidMsg(e.to_string())
+            })?
+            // should never happen
+            .ok_or_else(|| {
+                error!("Subnet {} not found, unexpected", self.subnet_id);
+                IpcValidateError::InvalidMsg(format!("Subnet {} not found.", self.subnet_id))
+            })?;
+
+        self.validate_for_subnet(&subnet_state)?;
+
+        // we clone and modify the validator
+        let mut validator = subnet_state
+            .committee
+            .validators
+            .iter()
+            .find(|v| v.pubkey == self.pubkey)
+            .ok_or(IpcValidateError::InvalidMsg(format!(
+                "Validator with public key {} not part of committee",
+                self.pubkey
+            )))?
+            .clone();
+
+        let new_collateral = self.amount + validator.collateral;
+        let new_power = multisig::collateral_to_power(
+            &new_collateral,
+            &genesis_info.create_subnet_msg.min_validator_stake,
+        )?;
+
+        validator.collateral = new_collateral;
+        validator.power = new_power;
+
+        // Update the next committee or create one if it doesn't exist
+        let mut next_committee = subnet_state
+            .waiting_committee
+            .unwrap_or_else(|| subnet_state.committee.clone());
+
+        // Modify the validator in the next committee
+        next_committee.modify_validator(&self.subnet_id, &validator)?;
+
+        // Update the subnet state with the modified next committee
+        subnet_state.waiting_committee = Some(next_committee.clone());
+
+        let stake_change_configuration_number =
+            db.get_next_stake_change_configuration_number(self.subnet_id)?;
+
+        // Create a stake change request to track this change
+        let stake_change = db::StakeChangeRequest {
+            change: db::StakingChange::Deposit {
+                amount: self.amount,
+            },
+            validator_xpk: self.pubkey,
+            validator_subnet_address: validator.subnet_address,
+            configuration_number: stake_change_configuration_number,
+            committee_after_change: next_committee.clone(),
+            block_height,
+            block_hash,
+            checkpoint_block_height: None,
+            checkpoint_block_hash: None,
+            txid,
+        };
+
+        let mut wtxn = db.write_txn()?;
+
+        // Save the updated subnet state to the database
+        db.save_subnet_state(&mut wtxn, self.subnet_id, &subnet_state)?;
+        // Add the stake change to the database
+        db.add_stake_change(&mut wtxn, self.subnet_id, stake_change)?;
+
+        wtxn.commit()?;
+
+        Ok(())
+    }
+}
+
+impl IpcValidate for IpcStakeCollateralMsg {
+    fn validate(&self) -> Result<(), IpcValidateError> {
+        // Check subnet_id is not all zeros
+        if self.subnet_id == SubnetId::default() {
+            return Err(IpcValidateError::InvalidField(
+                "subnet_id",
+                "Subnet ID cannot be all zeros".to_string(),
+            ));
+        }
+
+        // Check collateral is not zero
+        if self.amount == Amount::ZERO {
+            return Err(IpcValidateError::InvalidField(
+                "amount",
+                "Amount amount must be greater than zero".to_string(),
+            ));
+        }
+
+        Ok(())
+    }
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct IpcUnstakeCollateralMsg {}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct IpcLeaveSubnetMsg {}
+
 //
 // IPC Messages
 //
@@ -2348,6 +2708,9 @@ pub enum IpcMessage {
     FundSubnet(IpcFundSubnetMsg),
     CheckpointSubnet(IpcCheckpointSubnetMsg),
     BatchTransfer(IpcBatchTransferMsg),
+    StakeCollateral(IpcStakeCollateralMsg),
+    UnstakeCollateral(IpcUnstakeCollateralMsg),
+    LeaveSubnet(IpcLeaveSubnetMsg),
 }
 
 impl IpcMessage {
@@ -2389,6 +2752,13 @@ impl IpcMessage {
                 Err(IpcSerializeError::DeserializationError("Skip".to_string()))
             }
             IpcTag::FundSubnet => Err(IpcSerializeError::DeserializationError("Skip".to_string())),
+            IpcTag::StakeCollateral => {
+                Err(IpcSerializeError::DeserializationError("Skip".to_string()))
+            }
+            IpcTag::UnstakeCollateral => {
+                Err(IpcSerializeError::DeserializationError("Skip".to_string()))
+            }
+            IpcTag::LeaveSubnet => Err(IpcSerializeError::DeserializationError("Skip".to_string())),
         }
     }
 }
@@ -2624,6 +2994,7 @@ mod tests {
     };
     use crate::L1_NAME;
     use bitcoin::hex::DisplayHex;
+    use bitcoin::{Amount, XOnlyPublicKey};
     use fvm_shared::address::{set_current_network, Network as FvmNetwork};
 
     fn set_test_fvm_network() {
@@ -3163,7 +3534,7 @@ mod prefund_msg_tests {
 #[cfg(test)]
 mod checkpoint_msg_tests {
     use super::*;
-    use crate::{test_utils, DEFAULT_BTC_FEE_RATE};
+    use crate::{db::Database, test_utils, DEFAULT_BTC_FEE_RATE};
     use std::str::FromStr;
 
     fn create_test_checkpoint_msg() -> IpcCheckpointSubnetMsg {
@@ -3679,5 +4050,51 @@ mod checkpoint_msg_tests {
             batch_tx.is_some(),
             "Should have a batch transfer transaction"
         );
+    }
+
+    #[test]
+    fn test_stake_collateral_from_tx() {
+        let db = crate::db::tests::create_test_db();
+        let subnet_id = crate::test_utils::generate_subnet_id();
+        let subnet_state = crate::db::SubnetState {
+            id: subnet_id,
+            committee_number: 1,
+            committee: crate::db::SubnetCommittee {
+                configuration_number: 0,
+                threshold: 1,
+                validators: vec![],
+                multisig_address: bitcoin::Address::from_str(
+                    "bcrt1p2wqu7w8n8mnw37sl40u6y9tlpyy9hy6d2k4wt6r8ut7897ejl8fsgdhxzg",
+                )
+                .unwrap(),
+            },
+            waiting_committee: None,
+            last_checkpoint_number: None,
+        };
+
+        {
+            let mut wtxn = db.write_txn().unwrap();
+            db.save_subnet_state(&mut wtxn, subnet_id, &subnet_state)
+                .expect("saves subnet");
+            wtxn.commit().expect("commits transaction");
+        }
+
+        let txbytes = hex::decode("020000000001019c40ba653f54403e8bfda357ccd6fff74746dea98d22316cd194544c27fe81ac0000000000fdffffff030000000000000000286a2649504353544b851c1bda327584479e98a7c28ea7adc097d290efd105310bcf714231bb99faf460ec5300000000002251205381cf38f33ee6e8fa1fabf9a2157f09085b934d55aae5e867e2fc72fb32f9d31e03b229010000002251209acb5b5b3729a8f9ca2c2df76a6e600974f858352dbbca140e7e7d732e9da145024730440220316c97ebc27947c85e5ddec43d35075dc029b244188161265c4f540ceabd40d302200a7940cb366e46f1ba744ea84f1c34b6ade3fd3425f424099f19289fb64321ff012103fe6bbd509c039530b43c6c93524ec4d3df82da5de278096c095694166ccb828200000000").expect("Failed to parse transaction hex");
+
+        let tx: bitcoin::Transaction =
+            bitcoin::consensus::deserialize(&txbytes).expect("Failed to deserialize transaction");
+
+        let msg = IpcStakeCollateralMsg::from_tx(&db, &tx).expect("Should parse tx as msg");
+
+        assert_eq!(msg.amount, Amount::from_sat(5500000));
+        assert_eq!(
+            msg.pubkey,
+            XOnlyPublicKey::from_str(
+                "851c1bda327584479e98a7c28ea7adc097d290efd105310bcf714231bb99faf4"
+            )
+            .unwrap()
+        );
+
+        dbg!(&msg);
     }
 }

--- a/src/multisig.rs
+++ b/src/multisig.rs
@@ -1780,7 +1780,7 @@ mod psbt_tests {
             &secp,
             &subnet_id,
             &committee_pubkeys,
-            required_sigs.try_into().unwrap(),
+            required_sigs.into(),
             &psbt_signed_twice,
         )
         .expect("Failed to finalize PSBT");
@@ -1823,7 +1823,7 @@ mod psbt_tests {
             &secp,
             &subnet_id,
             &committee_pubkeys,
-            threshold.into(),
+            threshold,
             NETWORK,
         )
         .unwrap();

--- a/src/multisig.rs
+++ b/src/multisig.rs
@@ -150,6 +150,9 @@ pub fn collateral_to_power(amount: &Amount, min_amount: &Amount) -> Result<Power
 /// Calculates the size in bytes of witness elements for spending a multisig utxo
 /// Calculates the "worst case" size, assuming all public keys' signatures are included
 /// Useful for fee calculations.
+//
+// NOTE: this is quite sensitive as it's not easy to change if the multisig script is changed
+// maybe consider using a real transaction to calculate the size at compile time?
 pub fn multisig_spend_max_witness_size(public_keys: &[WeightedKey], threshold: Power) -> usize {
     let committee_size = public_keys.len();
 
@@ -322,6 +325,9 @@ pub fn construct_spend_unsigned_transaction(
                 witness: Witness::new(),
             })
             .collect::<Vec<TxIn>>();
+
+        // TODO filter out inputs which are not profitable to transfer
+        // ie. small inputs
 
         // Start with the transaction containing all inputs and specified outputs
         let mut spend_tx = Transaction {

--- a/src/provider/rpc.rs
+++ b/src/provider/rpc.rs
@@ -1084,6 +1084,18 @@ pub async fn unstake_collateral(
         return Err(RpcError::InvalidParams(err.to_string()).into());
     }
 
+    let genesis_info = data
+        .db
+        .get_subnet_genesis_info(msg.subnet_id)
+        .map_err(|e| {
+            error!("Error getting subnet info from Db: {}", e);
+            RpcError::DbError(e)
+        })?
+        .ok_or(RpcError::InvalidParams(format!(
+            "Subnet {} not found.",
+            msg.subnet_id
+        )))?;
+
     let subnet_state = data
         .db
         .get_subnet_state(msg.subnet_id)
@@ -1096,13 +1108,14 @@ pub async fn unstake_collateral(
             msg.subnet_id
         )))?;
 
-    msg.validate_for_subnet(&subnet_state).map_err(|e| {
-        error!(
-            "Error validating unstake collateral msg for subnet info: {}",
-            e
-        );
-        RpcError::InvalidParams(e.to_string())
-    })?;
+    msg.validate_for_subnet(&genesis_info, &subnet_state)
+        .map_err(|e| {
+            error!(
+                "Error validating unstake collateral msg for subnet info: {}",
+                e
+            );
+            RpcError::InvalidParams(e.to_string())
+        })?;
 
     let multisig_address = subnet_state.multisig_address();
 

--- a/src/provider/rpc.rs
+++ b/src/provider/rpc.rs
@@ -3,7 +3,7 @@ use crate::{
     db::{self, Database},
     ipc_lib::{
         IpcCheckpointSubnetMsg, IpcCreateSubnetMsg, IpcFundSubnetMsg, IpcJoinSubnetMsg,
-        IpcPrefundSubnetMsg, IpcStakeCollateralMsg, IpcValidate, SubnetId,
+        IpcPrefundSubnetMsg, IpcStakeCollateralMsg, IpcUnstakeCollateralMsg, IpcValidate, SubnetId,
     },
     multisig, NETWORK,
 };
@@ -1005,6 +1005,54 @@ pub async fn stake_collateral(
     Ok(StakeCollateralResponse { txid })
 }
 
+// Stake collateral
+
+#[derive(Serialize, Deserialize)]
+pub struct UnstakeCollateralResponse {
+    txid: bitcoin::Txid,
+}
+
+pub async fn unstake_collateral(
+    data: Data<Arc<ServerData>>,
+    Params(msg): Params<IpcUnstakeCollateralMsg>,
+) -> Result<UnstakeCollateralResponse, JsonRpcError> {
+    info!(
+        "unstakecollateral: {} {} {}",
+        msg.subnet_id, msg.pubkey, msg.amount
+    );
+
+    if let Err(err) = msg.validate() {
+        error!("Invalid unstake collateral message={msg:?}: {err}");
+        return Err(RpcError::InvalidParams(err.to_string()).into());
+    }
+
+    let subnet_state = data
+        .db
+        .get_subnet_state(msg.subnet_id)
+        .map_err(|e| {
+            error!("Error getting subnet info from Db: {}", e);
+            RpcError::DbError(e)
+        })?
+        .ok_or(RpcError::InvalidParams(format!(
+            "Subnet {} not found.",
+            msg.subnet_id
+        )))?;
+
+    msg.validate_for_subnet(&subnet_state).map_err(|e| {
+        error!(
+            "Error validating unstake collateral msg for subnet info: {}",
+            e
+        );
+        RpcError::InvalidParams(e.to_string())
+    })?;
+
+    let txid = msg
+        .submit_to_bitcoin(&data.btc_rpc)
+        .map_err(|e| JsonRpcError::internal(e.to_string()))?;
+
+    Ok(UnstakeCollateralResponse { txid })
+}
+
 // Stake changes
 
 #[derive(Serialize, Deserialize)]
@@ -1067,6 +1115,7 @@ pub fn make_rpc_server(server_data: Arc<ServerData>) -> RpcServer {
         .with_method("getsubnetcheckpoint", get_subnet_checkpoint)
         // stake changes
         .with_method("stakecollateral", stake_collateral)
+        .with_method("unstakecollateral", unstake_collateral)
         .with_method("getstakechanges", get_stake_changes)
         .finish()
 }

--- a/src/provider/rpc.rs
+++ b/src/provider/rpc.rs
@@ -1,8 +1,8 @@
 use crate::{
     bitcoin_utils,
-    db::{self, Database},
+    db::{self, Database, StakingChange},
     ipc_lib::{
-        IpcCheckpointSubnetMsg, IpcCreateSubnetMsg, IpcFundSubnetMsg, IpcJoinSubnetMsg,
+        self, IpcCheckpointSubnetMsg, IpcCreateSubnetMsg, IpcFundSubnetMsg, IpcJoinSubnetMsg,
         IpcPrefundSubnetMsg, IpcStakeCollateralMsg, IpcUnstakeCollateralMsg, IpcValidate, SubnetId,
     },
     multisig, NETWORK,
@@ -568,6 +568,12 @@ pub async fn gen_checkpoint_psbt(
         );
     }
 
+    if !msg.unstakes.len().is_zero() {
+        return Err(
+            RpcError::InvalidParams("Specifying unstakes not supported".to_string()).into(),
+        );
+    }
+
     // Check subnet exists
     let subnet = data
         .db
@@ -608,8 +614,9 @@ pub async fn gen_checkpoint_psbt(
     // assume no change in the committee
     let mut next_committee = subnet.committee.clone();
     let current_committee_configuration = subnet.committee.configuration_number;
+    // let mut unstakes = vec![];
 
-    // update next_committee if the configuration number changed
+    // update next_committee and process unstakes if the configuration number changed
     if msg.next_committee_configuration_number > current_committee_configuration {
         next_committee = data
             .db
@@ -624,11 +631,55 @@ pub async fn gen_checkpoint_psbt(
             )))?
             .committee_after_change;
 
+        // Get unconfirmed/unprocessed unstakes
+        let unconfirmed_stake_changes = data
+            .db
+            .get_unconfirmed_stake_changes(msg.subnet_id)
+            .map_err(|e| {
+                error!("Error getting unconfirmed stake changes from Db: {}", e);
+                RpcError::DbError(e)
+            })?;
+        let unstakes = unconfirmed_stake_changes
+            .iter()
+            .filter_map(|sc| {
+                let validator = subnet
+                    .committee
+                    .validators
+                    .iter()
+                    .find(|v| v.pubkey == sc.validator_xpk);
+
+                let address = match validator {
+                    Some(v) => v.backup_address.clone(),
+                    None => {
+                        error!(
+                            "Validator {} not found in committee for a stake change, skipping",
+                            sc.validator_xpk
+                        );
+                        return None;
+                    }
+                };
+
+                match sc.change {
+                    StakingChange::Withdraw { amount } => Some(ipc_lib::IpcUnstake {
+                        amount,
+                        address,
+                        pubkey: sc.validator_xpk,
+                    }),
+                    _ => {
+                        return None;
+                    }
+                }
+            })
+            .collect::<Vec<_>>();
+
+        msg.unstakes = unstakes;
+
         info!(
             "Rotating committee to configuration number {} multisig address {}",
             msg.next_committee_configuration_number,
             next_committee.address_checked()
         );
+        info!("Processing {} unstakes.", msg.unstakes.len());
     }
     // no change if the configuration number is zero or the same
     else if msg.next_committee_configuration_number.is_zero()

--- a/src/provider/rpc.rs
+++ b/src/provider/rpc.rs
@@ -3,7 +3,7 @@ use crate::{
     db::{self, Database},
     ipc_lib::{
         IpcCheckpointSubnetMsg, IpcCreateSubnetMsg, IpcFundSubnetMsg, IpcJoinSubnetMsg,
-        IpcPrefundSubnetMsg, IpcValidate, SubnetId,
+        IpcPrefundSubnetMsg, IpcStakeCollateralMsg, IpcValidate, SubnetId,
     },
     multisig, NETWORK,
 };
@@ -955,6 +955,56 @@ pub async fn finalize_checkpoint_psbt(
     })
 }
 
+// Stake collateral
+
+#[derive(Serialize, Deserialize)]
+pub struct StakeCollateralResponse {
+    txid: bitcoin::Txid,
+}
+
+pub async fn stake_collateral(
+    data: Data<Arc<ServerData>>,
+    Params(msg): Params<IpcStakeCollateralMsg>,
+) -> Result<StakeCollateralResponse, JsonRpcError> {
+    info!(
+        "stakecollateral: {} {} {}",
+        msg.subnet_id, msg.pubkey, msg.amount
+    );
+
+    if let Err(err) = msg.validate() {
+        error!("Invalid stake collateral message={msg:?}: {err}");
+        return Err(RpcError::InvalidParams(err.to_string()).into());
+    }
+
+    let subnet_state = data
+        .db
+        .get_subnet_state(msg.subnet_id)
+        .map_err(|e| {
+            error!("Error getting subnet info from Db: {}", e);
+            RpcError::DbError(e)
+        })?
+        .ok_or(RpcError::InvalidParams(format!(
+            "Subnet {} not found.",
+            msg.subnet_id
+        )))?;
+
+    msg.validate_for_subnet(&subnet_state).map_err(|e| {
+        error!(
+            "Error validating stake collateral msg for subnet info: {}",
+            e
+        );
+        RpcError::InvalidParams(e.to_string())
+    })?;
+
+    let multisig_address = subnet_state.multisig_address();
+
+    let txid = msg
+        .submit_to_bitcoin(&data.btc_rpc, &multisig_address)
+        .map_err(|e| JsonRpcError::internal(e.to_string()))?;
+
+    Ok(StakeCollateralResponse { txid })
+}
+
 // Stake changes
 
 #[derive(Serialize, Deserialize)]
@@ -1016,6 +1066,7 @@ pub fn make_rpc_server(server_data: Arc<ServerData>) -> RpcServer {
         .with_method("finalizecheckpointpsbt", finalize_checkpoint_psbt)
         .with_method("getsubnetcheckpoint", get_subnet_checkpoint)
         // stake changes
+        .with_method("stakecollateral", stake_collateral)
         .with_method("getstakechanges", get_stake_changes)
         .finish()
 }

--- a/src/provider/rpc.rs
+++ b/src/provider/rpc.rs
@@ -665,9 +665,7 @@ pub async fn gen_checkpoint_psbt(
                         address,
                         pubkey: sc.validator_xpk,
                     }),
-                    _ => {
-                        return None;
-                    }
+                    _ => None,
                 }
             })
             .collect::<Vec<_>>();
@@ -1065,12 +1063,21 @@ pub struct UnstakeCollateralResponse {
 
 pub async fn unstake_collateral(
     data: Data<Arc<ServerData>>,
-    Params(msg): Params<IpcUnstakeCollateralMsg>,
+    Params(mut msg): Params<IpcUnstakeCollateralMsg>,
 ) -> Result<UnstakeCollateralResponse, JsonRpcError> {
-    info!(
-        "unstakecollateral: {} {} {}",
-        msg.subnet_id, msg.pubkey, msg.amount
-    );
+    info!("unstakecollateral: {} {}", msg.subnet_id, msg.amount);
+
+    let (validator_xpk, validator_sk) = match data.validator {
+        Some(validator) => validator,
+        None => {
+            error!("No validator keypair configured.");
+            return Err(
+                RpcError::InternalError("No validator keypair configured.".to_string()).into(),
+            );
+        }
+    };
+
+    msg.pubkey = Some(validator_xpk);
 
     if let Err(err) = msg.validate() {
         error!("Invalid unstake collateral message={msg:?}: {err}");
@@ -1097,8 +1104,10 @@ pub async fn unstake_collateral(
         RpcError::InvalidParams(e.to_string())
     })?;
 
+    let multisig_address = subnet_state.multisig_address();
+
     let txid = msg
-        .submit_to_bitcoin(&data.btc_rpc)
+        .submit_to_bitcoin(&data.btc_rpc, &multisig_address, validator_sk)
         .map_err(|e| JsonRpcError::internal(e.to_string()))?;
 
     Ok(UnstakeCollateralResponse { txid })

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -56,7 +56,7 @@ pub fn generate_subnet_id() -> SubnetId {
     SubnetId::from_txid(&Txid::from_slice(&rand::random::<[u8; 32]>()).unwrap())
 }
 
-pub fn generate_subnet(n: usize) -> db::SubnetState {
+pub fn generate_subnet(n_val: usize) -> db::SubnetState {
     use crate::{
         db, eth_utils::eth_addr_from_x_only_pubkey, multisig::create_subnet_multisig_address,
         NETWORK,
@@ -65,10 +65,10 @@ pub fn generate_subnet(n: usize) -> db::SubnetState {
     use std::net::{IpAddr, Ipv4Addr, SocketAddr};
     use std::str::FromStr;
 
-    assert!(n >= 1, "n must be at least 1");
+    assert!(n_val >= 1, "number of validators must be at least 1");
 
     let subnet_id = generate_subnet_id();
-    let keypairs = generate_keypairs(n);
+    let keypairs = generate_keypairs(n_val);
 
     // Create subnet validators
     let validators: Vec<db::SubnetValidator> = keypairs
@@ -108,7 +108,7 @@ pub fn generate_subnet(n: usize) -> db::SubnetState {
         .collect();
 
     // Create subnet parameters
-    let min_validators = std::cmp::max(1, n / 2) as Power; // Set threshold to n/2 rounded up
+    let min_validators = std::cmp::max(1, n_val / 2) as Power; // Set threshold to n/2 rounded up
 
     // Create committee
     let secp = bitcoin::secp256k1::Secp256k1::new();

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -2,7 +2,7 @@ use bitcoin::{
     hashes::Hash,
     key::{Keypair, Secp256k1},
     secp256k1::{PublicKey, SecretKey},
-    Txid, XOnlyPublicKey,
+    BlockHash, Txid, XOnlyPublicKey,
 };
 use rand::Rng;
 
@@ -140,4 +140,23 @@ pub fn generate_subnet(n: usize) -> db::SubnetState {
         waiting_committee: None,
         last_checkpoint_number: None,
     }
+}
+
+pub fn create_test_db() -> crate::db::HeedDb {
+    let temp_dir = tempfile::tempdir().unwrap();
+    let db_path = temp_dir.path().to_str().unwrap();
+    tokio::runtime::Runtime::new()
+        .unwrap()
+        .block_on(crate::db::HeedDb::new(db_path, false))
+        .unwrap()
+}
+
+pub fn create_rand_txid() -> Txid {
+    Txid::from_slice(&rand::random::<[u8; 32]>()).unwrap()
+}
+pub fn create_rand_blockhash() -> BlockHash {
+    BlockHash::from_slice(&rand::random::<[u8; 32]>()).unwrap()
+}
+pub fn create_rand_addr() -> alloy_primitives::Address {
+    alloy_primitives::Address::from_slice(&rand::random::<[u8; 20]>())
 }

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -115,14 +115,9 @@ pub fn generate_subnet(n_val: usize) -> db::SubnetState {
     let committee_keys: Vec<WeightedKey> = validators.iter().map(|v| (v.pubkey, 1)).collect();
 
     // Create multisig address
-    let multisig_address = create_subnet_multisig_address(
-        &secp,
-        &subnet_id,
-        &committee_keys,
-        min_validators.into(),
-        NETWORK,
-    )
-    .unwrap();
+    let multisig_address =
+        create_subnet_multisig_address(&secp, &subnet_id, &committee_keys, min_validators, NETWORK)
+            .unwrap();
     let multisig_address = multisig_address.as_unchecked();
 
     let committee = db::SubnetCommittee {


### PR DESCRIPTION
See `curl_reqs.md` or the below examples: 

```sh
# stake
curl -X POST http://localhost:3040/api \
-H "Content-Type: application/json" \
-H "Authorization: Bearer asda123123jhaskjdhgbjsjhdj" \
-d '{
    "jsonrpc": "2.0",
    "method": "stakecollateral",
    "params": {
	"subnet_id": "/b4/t410ftevsylx6rsrfl6yymjxja3nnk7hwim3k47ip6iy",
	"amount": 6500000,
	"pubkey": "851c1bda327584479e98a7c28ea7adc097d290efd105310bcf714231bb99faf4"
    },
    "id": 1
}' | jq


# unstake
curl -X POST http://localhost:3040/api \
-H "Content-Type: application/json" \
-H "Authorization: Bearer asda123123jhaskjdhgbjsjhdj" \
-d '{
    "jsonrpc": "2.0",
    "method": "unstakecollateral",
    "params": {
        "subnet_id": "/b4/t410fbbjlqjgx6cyr466yevwd4bp54mbpchkfafeuaby",
        "amount": 4200000
    },
    "id": 1
}' | jq
```

Depends on #89 
Closes #88