### PR TITLE
Generate, sign and finalize bootstrap handover transaction

### DIFF
--- a/internal/bootstrap_handover.sh
+++ b/internal/bootstrap_handover.sh
@@ -1,0 +1,173 @@
+#!/bin/bash
+set -e
+
+# Load environment variables from the .env file in the root of the project
+ENV_FILE=".env"
+if [ ! -f "$ENV_FILE" ]; then
+  echo "Error: $ENV_FILE not found!"
+  exit 1
+fi
+
+# Extract the PROVIDER_AUTH_TOKEN and PROVIDER_PORT values
+BEARER_TOKEN=$(grep '^PROVIDER_AUTH_TOKEN=' "$ENV_FILE" | cut -d '=' -f2)
+PORT=$(grep '^PROVIDER_PORT=' "$ENV_FILE" | cut -d '=' -f2)
+
+if [ -z "$BEARER_TOKEN" ] || [ -z "$PORT" ]; then
+  echo "Error: Required environment variables not found in $ENV_FILE"
+  exit 1
+fi
+
+API_URL="http://localhost:${PORT}/api"
+
+# Check if a subnet ID is provided as an argument
+if [ -z "$1" ]; then
+  echo "Usage: $0 <subnet_id>"
+  exit 1
+fi
+
+SUBNET_ID="$1"
+echo "Working with subnet: $SUBNET_ID"
+
+# Secret keys for signing (whitelist validator private keys)
+SECRET_KEYS=(
+  "21b16a87dd69bc6283045ab63738c9ab73c93c93f91e96cd0e54bd321bba80ad"
+  "67308c2f3915f4c36135f267ed709418c2880025d669e4ada7a206842d53c146"
+  "994220215e4601d21a245f8f5e0c407f2f5733ce7907e128c3190c64f4ef443c"
+  "ab3a1fafa925836386be55b12fdc92f208ebdad5ef96c0109e4bd06638dcb897"
+)
+
+# 1. Generate bootstrap handover PSBT
+echo "1. Generating bootstrap handover PSBT..."
+
+HANDOVER_RESPONSE=$(curl -s -X POST "$API_URL" \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer $BEARER_TOKEN" \
+  -d "{
+    \"jsonrpc\": \"2.0\",
+    \"method\": \"genbootstraphandover\",
+    \"params\": {
+        \"subnet_id\": \"$SUBNET_ID\"
+    },
+    \"id\": 1
+}")
+
+# Check for errors in the response
+if echo "$HANDOVER_RESPONSE" | jq -e '.error' > /dev/null; then
+  echo "Error generating bootstrap handover PSBT:"
+  echo "$HANDOVER_RESPONSE" | jq
+  exit 1
+fi
+
+# Extract the unsigned PSBT
+UNSIGNED_PSBT_BASE64=$(echo "$HANDOVER_RESPONSE" | jq -r '.result.unsigned_psbt_base64')
+
+if [ "$UNSIGNED_PSBT_BASE64" == "null" ] || [ -z "$UNSIGNED_PSBT_BASE64" ]; then
+  echo "Error generating bootstrap handover PSBT:"
+  echo "$HANDOVER_RESPONSE" | jq
+  exit 1
+fi
+
+echo "Bootstrap handover PSBT generated successfully"
+
+# 2. Sign the PSBT using dev_multisignpsbt
+echo "2. Signing PSBT with development keys..."
+
+# Construct the JSON array of secret keys
+SECRET_KEYS_JSON=$(printf '%s\n' "${SECRET_KEYS[@]}" | jq -R . | jq -s .)
+
+SIGN_RESPONSE=$(curl -s -X POST "$API_URL" \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer $BEARER_TOKEN" \
+  -d "{
+    \"jsonrpc\": \"2.0\",
+    \"method\": \"dev_multisignpsbt\",
+    \"params\": {
+        \"unsigned_psbt_base64\": \"$UNSIGNED_PSBT_BASE64\",
+        \"secret_keys\": $SECRET_KEYS_JSON
+    },
+    \"id\": 1
+}")
+
+# Check for errors in the response
+if echo "$SIGN_RESPONSE" | jq -e '.error' > /dev/null; then
+  echo "Error signing PSBT:"
+  echo "$SIGN_RESPONSE" | jq
+  exit 1
+fi
+
+# Extract the signatures
+SIGNATURES=$(echo "$SIGN_RESPONSE" | jq '.result.signatures')
+
+if [ "$SIGNATURES" == "null" ] || [ -z "$SIGNATURES" ]; then
+  echo "Error: No signatures returned"
+  echo "$SIGN_RESPONSE" | jq
+  exit 1
+fi
+
+echo "PSBT signed successfully"
+
+# 3. Finalize the bootstrap handover transaction
+echo "3. Finalizing bootstrap handover transaction..."
+
+FINALIZE_RESPONSE=$(curl -s -X POST "$API_URL" \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer $BEARER_TOKEN" \
+  -d "{
+    \"jsonrpc\": \"2.0\",
+    \"method\": \"finalizebootstraphandover\",
+    \"params\": {
+        \"subnet_id\": \"$SUBNET_ID\",
+        \"unsigned_psbt_base64\": \"$UNSIGNED_PSBT_BASE64\",
+        \"signatures\": $SIGNATURES
+    },
+    \"id\": 1
+}")
+
+# Check for errors in the response
+if echo "$FINALIZE_RESPONSE" | jq -e '.error' > /dev/null; then
+  echo "Error finalizing bootstrap handover PSBT:"
+  echo "$FINALIZE_RESPONSE" | jq
+  exit 1
+fi
+
+# Extract transaction details
+TXID=$(echo "$FINALIZE_RESPONSE" | jq -r '.result.txid')
+
+echo "Bootstrap handover transaction finalized and broadcast successfully"
+echo "Transaction ID: $TXID"
+
+sleep 1
+
+# 4. Mine a block to confirm the transaction
+echo "4. Mining a block to confirm the transaction..."
+bitcoin-cli generatetoaddress 1 "$(bitcoin-cli -rpcwallet=default getnewaddress)" > /dev/null
+sleep 3.5
+
+# Check that our transaction was included in the block
+NEW_BLOCK=$(bitcoin-cli getblockcount)
+NEW_BLOCK_HASH=$(bitcoin-cli getblockhash "$NEW_BLOCK")
+BLOCK_INFO=$(bitcoin-cli getblock "$NEW_BLOCK_HASH")
+
+echo "New block mined: $NEW_BLOCK ($NEW_BLOCK_HASH)"
+
+if [[ $BLOCK_INFO == *"$TXID"* ]]; then
+  echo "✅ Bootstrap handover transaction confirmed in block $NEW_BLOCK"
+else
+  echo "⚠️ Bootstrap handover transaction not found in the new block"
+fi
+
+# Get updated subnet state to verify handover was processed
+echo "Getting updated subnet state..."
+curl -s -X POST "$API_URL" \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer $BEARER_TOKEN" \
+  -d "{
+    \"jsonrpc\": \"2.0\",
+    \"method\": \"getsubnet\",
+    \"params\": {
+        \"subnet_id\": \"$SUBNET_ID\"
+    },
+    \"id\": 1
+}" | jq '.result'
+
+echo "Bootstrap handover submission complete!"

--- a/internal/curl_reqs.md
+++ b/internal/curl_reqs.md
@@ -1,5 +1,5 @@
 ```sh
-curl -X POST http://localhost:3030/api \
+curl -X POST http://localhost:3040/api \
 -H "Content-Type: application/json" \
 -H "Authorization: Bearer asda123123jhaskjdhgbjsjhdj" \
 -d '{
@@ -28,7 +28,7 @@ curl -X POST http://localhost:3030/api \
     "jsonrpc": "2.0",
     "method": "joinsubnet",
     "params": {
-			"subnet_id": "/b4/t420fmsv2gwpnksrxob6yij4wi6iuu2pg4vowy6xopfembcl6axt5ocqtymspsm",
+			"subnet_id": "/b4/t410f7kn2c5qglq6ymzbqczbff2scqm2y6vszeqc2lxy",
 			"collateral": 200000000,
 			"ip": "66.222.44.55:8080",
 			"backup_address": "bcrt1q3fznspr3e02artm9df7tk827a2xhny2m4zzr6n",
@@ -46,7 +46,7 @@ curl -X POST http://localhost:3040/api \
     "jsonrpc": "2.0",
     "method": "joinsubnet",
     "params": {
-			"subnet_id": "/b4/t410fbbjlqjgx6cyr466yevwd4bp54mbpchkfafeuaby",
+			"subnet_id": "/b4/t410f7kn2c5qglq6ymzbqczbff2scqm2y6vszeqc2lxy",
 			"collateral": 20000000,
 			"ip": "66.222.44.55:8080",
 			"backup_address": "bcrt1q3fznspr3e02artm9df7tk827a2xhny2m4zzr6n",
@@ -57,7 +57,6 @@ curl -X POST http://localhost:3040/api \
 
 # join new validator 2
 
-curl -X POST http://localhost:3040/api \
 -H "Content-Type: application/json" \
 -H "Authorization: Bearer asda123123jhaskjdhgbjsjhdj" \
 -d '{
@@ -65,7 +64,7 @@ curl -X POST http://localhost:3040/api \
     "method": "joinsubnet",
     "params": {
 			"subnet_id": "/b4/t410fertekptrvemo3wddyaht6v2pqykjdjieorit6ha",
-			"collateral": 20000000,
+			"collateral": 21000000,
 			"ip": "66.222.44.55:8080",
 			"backup_address": "bcrt1q3fznspr3e02artm9df7tk827a2xhny2m4zzr6n",
 			"pubkey": "71ac1eb874233999e11cd050f388f1dd6da9b446180fdf9b06740419cc487b6f"
@@ -82,9 +81,23 @@ curl -X POST http://localhost:3040/api \
     "jsonrpc": "2.0",
     "method": "stakecollateral",
     "params": {
-			"subnet_id": "/b4/t410fbbjlqjgx6cyr466yevwd4bp54mbpchkfafeuaby",
+			"subnet_id": "/b4/t410f7kn2c5qglq6ymzbqczbff2scqm2y6vszeqc2lxy",
 			"amount": 6500000,
 			"pubkey": "851c1bda327584479e98a7c28ea7adc097d290efd105310bcf714231bb99faf4"
+    },
+    "id": 1
+}' | jq
+
+curl -X POST http://localhost:3040/api \
+-H "Content-Type: application/json" \
+-H "Authorization: Bearer asda123123jhaskjdhgbjsjhdj" \
+-d '{
+    "jsonrpc": "2.0",
+    "method": "stakecollateral",
+    "params": {
+			"subnet_id": "/b4/t410f7kn2c5qglq6ymzbqczbff2scqm2y6vszeqc2lxy",
+			"amount": 8500000,
+			"pubkey": "b15f99928f2478a10c5739a03f5495d342e77352d624e7cc8ebfbded544f9ac0"
     },
     "id": 1
 }' | jq
@@ -98,8 +111,8 @@ curl -X POST http://localhost:3040/api \
     "jsonrpc": "2.0",
     "method": "stakecollateral",
     "params": {
-			"subnet_id": "/b4/t410fbbjlqjgx6cyr466yevwd4bp54mbpchkfafeuaby",
-			"amount": 6500000,
+			"subnet_id": "/b4/t410f7kn2c5qglq6ymzbqczbff2scqm2y6vszeqc2lxy",
+			"amount": 4500000,
 			"pubkey": "e327a66b169732bde49d827d90781327af558fc12d5cd2d5004e7551ec00c662"
     },
     "id": 1
@@ -114,8 +127,8 @@ curl -X POST http://localhost:3040/api \
     "jsonrpc": "2.0",
     "method": "unstakecollateral",
     "params": {
-			"subnet_id": "/b4/t410fbbjlqjgx6cyr466yevwd4bp54mbpchkfafeuaby",
-			"amount": 4200000
+			"subnet_id": "/b4/t410f7kn2c5qglq6ymzbqczbff2scqm2y6vszeqc2lxy",
+			"amount": 2000000
     },
     "id": 1
 }' | jq
@@ -128,7 +141,7 @@ curl -X POST http://localhost:3030/api \
     "jsonrpc": "2.0",
     "method": "joinsubnet",
     "params": {
-			"subnet_id": "/b4/t420fmsv2gwpnksrxob6yij4wi6iuu2pg4vowy6xopfembcl6axt5ocqtymspsm",
+			"subnet_id": "/b4/t410f7kn2c5qglq6ymzbqczbff2scqm2y6vszeqc2lxy",
 			"collateral": 110000000,
 			"ip": "66.222.44.55:8081",
 			"backup_address": "bcrt1q3fznspr3e02artm9df7tk827a2xhny2m4zzr6n",
@@ -144,7 +157,7 @@ curl -X POST http://localhost:3030/api \
     "jsonrpc": "2.0",
     "method": "joinsubnet",
     "params": {
-			"subnet_id": "/b4/t420fmsv2gwpnksrxob6yij4wi6iuu2pg4vowy6xopfembcl6axt5ocqtymspsm",
+			"subnet_id": "/b4/t410f7kn2c5qglq6ymzbqczbff2scqm2y6vszeqc2lxy",
 			"collateral": 150000000,
 			"ip": "66.222.44.55:8082",
 			"backup_address": "bcrt1q3fznspr3e02artm9df7tk827a2xhny2m4zzr6n",
@@ -160,7 +173,7 @@ curl -X POST http://localhost:3030/api \
     "jsonrpc": "2.0",
     "method": "joinsubnet",
     "params": {
-			"subnet_id": "/b4/t420fmsv2gwpnksrxob6yij4wi6iuu2pg4vowy6xopfembcl6axt5ocqtymspsm",
+			"subnet_id": "/b4/t410f7kn2c5qglq6ymzbqczbff2scqm2y6vszeqc2lxy",
 			"collateral": 180000000,
 			"ip": "66.222.44.55:8083",
 			"backup_address": "bcrt1q3fznspr3e02artm9df7tk827a2xhny2m4zzr6n",
@@ -188,7 +201,7 @@ curl -X POST http://localhost:3040/api \
     "jsonrpc": "2.0",
     "method": "getsubnet",
     "params": {
-			"subnet_id": "/b4/t410fbbjlqjgx6cyr466yevwd4bp54mbpchkfafeuaby"
+			"subnet_id": "/b4/t410f7kn2c5qglq6ymzbqczbff2scqm2y6vszeqc2lxy"
     },
     "id": 1
 }' | jq
@@ -228,7 +241,7 @@ curl -X POST http://localhost:3030/api \
     "jsonrpc": "2.0",
     "method": "getrootnetmessages",
     "params": {
-			"subnet_id": "/b4/t420fmsv2gwpnksrxob6yij4wi6iuu2pg4vowy6xopfembcl6axt5ocqtymspsm",
+			"subnet_id": "/b4/t410f7kn2c5qglq6ymzbqczbff2scqm2y6vszeqc2lxy",
 			"block_height": 235
     },
     "id": 1
@@ -241,7 +254,7 @@ curl -X POST http://localhost:3040/api \
     "jsonrpc": "2.0",
     "method": "getstakechanges",
     "params": {
-			"subnet_id": "/b4/t410fbbjlqjgx6cyr466yevwd4bp54mbpchkfafeuaby",
+			"subnet_id": "/b4/t410f7kn2c5qglq6ymzbqczbff2scqm2y6vszeqc2lxy",
 			"block_height": 162
     },
     "id": 1
@@ -257,6 +270,30 @@ curl -X POST http://localhost:3030/api \
 			"subnet_id": "/b4/t420fxm3vljgrnt4az4nbhwo74ih3b4lce2ecfzfrytqtzfnulhjfuagct52yci",
 			"recipient": "bcrt1q3pw5xfrph88qgd4uwmwgw5xh60np6mdcdd2h5k",
 			"amount": 20000000
+    },
+    "id": 1
+}' | jq
+
+curl -X POST http://localhost:3040/api \
+-H "Content-Type: application/json" \
+-H "Authorization: Bearer asda123123jhaskjdhgbjsjhdj" \
+-d '{
+    "jsonrpc": "2.0",
+    "method": "genbootstraphandover",
+    "params": {
+			"subnet_id": "/b4/t410f7eqjpzo3akekevrpbfdwwhkbj65pzaanskoml6i"
+    },
+    "id": 1
+}' | jq
+
+curl -X POST http://localhost:3030/api \
+-H "Content-Type: application/json" \
+-H "Authorization: Bearer validator1_auth_token" \
+-d '{
+    "jsonrpc": "2.0",
+    "method": "genbootstraphandover",
+    "params": {
+			"subnet_id": "/b4/t410f7eqjpzo3akekevrpbfdwwhkbj65pzaanskoml6i"
     },
     "id": 1
 }' | jq

--- a/src/provider/rpc.rs
+++ b/src/provider/rpc.rs
@@ -638,6 +638,14 @@ pub async fn gen_bootstrap_handover(
                 RpcError::InternalError(e.to_string())
             })?;
 
+    if unspent.is_empty() {
+        return Err(RpcError::InvalidParams(format!(
+            "No unspent outputs found for whitelist multisig address {}. The handover was possibly already done.",
+            whitelist_multisig_addr
+        ))
+        .into());
+    }
+
     debug!("Unspent for whitelist multisig: {:?}", unspent);
 
     // Create the handover PSBT

--- a/src/provider/rpc.rs
+++ b/src/provider/rpc.rs
@@ -5,13 +5,13 @@ use crate::{
         self, IpcCheckpointSubnetMsg, IpcCreateSubnetMsg, IpcFundSubnetMsg, IpcJoinSubnetMsg,
         IpcPrefundSubnetMsg, IpcStakeCollateralMsg, IpcUnstakeCollateralMsg, IpcValidate, SubnetId,
     },
-    multisig, NETWORK,
+    multisig, wallet, NETWORK,
 };
 use base64::{engine::general_purpose::STANDARD as BASE64_STANDARD, Engine};
 use bitcoin::hashes::Hash;
 use bitcoincore_rpc::{Client, RpcApi};
 use jsonrpc_v2::{Data, Error as JsonRpcError, ErrorLike, MapRouter, Params};
-use log::{error, info, trace};
+use log::{debug, error, info, trace, warn};
 use num_traits::Zero;
 use serde::{Deserialize, Serialize};
 use serde_json::json;
@@ -519,6 +519,171 @@ pub async fn gen_multisig_spend_psbt(
     })
 }
 
+#[derive(Serialize, Deserialize, Debug)]
+pub struct PostBoostrapHandoverParams {
+    subnet_id: SubnetId,
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+pub struct PostBoostrapHandoverResponse {
+    unsigned_psbt: bitcoin::Psbt,
+    unsigned_psbt_base64: String,
+    psbt_inputs_signatures: Vec<bitcoin::secp256k1::schnorr::Signature>,
+}
+
+pub async fn gen_bootstrap_handover(
+    data: Data<Arc<ServerData>>,
+    Params(params): Params<PostBoostrapHandoverParams>,
+) -> Result<PostBoostrapHandoverResponse, JsonRpcError> {
+    info!("post_bootstrap_handover: {:?}", params);
+
+    let (validator_xonly_pubkey, validator_sk) = match data.validator {
+        Some(validator) => validator,
+        None => {
+            error!("No validator keypair configured.");
+            return Err(
+                RpcError::InternalError("No validator keypair configured.".to_string()).into(),
+            );
+        }
+    };
+
+    // Check genesis info
+    let genesis_info = data
+        .db
+        .get_subnet_genesis_info(params.subnet_id)
+        .map_err(|e| {
+            error!("Error getting subnet info from Db: {}", e);
+            RpcError::DbError(e)
+        })?
+        .ok_or(RpcError::InvalidParams(format!(
+            "Subnet {} not found.",
+            params.subnet_id
+        )))?;
+
+    // Check subnet exists
+    let subnet = data
+        .db
+        .get_subnet_state(params.subnet_id)
+        .map_err(|e| {
+            error!("Error getting subnet info from Db: {}", e);
+            RpcError::DbError(e)
+        })?
+        .ok_or(RpcError::InvalidParams(format!(
+            "Subnet {} not found.",
+            params.subnet_id
+        )))?;
+
+    // Check if self is a validator in the subnet
+    if !subnet.is_validator(&validator_xonly_pubkey) {
+        error!("Configured validator isn't a validator in the specified subnet.");
+        return Err(RpcError::InvalidParams(
+            "Configured validator isn't a validator in the specified subnet.".to_string(),
+        )
+        .into());
+    }
+
+    if subnet.last_checkpoint_number.is_some() {
+        // NOTE: we should accept to bootstrap handover even if the subnet already has checkpoints
+        // normally it should be done before the first checkpoint is posted, but in an
+        // exceptional case better to handover to the 2nd committee then not at all?
+        // if subnet.last_checkpoint_number.is_some() {
+        //     error!(
+        //         "Subnet {} already has checkpoints, cannot post bootstrap handover.",
+        //         params.subnet_id
+        //     );
+        //     return Err(RpcError::InvalidParams(format!(
+        //         "Subnet {} already has checkpoints, cannot post bootstrap handover.",
+        //         params.subnet_id
+        //     ))
+        //     .into());
+        // }
+
+        warn!(
+            "Subnet {} already has checkpoints, but proceeding with bootstrap handover.",
+            params.subnet_id
+        );
+    }
+
+    // Collect committee information
+
+    let committee_address = subnet
+        .committee
+        .multisig_address
+        .clone()
+        .require_network(NETWORK)
+        .expect("Multisig should be valid for saved subnet genesis info");
+
+    // Collect whitelist collateral
+
+    let whitelist_keys: Vec<multisig::WeightedKey> = genesis_info
+        .create_subnet_msg
+        .whitelist
+        .iter()
+        // Each key has the same weight
+        .map(|xpk| (*xpk, 1))
+        .collect::<Vec<_>>();
+    let whitelist_threshold: u32 = genesis_info.create_subnet_msg.min_validators.into();
+    let whitelist_multisig_addr = genesis_info
+        .create_subnet_msg
+        .multisig_address_from_whitelist(&params.subnet_id)
+        .map_err(|e| {
+            error!("Error creating multisig address from whitelist: {}", e);
+            RpcError::InternalError(e.to_string())
+        })?;
+
+    let unspent =
+        wallet::get_unspent_for_address(&data.btc_watchonly_rpc, &whitelist_multisig_addr)
+            .map_err(|e| {
+                error!("Error getting unspent for whitelist multisig: {}", e);
+                RpcError::InternalError(e.to_string())
+            })?;
+
+    debug!("Unspent for whitelist multisig: {:?}", unspent);
+
+    // Create the handover PSBT
+
+    let fee_rate = bitcoin_utils::get_fee_rate(&data.btc_watchonly_rpc, None, None);
+    let secp = bitcoin::secp256k1::Secp256k1::new();
+
+    let unsigned_psbt = multisig::construct_spend_psbt(
+        &secp,
+        &params.subnet_id,
+        &whitelist_keys,
+        whitelist_threshold,
+        &committee_address,
+        &unspent,
+        true,
+        &[],
+        &fee_rate,
+    )
+    .map_err(|e| {
+        error!(
+            "Error generating multisig spend psbt for subnet_id={}: {}",
+            &params.subnet_id, e
+        );
+        RpcError::InternalError(e.to_string())
+    })?;
+
+    let validator_keypair = validator_sk.keypair(&secp);
+
+    let (_, psbt_inputs_signatures) =
+        multisig::sign_spend_psbt(&secp, unsigned_psbt.clone(), validator_keypair).map_err(
+            |e| {
+                error!(
+                    "Error signing multisig spend psbt for subnet_id={}: {}",
+                    &params.subnet_id, e
+                );
+                RpcError::InternalError(e.to_string())
+            },
+        )?;
+
+    Ok(PostBoostrapHandoverResponse {
+        unsigned_psbt: unsigned_psbt.clone(),
+        unsigned_psbt_base64: BASE64_STANDARD.encode(unsigned_psbt.serialize()),
+        psbt_inputs_signatures,
+    })
+}
+
 #[derive(Serialize, Deserialize)]
 pub struct GenCheckpointPsbtResponse {
     // Checkpoint
@@ -603,7 +768,6 @@ pub async fn gen_checkpoint_psbt(
     // assume no change in the committee
     let mut next_committee = subnet.committee.clone();
     let current_committee_configuration = subnet.committee.configuration_number;
-    // let mut unstakes = vec![];
 
     // update next_committee and process unstakes if the configuration number changed
     if msg.next_committee_configuration_number > current_committee_configuration {
@@ -993,6 +1157,146 @@ pub async fn finalize_checkpoint_psbt(
     })
 }
 
+#[derive(Serialize, Deserialize)]
+pub struct FinalizeBootstrapHandoverParams {
+    subnet_id: SubnetId,
+    unsigned_psbt_base64: String,
+    signatures: Vec<(
+        bitcoin::XOnlyPublicKey,
+        Vec<bitcoin::secp256k1::schnorr::Signature>,
+    )>,
+}
+
+#[derive(Serialize, Deserialize)]
+pub struct FinalizeBootstrapHandoverResponse {
+    tx: bitcoin::Transaction,
+    txid: String,
+    tx_hex: String,
+}
+
+pub async fn finalize_bootstrap_handover(
+    data: Data<Arc<ServerData>>,
+    Params(params): Params<FinalizeBootstrapHandoverParams>,
+) -> Result<FinalizeBootstrapHandoverResponse, JsonRpcError> {
+    info!(
+        "finalize_bootstrap_handover for subnet {}",
+        params.subnet_id
+    );
+
+    // Check genesis info
+    let genesis_info = data
+        .db
+        .get_subnet_genesis_info(params.subnet_id)
+        .map_err(|e| {
+            error!("Error getting subnet genesis info from Db: {}", e);
+            RpcError::DbError(e)
+        })?
+        .ok_or(RpcError::InvalidParams(format!(
+            "Subnet {} not found.",
+            params.subnet_id
+        )))?;
+
+    // Get whitelist multisig info for signature verification
+    let whitelist_keys: Vec<multisig::WeightedKey> = genesis_info
+        .create_subnet_msg
+        .whitelist
+        .iter()
+        // Each key has the same weight
+        .map(|xpk| (*xpk, 1))
+        .collect::<Vec<_>>();
+    let whitelist_threshold: u32 = genesis_info.create_subnet_msg.min_validators.into();
+
+    // Decode base64 PSBT
+    let psbt_bytes = BASE64_STANDARD
+        .decode(params.unsigned_psbt_base64.as_bytes())
+        .map_err(|e| {
+            error!("Invalid base64 format for PSBT: {}", e);
+            RpcError::InvalidParams(format!("Invalid base64 format for PSBT: {}", e))
+        })?;
+
+    // Deserialize PSBT
+    let unsigned_psbt = bitcoin::psbt::Psbt::deserialize(&psbt_bytes).map_err(|e| {
+        error!("Invalid PSBT format: {}", e);
+        RpcError::InvalidParams(format!("Invalid PSBT format: {}", e))
+    })?;
+
+    let secp = bitcoin::secp256k1::Secp256k1::new();
+
+    // Create a map of provided signatures indexed by public key
+    let signatures_map: std::collections::HashMap<
+        bitcoin::XOnlyPublicKey,
+        Vec<bitcoin::secp256k1::schnorr::Signature>,
+    > = params.signatures.into_iter().collect();
+
+    // Prepare signature sets in the same order as whitelist keys
+    let mut signature_sets: Vec<&[bitcoin::secp256k1::schnorr::Signature]> =
+        Vec::with_capacity(whitelist_keys.len());
+
+    // Check if any unrecognized public keys were provided
+    for pubkey in signatures_map.keys() {
+        if !whitelist_keys
+            .iter()
+            .any(|(whitelist_key, _)| whitelist_key == pubkey)
+        {
+            error!("Unrecognized public key in signatures: {}", pubkey);
+            return Err(RpcError::InvalidParams(format!(
+                "Unrecognized public key in signatures: {}",
+                pubkey
+            ))
+            .into());
+        }
+    }
+
+    // For each whitelist key, get the corresponding signatures or use empty set
+    for (pubkey, _) in &whitelist_keys {
+        let sigs = match signatures_map.get(pubkey) {
+            Some(sigs) => sigs.as_slice(),
+            None => &[],
+        };
+        signature_sets.push(sigs);
+    }
+
+    // Finalize the PSBT using multisig::finalize_spend_psbt_from_sigs
+    let finalized_tx = multisig::finalize_spend_psbt_from_sigs(
+        &secp,
+        &params.subnet_id,
+        &whitelist_keys,
+        whitelist_threshold,
+        &unsigned_psbt,
+        &signature_sets,
+    )
+    .map_err(|e| {
+        error!("Error finalizing bootstrap handover PSBT: {}", e);
+        RpcError::InternalError(e.to_string())
+    })?;
+
+    // Convert transaction to hex
+    let tx_hex = hex::encode(bitcoin::consensus::serialize(&finalized_tx));
+
+    // Get transaction ID
+    let txid = finalized_tx.compute_txid().to_string();
+
+    trace!("bootstrap_handover_txid = {}", txid);
+
+    // Send the transaction to the Bitcoin network
+    bitcoin_utils::submit_to_mempool(&data.btc_rpc, vec![finalized_tx.clone()]).map_err(|e| {
+        error!(
+            "Error sending bootstrap handover transaction to Bitcoin network: {}",
+            e
+        );
+        RpcError::InternalError(format!(
+            "Error sending bootstrap handover transaction to Bitcoin network: {}",
+            e
+        ))
+    })?;
+
+    Ok(FinalizeBootstrapHandoverResponse {
+        tx: finalized_tx,
+        txid,
+        tx_hex,
+    })
+}
+
 // Stake collateral
 
 #[derive(Serialize, Deserialize)]
@@ -1170,6 +1474,8 @@ pub fn make_rpc_server(server_data: Arc<ServerData>) -> RpcServer {
         .with_method("getrootnetmessages", get_rootnet_messages)
         // multisig
         .with_method("genmultisigspendpsbt", gen_multisig_spend_psbt)
+        .with_method("genbootstraphandover", gen_bootstrap_handover)
+        .with_method("finalizebootstraphandover", finalize_bootstrap_handover)
         // checkpoints
         .with_method("gencheckpointpsbt", gen_checkpoint_psbt)
         .with_method("dev_multisignpsbt", dev_multisign_psbt) // TODO make dev only

--- a/src/wallet.rs
+++ b/src/wallet.rs
@@ -107,7 +107,10 @@ pub fn get_unspent_for_address(
     rpc: &Client,
     addr: &bitcoin::Address,
 ) -> Result<Vec<ListUnspentResultEntry>, WalletError> {
-    let unspent = rpc.list_unspent(None, None, Some(&[addr]), None, None)?;
+    let mut unspent = rpc.list_unspent(None, None, Some(&[addr]), None, None)?;
+    // exact ordering doesn't matter, we care about having it deterministic
+    // coin selection or similar should order it more specifically
+    unspent.sort_by(|a, b| b.amount.cmp(&a.amount));
     debug!("get_unspent_for_address {addr}: {unspent:?}");
     Ok(unspent)
 }


### PR DESCRIPTION
We need to collect all of the collateral sent to the whitelist multisig and forward it to the actual subnet committee (that has a different address due to validators and weight). For this purpose there are 2 new RPC endpoints, `genbootstraphandover` and `finalizebootstraphandover`, which function in a similar way to the checkpoint collection.

Look at `bootstrap_handover.sh` script that uses `dev_multisign_psbt` for tests. You can confirm afterwards that the actual committee has a new utxo with the collaterals (see `bitcoin_wallets.md` for the how-to).

Closes #90 