### PR TITLE
Fixes from Feature/devnet: Faster Monitor sync, Monitor resilience, checkpoint sizing fix, a new balance RPC, and the BSL client image build pipeline.

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -21,6 +21,9 @@ PROVIDER_AUTH_TOKEN=validator1_auth_token
 # Monitor
 
 MONITOR_POLL_INTERVAL=2
+# Blocks fetched per batched RPC round-trip during sync.
+# Higher value cuts round-trips but uses more memory per batch.
+MONITOR_SYNC_BATCH_SIZE=1000
 
 # General
 

--- a/.github/workflows/bsl-client-image.yml
+++ b/.github/workflows/bsl-client-image.yml
@@ -1,0 +1,123 @@
+# Builds the public BSL client image and pushes it to GHCR.
+#
+# The image needs source from two repos, so each build job checks out this repo
+# (bitcoin-ipc: monitor, provider) and the public ipc repo (ipc-cli) as sibling
+# directories, then builds docker-build-client/Dockerfile against that context.
+#
+# Multi-arch is built on NATIVE runners (amd64 on ubuntu-latest, arm64 on
+# ubuntu-24.04-arm), and the merge job assembles the digests into the
+#:testnet manifest list.
+name: bsl-client image
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  packages: write
+
+concurrency:
+  group: bsl-client-image-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  REGISTRY_IMAGE: ghcr.io/bitcoinscalinglabs/bsl-client
+
+jobs:
+  build:
+    runs-on: ${{ matrix.platform == 'linux/arm64' && 'ubuntu-24.04-arm' || 'ubuntu-latest' }}
+    strategy:
+      fail-fast: false
+      matrix:
+        platform:
+          - linux/amd64
+          - linux/arm64
+    steps:
+      - name: Prepare platform tag
+        run: |
+          platform=${{ matrix.platform }}
+          echo "PLATFORM_PAIR=${platform//\//-}" >> "$GITHUB_ENV"
+
+      - name: Checkout bitcoin-ipc
+        uses: actions/checkout@v4
+        with:
+          path: bitcoin-ipc
+
+      - name: Checkout ipc (public, main)
+        uses: actions/checkout@v4
+        with:
+          repository: bitcoinscalinglabs/ipc
+          ref: main
+          path: ipc
+
+      - name: Docker metadata (labels)
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY_IMAGE }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push by digest
+        id: build
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: bitcoin-ipc/docker-build-client/Dockerfile
+          platforms: ${{ matrix.platform }}
+          labels: ${{ steps.meta.outputs.labels }}
+          outputs: type=image,name=${{ env.REGISTRY_IMAGE }},push-by-digest=true,name-canonical=true,push=true
+
+      - name: Export digest
+        run: |
+          mkdir -p "${{ runner.temp }}/digests"
+          digest="${{ steps.build.outputs.digest }}"
+          touch "${{ runner.temp }}/digests/${digest#sha256:}"
+
+      - name: Upload digest
+        uses: actions/upload-artifact@v4
+        with:
+          name: digests-${{ env.PLATFORM_PAIR }}
+          path: ${{ runner.temp }}/digests/*
+          if-no-files-found: error
+          retention-days: 1
+
+  merge:
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Download digests
+        uses: actions/download-artifact@v4
+        with:
+          path: ${{ runner.temp }}/digests
+          pattern: digests-*
+          merge-multiple: true
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Create manifest list and push
+        working-directory: ${{ runner.temp }}/digests
+        run: |
+          docker buildx imagetools create -t "${REGISTRY_IMAGE}:testnet" \
+            $(printf "${REGISTRY_IMAGE}@sha256:%s " *)
+
+      - name: Inspect
+        run: docker buildx imagetools inspect "${REGISTRY_IMAGE}:testnet"

--- a/docker-build-client/Dockerfile
+++ b/docker-build-client/Dockerfile
@@ -1,0 +1,30 @@
+FROM rust:1.87.0-slim AS build-bitcoinipc
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    git curl pkg-config libssl-dev build-essential ca-certificates \
+ && rm -rf /var/lib/apt/lists/*
+WORKDIR /src
+COPY bitcoin-ipc/ .
+RUN cargo build --release --features emission_chain --bin monitor --bin provider
+
+FROM rust:bookworm AS build-ipc
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    build-essential libssl-dev pkg-config curl clang git jq ca-certificates protobuf-compiler \
+ && rm -rf /var/lib/apt/lists/*
+WORKDIR /src
+COPY ipc/ .
+RUN cargo build --release -p ipc-cli
+
+FROM debian:bookworm-slim
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    ca-certificates libssl3 autossh openssh-client curl jq netcat-openbsd \
+ && rm -rf /var/lib/apt/lists/*
+# TARGETARCH (amd64|arm64) is supplied by buildx and matches Foundry's naming.
+ARG TARGETARCH
+RUN curl -fsSL "https://github.com/foundry-rs/foundry/releases/download/stable/foundry_stable_linux_${TARGETARCH}.tar.gz" \
+    | tar -xz -C /usr/local/bin cast
+COPY --from=build-bitcoinipc /src/target/release/monitor  /usr/local/bin/monitor
+COPY --from=build-bitcoinipc /src/target/release/provider /usr/local/bin/provider
+COPY --from=build-ipc        /src/target/release/ipc-cli  /usr/local/bin/ipc-cli
+COPY bitcoin-ipc/docker-build-client/entrypoint.sh /usr/local/bin/entrypoint.sh
+RUN chmod +x /usr/local/bin/entrypoint.sh
+ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]

--- a/docker-build-client/README.md
+++ b/docker-build-client/README.md
@@ -1,0 +1,20 @@
+# bsl-client image
+
+Docker image for interacting with the Bitcoin-IPC framework. It reads the framework's
+state from Bitcoin — subnets, their validators, stakes, and checkpoints — and can act
+on it, for example joining a subnet as a validator. It reaches a Bitcoin node over an
+SSH tunnel (currently Bitcoin Core on the Regtest testnet only).
+
+The container runs three processes:
+
+- **monitor** — continuously reads the Bitcoin chain and reconstructs the Bitcoin-IPC
+  state (subnets, validators, collateral, checkpoints, IPC-BTC rewards) into a local
+  database.
+- **provider** — serves that state over a local JSON-RPC API (port 3030) and builds the
+  Bitcoin transactions Bitcoin-IPC needs, such as joining a subnet.
+- **ipc-cli** — command-line tool (run via `docker exec`) to query a subnet and act on
+  it; it talks to the provider.
+
+`monitor` and `provider` are built from this repo, `ipc-cli` from the ipc repo. The
+image is built multi-arch from both source trees and pushed to
+`ghcr.io/bitcoinscalinglabs/bsl-client` by `../.github/workflows/bsl-client-image.yml`.

--- a/docker-build-client/entrypoint.sh
+++ b/docker-build-client/entrypoint.sh
@@ -1,0 +1,103 @@
+#!/usr/bin/env bash
+# Open the SSH tunnel to bitcoind, then run monitor + provider against it.
+set -euo pipefail
+
+: "${BITCOIN_CONN_MODE:=ssh-tunnel}"
+if [ "$BITCOIN_CONN_MODE" != "ssh-tunnel" ]; then
+  echo "ERROR: BITCOIN_CONN_MODE='$BITCOIN_CONN_MODE' not supported (only 'ssh-tunnel')." >&2
+  exit 1
+fi
+
+: "${SSH_HOST:?SSH_HOST required}"
+: "${SSH_USER:?SSH_USER required}"
+: "${RPC_USER:?RPC_USER required}"
+: "${RPC_PASS:?RPC_PASS required}"
+: "${WALLET_NAME:?WALLET_NAME required}"
+: "${PROVIDER_AUTH_TOKEN:?PROVIDER_AUTH_TOKEN required}"
+: "${ACTIVATION_HEIGHT:?ACTIVATION_HEIGHT required}"
+: "${SNAPSHOT_LENGTH:?SNAPSHOT_LENGTH required}"
+: "${PROVIDER_PORT:=3030}"
+: "${DATABASE_URL:=/var/lib/bsl/db}"
+: "${MONITOR_SYNC_BATCH_SIZE:=1000}"
+: "${SUBNET_ID:=/b4}"
+: "${RUST_LOG:=bitcoin_ipc=info,monitor=info,provider=info,bitcoincore_rpc=error}"
+TUNNEL_KEY="${TUNNEL_KEY:-/run/tunnel_key}"
+LOCAL_RPC_PORT=18443
+RPC_URL="http://127.0.0.1:${LOCAL_RPC_PORT}"
+
+[ -f "$TUNNEL_KEY" ] || { echo "ERROR: tunnel key not mounted at $TUNNEL_KEY" >&2; exit 1; }
+# ssh rejects a world-readable key, so copy the ro mount to a 600 file.
+install -m 600 "$TUNNEL_KEY" /tmp/tunnel_key
+
+echo "==> opening SSH tunnel to ${SSH_USER}@${SSH_HOST}"
+autossh -M 0 -f -N \
+  -L "${LOCAL_RPC_PORT}:127.0.0.1:18443" \
+  -i /tmp/tunnel_key \
+  -o ServerAliveInterval=30 -o ServerAliveCountMax=3 \
+  -o ExitOnForwardFailure=yes -o StrictHostKeyChecking=accept-new \
+  "${SSH_USER}@${SSH_HOST}"
+
+echo "==> waiting for bitcoind RPC via tunnel"
+for _ in $(seq 1 30); do
+  nc -z 127.0.0.1 "$LOCAL_RPC_PORT" && break
+  sleep 1
+done
+nc -z 127.0.0.1 "$LOCAL_RPC_PORT" || { echo "ERROR: tunnel to bitcoind not reachable" >&2; exit 1; }
+
+mkdir -p "$DATABASE_URL" /etc/bsl /root/.ipc
+cat > /etc/bsl/stack.env <<EOF
+RPC_USER=$RPC_USER
+RPC_PASS=$RPC_PASS
+RPC_URL=$RPC_URL
+WALLET_NAME=$WALLET_NAME
+DATABASE_URL=$DATABASE_URL
+PROVIDER_PORT=$PROVIDER_PORT
+PROVIDER_AUTH_TOKEN=$PROVIDER_AUTH_TOKEN
+ACTIVATION_HEIGHT=$ACTIVATION_HEIGHT
+SNAPSHOT_LENGTH=$SNAPSHOT_LENGTH
+MONITOR_SYNC_BATCH_SIZE=$MONITOR_SYNC_BATCH_SIZE
+RUST_LOG=$RUST_LOG
+EOF
+# No VALIDATOR_SK_PATH: the provider runs read/join-only, which needs no signing key.
+
+# ipc-cli operates on the subnet "as viewed by the parent", so the config entry is
+# the parent id (e.g. /b4), not the full child subnet id; commands pass --subnet.
+cat > /root/.ipc/config.toml <<EOF
+keystore_path = "~/.ipc"
+
+[[subnets]]
+id = "${SUBNET_ID%/*}"
+
+[subnets.config]
+network_type = "btc"
+provider_http = "http://127.0.0.1:${PROVIDER_PORT}/api"
+auth_token = "$PROVIDER_AUTH_TOKEN"
+EOF
+
+echo "==> starting monitor"
+monitor --env /etc/bsl/stack.env &
+MON=$!
+
+# The provider opens the DB read-only and panics if the monitor hasn't created it
+# yet. Give the monitor a head start so the first attempt usually wins the race; the
+# retry loop below still covers a slower-than-expected monitor start.
+sleep 5
+
+echo "==> starting provider"
+PRV=""
+for _ in $(seq 1 30); do
+  provider --env /etc/bsl/stack.env &
+  PRV=$!
+  sleep 3
+  kill -0 "$PRV" 2>/dev/null && break
+  kill -0 "$MON" 2>/dev/null || { echo "ERROR: monitor exited during startup" >&2; exit 1; }
+  PRV=""
+done
+[ -n "$PRV" ] && kill -0 "$PRV" 2>/dev/null \
+  || { echo "ERROR: provider failed to start" >&2; kill "$MON" 2>/dev/null; exit 1; }
+
+# Exit if either dies so Docker's restart policy restarts the whole container.
+wait -n "$MON" "$PRV"
+echo "ERROR: monitor or provider exited; shutting down" >&2
+kill "$MON" "$PRV" 2>/dev/null || true
+exit 1

--- a/scripts/spin_up_subnet_a_from_container.sh
+++ b/scripts/spin_up_subnet_a_from_container.sh
@@ -183,6 +183,7 @@ if ! VALIDATOR1_OUTPUT=$(cargo-make make --makefile "$FENDERMINT_MAKEFILE_PATH" 
     --env TOPDOWN_PROPOSAL_DELAY=0 \
     --env FM_PULL_SKIP=1 \
     --env FM_LOG_LEVEL="info,fendermint=info,tower=warn,libp2p=warn,tendermint=warn" \
+    --env ETHAPI_LOG_LEVEL="info,fendermint=info,tower=warn,libp2p=warn,tendermint=warn" \
     child-validator 2>&1); then
     echo "Error: failed to start validator 1" >&2
     echo "$VALIDATOR1_OUTPUT" >&2
@@ -226,6 +227,7 @@ run_validator() {
         --env TOPDOWN_PROPOSAL_DELAY=0 \
         --env FM_PULL_SKIP=1 \
         --env FM_LOG_LEVEL="info,fendermint=info,tower=warn,libp2p=warn,tendermint=warn" \
+        --env ETHAPI_LOG_LEVEL="info,fendermint=info,tower=warn,libp2p=warn,tendermint=warn" \
         child-validator > "/root/.ipc/logs/spin-up-subnet-a-validator-${validator_num}.log" 2>&1
 
     # Verify containers are actually running (cargo-make can exit 0 despite failures)

--- a/scripts/spin_up_subnet_a_from_container.sh
+++ b/scripts/spin_up_subnet_a_from_container.sh
@@ -259,11 +259,12 @@ done
 
 echo "All validators have been started for subnet $SUBNET_ID!"
 
-# Start relayers for validators 1-4 (logs under /root/logs)
+# Start relayers for validators 1-4 (logs under /root/.ipc/logs).
+# Truncate the log on each spin-up so it only reflects the current subnet.
 mkdir -p /root/.ipc/logs
 echo "Starting relayers for validators 1-4..."
 for n in 1 2 3 4; do
-    RUST_LOG=debug nohup ipc-cli --config-path "/root/.ipc/validator${n}/config.toml" checkpoint relayer --subnet "$SUBNET_ID" >> "/root/.ipc/logs/relayer-subnet-a-validator${n}.log" 2>&1 &
+    RUST_LOG=debug nohup ipc-cli --config-path "/root/.ipc/validator${n}/config.toml" checkpoint relayer --subnet "$SUBNET_ID" > "/root/.ipc/logs/relayer-subnet-a-validator${n}.log" 2>&1 &
     echo "  Relayer for validator${n} started (log: /root/.ipc/logs/relayer-subnet-a-validator${n}.log)"
 done
 

--- a/scripts/spin_up_subnet_b_from_container.sh
+++ b/scripts/spin_up_subnet_b_from_container.sh
@@ -183,6 +183,7 @@ if ! VALIDATOR1_OUTPUT=$(cargo-make make --makefile "$FENDERMINT_MAKEFILE_PATH" 
     --env TOPDOWN_PROPOSAL_DELAY=0 \
     --env FM_PULL_SKIP=1 \
     --env FM_LOG_LEVEL="info,fendermint=info,tower=warn,libp2p=warn,tendermint=warn" \
+    --env ETHAPI_LOG_LEVEL="info,fendermint=info,tower=warn,libp2p=warn,tendermint=warn" \
     child-validator 2>&1); then
     echo "Error: failed to start validator 1" >&2
     echo "$VALIDATOR1_OUTPUT" >&2
@@ -226,6 +227,7 @@ run_validator() {
         --env TOPDOWN_PROPOSAL_DELAY=0 \
         --env FM_PULL_SKIP=1 \
         --env FM_LOG_LEVEL="info,fendermint=info,tower=warn,libp2p=warn,tendermint=warn" \
+        --env ETHAPI_LOG_LEVEL="info,fendermint=info,tower=warn,libp2p=warn,tendermint=warn" \
         child-validator > "/root/.ipc/logs/spin-up-subnet-b-validator-${validator_num}.log" 2>&1
 
     # Verify containers are actually running (cargo-make can exit 0 despite failures)

--- a/scripts/spin_up_subnet_b_from_container.sh
+++ b/scripts/spin_up_subnet_b_from_container.sh
@@ -259,11 +259,12 @@ done
 
 echo "All validators have been started for subnet $SUBNET_ID!"
 
-# Start relayers for validators 1-4 (logs under /root/.ipc/logs)
+# Start relayers for validators 1-4 (logs under /root/.ipc/logs).
+# Truncate the log on each spin-up so it only reflects the current subnet.
 mkdir -p /root/.ipc/logs
 echo "Starting relayers for validators 1-4..."
 for n in 1 2 3 4; do
-    RUST_LOG=debug nohup ipc-cli --config-path "/root/.ipc/validator${n}/config.toml" checkpoint relayer --subnet "$SUBNET_ID" >> "/root/.ipc/logs/relayer-subnet-b-validator${n}.log" 2>&1 &
+    RUST_LOG=debug nohup ipc-cli --config-path "/root/.ipc/validator${n}/config.toml" checkpoint relayer --subnet "$SUBNET_ID" > "/root/.ipc/logs/relayer-subnet-b-validator${n}.log" 2>&1 &
     echo "  Relayer for validator${n} started (log: /root/.ipc/logs/relayer-subnet-b-validator${n}.log)"
 done
 

--- a/src/bin/monitor.rs
+++ b/src/bin/monitor.rs
@@ -100,7 +100,8 @@ async fn main() {
         loop {
             let started = Instant::now();
             match monitor.sync_and_listen().await {
-                // Completed, or returned because of cancellation.
+                // sync_and_listen() expected to run until cancelled by the user
+                // or crashed due to unhandled error.
                 Ok(()) => return Ok(()),
                 Err(e) if is_retryable(&e) => {
                     if retry_cancel.is_cancelled() {
@@ -111,7 +112,12 @@ async fn main() {
                     if started.elapsed() > Duration::from_secs(60) {
                         backoff = Duration::from_secs(1);
                     }
-                    warn!("Monitor RPC error (ran {:?}), retrying in {:?}: {:?}", started.elapsed(), backoff, e);
+                    warn!(
+                        "A retriable error occured, retrying in {:?}. Error: {:?}. Ran {:?}.",
+                        backoff,
+                        e,
+                        started.elapsed()
+                    );
                     tokio::time::sleep(backoff).await;
                     backoff = (backoff * 2).min(max_backoff);
                 }

--- a/src/bin/monitor.rs
+++ b/src/bin/monitor.rs
@@ -9,7 +9,7 @@ use tokio::signal;
 use tokio::time::Duration;
 use tokio_util::sync::CancellationToken;
 
-use bitcoin::BlockHash;
+use bitcoin::{Block, BlockHash};
 use bitcoin_ipc::db::{self, DatabaseCore, HeedDb};
 use bitcoin_ipc::ipc_lib::{self, IpcLibError, IpcValidate, IpcValidateError};
 use bitcoin_ipc::{bitcoin_utils, eth_utils, IpcMessage, BTC_CONFIRMATIONS};
@@ -22,6 +22,11 @@ trait Database: DatabaseCore + DatabaseRewardExtensions {}
 impl<T: DatabaseCore + DatabaseRewardExtensions> Database for T {}
 
 const DEFAULT_POLL_INTERVAL: Duration = Duration::from_secs(2);
+
+/// Default blocks per batched fetch during cold sync; override with
+/// `MONITOR_SYNC_BATCH_SIZE`. Higher cuts round-trips but raises per-batch
+/// memory (≈ N × block size).
+const DEFAULT_SYNC_BATCH_SIZE: u64 = 100;
 
 #[derive(Parser, Debug)]
 #[command(author, version, about, long_about = None)]
@@ -78,10 +83,18 @@ async fn main() {
         .map(|s| Duration::from_secs(s.parse::<u64>().unwrap_or(DEFAULT_POLL_INTERVAL.as_secs())))
         .unwrap_or(DEFAULT_POLL_INTERVAL);
 
+    // Cold-sync batch size (number of blocks per batched RPC round-trip)
+    let sync_batch_size = std::env::var("MONITOR_SYNC_BATCH_SIZE")
+        .ok()
+        .and_then(|s| s.parse::<u64>().ok())
+        .filter(|&n| n > 0)
+        .unwrap_or(DEFAULT_SYNC_BATCH_SIZE);
+
     let mut monitor = Monitor::new(
         db,
         btc_rpc,
         btc_watchonly_rpc,
+        sync_batch_size,
         poll_interval,
         cancel_token.clone(),
     );
@@ -174,6 +187,7 @@ struct Monitor<D: Database> {
     db: D,
     rpc: bitcoincore_rpc::Client,
     watchonly_rpc: bitcoincore_rpc::Client,
+    sync_batch_size: u64,
     check_interval: Duration,
     current_height: u64,
     cancel_token: CancellationToken,
@@ -189,6 +203,7 @@ where
         db: D,
         rpc: bitcoincore_rpc::Client,
         watchonly_rpc: bitcoincore_rpc::Client,
+        sync_batch_size: u64,
         check_interval: Duration,
         cancel_token: CancellationToken,
     ) -> Self {
@@ -196,6 +211,7 @@ where
             db,
             rpc,
             watchonly_rpc,
+            sync_batch_size,
             check_interval,
             cancel_token,
             current_height: 0,
@@ -240,40 +256,52 @@ where
                 ));
             }
 
-            // Process blocks from current_height to latest_block_height
+            // Catch up in batched windows. current_height advances per
+            // block so a crash or cancellation mid-window resumes cleanly.
             while self.current_height < latest_block_height {
                 if self.cancel_token.is_cancelled() {
                     debug!("Cancellation requested, stopping sync");
                     return Ok(false);
                 }
 
-                let next_height = self.current_height + 1;
-                match self.process_block(next_height).await {
-                    Ok(_) => {
-                        info!("Processed block {}", next_height);
-                        self.current_height = next_height;
-                        if let Err(e) = self.db.set_last_processed_block(self.current_height) {
-                            error!("Failed to update last processed block: {:?}", e);
-                        }
-                    }
-                    Err(e) => {
-                        error!("Error processing block {}: {:?}.", next_height, e);
-                        // Retry logic can be added here if needed
+                let window_start = self.current_height + 1;
+                let window_end =
+                    (self.current_height + self.sync_batch_size).min(latest_block_height);
+
+                let blocks = bitcoin_utils::fetch_blocks_batched(
+                    self.rpc.get_jsonrpc_client(),
+                    window_start,
+                    window_end,
+                )?;
+
+                for (offset, (block_hash, block)) in blocks.into_iter().enumerate() {
+                    let height = window_start + offset as u64;
+                    if let Err(e) = self.process_block_data(height, block_hash, block).await {
+                        error!("Error processing block {}: {:?}.", height, e);
                         return Err(e);
                     }
-                }
+                    debug!("Processed block {}", height);
+                    self.current_height = height;
+                    if let Err(e) = self.db.set_last_processed_block(self.current_height) {
+                        error!("Failed to update last processed block: {:?}", e);
+                    }
 
-                // Reward bookkeeping hooks (must run after processing all tx in each block).
-
-                if let Some(ref mut reward_tracker) = self.reward_tracker {
-                    match reward_tracker.update_after_block(&self.db, next_height) {
-                        Ok(_) => {}
-                        Err(e) => error!(
-                            "Error updating reward bookkeeping after block {}: {:?}",
-                            next_height, e
-                        ),
+                    // Reward bookkeeping hooks (must run after processing all tx in each block).
+                    if let Some(ref mut reward_tracker) = self.reward_tracker {
+                        match reward_tracker.update_after_block(&self.db, height) {
+                            Ok(_) => {}
+                            Err(e) => error!(
+                                "Error updating reward bookkeeping after block {}: {:?}",
+                                height, e
+                            ),
+                        }
                     }
                 }
+
+                info!(
+                    "Synced blocks {}..={} (tip {})",
+                    window_start, window_end, latest_block_height
+                );
             }
 
             // Refetch the latest block height
@@ -471,7 +499,18 @@ where
         debug!("Processing block {}", block_height);
         let block_hash = self.rpc.get_block_hash(block_height)?;
         let block = self.rpc.get_block(&block_hash)?;
+        self.process_block_data(block_height, block_hash, block)
+            .await
+    }
 
+    /// Processes an already-fetched block. Shared by `process_block` (single
+    /// fetch) and the batched cold-sync path.
+    async fn process_block_data(
+        &mut self,
+        block_height: u64,
+        block_hash: BlockHash,
+        block: Block,
+    ) -> Result<(), MonitorError> {
         for tx in block.txdata {
             self.process_transaction(&tx, block_height, block_hash, block.header.time)
                 .await?;

--- a/src/bin/monitor.rs
+++ b/src/bin/monitor.rs
@@ -389,13 +389,45 @@ where
 
         if !import_addresses.is_empty() {
             // Import all addresses in a batch, each with its own timestamp
-            bitcoin_ipc::wallet::import_address_batch(&self.watchonly_rpc, &import_addresses)?;
+            match bitcoin_ipc::wallet::import_address_batch(&self.watchonly_rpc, &import_addresses)
+            {
+                Ok(_) => {
+                    debug!("Imported {} addresses in batch.", import_addresses.len());
+                    // Clear processed side effects
+                    self.side_effects.clear();
+                    return Ok(());
+                }
+                Err(e) => {
+                    // import_address_batch() may:
+                    // (1) time out (because importdescriptors may take minutes or hours:
+                    // https://bitcoincore.org/en/doc/27.0.0/rpc/wallet/importdescriptors/)
+                    // (2) Return error "Wallet is currently rescanning", if the import of
+                    // another address is still in progress.
+                    // For such not-fatal errors, we swallow the error here, log a warning, but do not
+                    // remove the address from side_effects and retry in the next cycle.
 
-            debug!("Imported {} addresses in batch.", import_addresses.len());
+                    // Case (1)
+                    if matches!(
+                        &e,
+                        bitcoincore_rpc::Error::JsonRpc(
+                            bitcoincore_rpc::jsonrpc::Error::Transport(_)
+                        )
+                    ) {
+                        warn!("Watch-only import RPC transport error (timeout or connection); will retry.");
+                        return Ok(());
+                    }
+                    // Case (2)
+                    if matches!(&e, bitcoincore_rpc::Error::JsonRpc(_))
+                        && e.to_string().to_lowercase().contains("rescanning")
+                    {
+                        warn!("Watch-only wallet is rescanning; will retry.");
+                        return Ok(());
+                    }
+                    return Err(e.into());
+                }
+            }
         }
 
-        // Clear processed side effects
-        self.side_effects.clear();
         Ok(())
     }
 

--- a/src/bin/monitor.rs
+++ b/src/bin/monitor.rs
@@ -1,8 +1,9 @@
 use std::env;
 use std::path::PathBuf;
+use std::time::Instant;
 
 use clap::Parser;
-use log::{debug, error, info, trace};
+use log::{debug, error, info, trace, warn};
 use thiserror::Error;
 use tokio::signal;
 use tokio::time::Duration;
@@ -88,9 +89,36 @@ async fn main() {
     #[cfg(feature = "emission_chain")]
     monitor.set_reward_tracker();
 
-    // Spawn monitor task
-
-    let monitor_handle = tokio::spawn(async move { monitor.sync_and_listen().await });
+    // Spawn monitor task. A transient bitcoind RPC failure (dropped/refused connection,
+    // bitcoind restarting) is retried with backoff instead of killing the process:
+    // sync() reloads the last processed block from the DB on re-entry, so this resumes
+    // rather than restarting. Non-RPC errors (DB, config) still propagate and exit.
+    let retry_cancel = cancel_token.clone();
+    let monitor_handle = tokio::spawn(async move {
+        let max_backoff = Duration::from_secs(30);
+        let mut backoff = Duration::from_secs(1);
+        loop {
+            let started = Instant::now();
+            match monitor.sync_and_listen().await {
+                // Completed, or returned because of cancellation.
+                Ok(()) => return Ok(()),
+                Err(e) if is_retryable(&e) => {
+                    if retry_cancel.is_cancelled() {
+                        return Ok(());
+                    }
+                    // Reset backoff after a healthy stretch so an isolated blip
+                    // recovers fast while a sustained outage backs off.
+                    if started.elapsed() > Duration::from_secs(60) {
+                        backoff = Duration::from_secs(1);
+                    }
+                    warn!("Monitor RPC error (ran {:?}), retrying in {:?}: {:?}", started.elapsed(), backoff, e);
+                    tokio::time::sleep(backoff).await;
+                    backoff = (backoff * 2).min(max_backoff);
+                }
+                Err(e) => return Err(e),
+            }
+        }
+    });
 
     // Listen for ctrl+c
 
@@ -116,6 +144,13 @@ async fn main() {
     }
 
     info!("Shutting down");
+}
+
+/// Transient errors worth retrying — the bitcoind RPC class (dropped/refused
+/// connection, bitcoind restarting, wallet mid-load). DB, config, and IPC errors
+/// are real and are not retried.
+fn is_retryable(e: &MonitorError) -> bool {
+    matches!(e, MonitorError::BitcoinRpcError(_))
 }
 
 /// Side-effects that need to be executed after processing blocks

--- a/src/bitcoin_utils.rs
+++ b/src/bitcoin_utils.rs
@@ -33,6 +33,11 @@ use crate::{
     WATCHONLY_WALLET_SUFFIX,
 };
 
+/// How long to wait between retries when bitcoind reports the wallet is mid-load.
+const WALLET_LOAD_RETRY_DELAY: std::time::Duration = std::time::Duration::from_millis(500);
+/// Maximum number of `load_wallet` attempts before giving up. 20 × 500 ms = 10 s,
+const WALLET_LOAD_MAX_RETRIES: u32 = 20;
+
 /// Returns the number of blocks to wait for before considering a
 /// confirmed in a given network.
 pub const fn confirmations(network: Network) -> u64 {
@@ -69,8 +74,11 @@ pub fn make_rpc_client_from_env() -> Client {
             panic!("Error making bitcoincore rpc client: {}", e);
         }
     };
-    // Ignore any errors by loadwallet, as the wallet may already be loaded
-    let _ = rpc.load_wallet(&wallet_name);
+    // The wallet named by WALLET_NAME is provisioned externally before the
+    // monitor/provider start (by the deployment's bitcoin setup); we only load
+    // it here. A wallet that won't load breaks every later RPC, so fail loud.
+    load_wallet(&rpc, &wallet_name)
+        .unwrap_or_else(|e| panic!("Error loading wallet {}: {}", wallet_name, e));
     rpc
 }
 
@@ -427,23 +435,44 @@ pub fn create_or_load_wallet(
         "Wallet '{}' already exists. Attempting to load it.",
         wallet_name
     );
-    let loaded = rpc.load_wallet(wallet_name);
+    load_wallet(rpc, wallet_name)
+}
 
-    match loaded {
-        Ok(_) => {
-            trace!("Loaded wallet '{}'", wallet_name);
-            Ok(())
-        }
-        Err(e) => {
-            if !e.to_string().contains("already loaded") {
-                error!("Error loading wallet '{}': {}", wallet_name, e);
-                Err(BitcoinUtilsError::BitcoinRpcError(e))
-            } else {
-                trace!("Wallet already loaded '{}'", wallet_name);
-                Ok(())
+/// Load a wallet that already exists, retrying if bitcoind reports it is mid-loading.
+/// bitcoind serialises wallet loads; if it is already mid-loading this wallet
+/// (e.g. it auto-reloaded on startup and our call raced it), it returns -4
+/// "Wallet already loading". Retry briefly before propagating — the load
+/// finishes within a couple of seconds in practice.
+pub fn load_wallet(rpc: &Client, wallet_name: &str) -> Result<(), BitcoinUtilsError> {
+    for attempt in 1..=WALLET_LOAD_MAX_RETRIES {
+        match rpc.load_wallet(wallet_name) {
+            Ok(_) => {
+                break;
+            }
+            Err(e) => {
+                let msg = e.to_string();
+
+                if msg.contains("already loaded") {
+                    break;
+                }
+
+                if attempt == WALLET_LOAD_MAX_RETRIES {
+                    error!("Error loading wallet '{}': {}", wallet_name, e);
+                    return Err(BitcoinUtilsError::BitcoinRpcError(e));
+                }
+
+                if msg.contains("already loading") {
+                    debug!(
+                        "bitcoind is mid-loading wallet '{}', retry {}/{}",
+                        wallet_name, attempt, WALLET_LOAD_MAX_RETRIES,
+                    );
+                }
+                std::thread::sleep(WALLET_LOAD_RETRY_DELAY);
             }
         }
     }
+    trace!("Loaded wallet '{}'", wallet_name);
+    Ok(())
 }
 
 pub fn convert_bytes_to_push_bytes(data: &[u8]) -> &PushBytes {

--- a/src/bitcoin_utils.rs
+++ b/src/bitcoin_utils.rs
@@ -22,7 +22,7 @@ use bitcoin::{
     script::{Instruction, PushBytes},
     secp256k1::Secp256k1,
     taproot::{LeafVersion, TaprootBuilder},
-    Address, Amount, FeeRate, Network, ScriptBuf, Weight, XOnlyPublicKey,
+    Address, Amount, Block, BlockHash, FeeRate, Network, ScriptBuf, Weight, XOnlyPublicKey,
 };
 
 use bitcoincore_rpc::json::{EstimateMode, EstimateSmartFeeResult};
@@ -113,6 +113,62 @@ pub fn init_rpc_client(
     let full_url = format!("{}/wallet/{}", rpc_url.trim_end_matches('/'), wallet_name);
     let rpc = Client::new(&full_url, Auth::UserPass(rpc_user, rpc_pass))?;
     Ok(rpc)
+}
+
+/// Fetches blocks for the inclusive height range `[start, end]` in two batched
+/// round-trips (hashes, then verbosity-0 blocks) rather than two per block,
+/// returned in ascending-height order with their hash. `client` is a node-level
+/// JSON-RPC client, e.g. `bitcoincore_rpc::Client::get_jsonrpc_client`.
+pub fn fetch_blocks_batched(
+    client: &bitcoincore_rpc::jsonrpc::Client,
+    start: u64,
+    end: u64,
+) -> Result<Vec<(BlockHash, Block)>, bitcoincore_rpc::Error> {
+    use bitcoincore_rpc::jsonrpc;
+    use bitcoincore_rpc::Error;
+
+    // 1) Resolve every height in the window to a hash in a single batched request.
+    let hash_params: Vec<_> = (start..=end).map(|h| jsonrpc::arg([h])).collect();
+    let hash_reqs: Vec<_> = hash_params
+        .iter()
+        .map(|p| client.build_request("getblockhash", Some(&**p)))
+        .collect();
+    let hashes: Vec<BlockHash> = client
+        .send_batch(&hash_reqs)?
+        .into_iter()
+        .enumerate()
+        .map(|(i, r)| {
+            r.ok_or_else(|| {
+                Error::ReturnedError(format!(
+                    "missing getblockhash response for height {}",
+                    start + i as u64
+                ))
+            })?
+            .result::<BlockHash>()
+            .map_err(Error::from)
+        })
+        .collect::<Result<_, _>>()?;
+
+    // 2) Fetch each block as raw hex (verbosity 0) in a single batched request.
+    let block_params: Vec<_> = hashes.iter().map(|h| jsonrpc::arg((h, 0))).collect();
+    let block_reqs: Vec<_> = block_params
+        .iter()
+        .map(|p| client.build_request("getblock", Some(&**p)))
+        .collect();
+    let block_resps = client.send_batch(&block_reqs)?;
+
+    let mut blocks = Vec::with_capacity(hashes.len());
+    for (i, r) in block_resps.into_iter().enumerate() {
+        let hex = r
+            .ok_or_else(|| {
+                Error::ReturnedError(format!("missing getblock response for {}", hashes[i]))
+            })?
+            .result::<String>()?;
+        let block: Block = bitcoin::consensus::encode::deserialize_hex(&hex)?;
+        blocks.push((hashes[i], block));
+    }
+
+    Ok(blocks)
 }
 
 /// Returns a provably unspendable internal key

--- a/src/multisig.rs
+++ b/src/multisig.rs
@@ -178,7 +178,7 @@ pub fn multisig_spend_max_witness_size(public_keys: &[WeightedKey], threshold: P
 	    // varint for the number of witnesses, which is a signature for each committee member + script + control block
 	    bitcoin::VarInt::from(committee_size + 2).size()
 	    // each schnorr sig
-        + VarInt::from(bitcoin::key::constants::SCHNORR_SIGNATURE_SIZE).size() * threshold as usize
+        + VarInt::from(bitcoin::key::constants::SCHNORR_SIGNATURE_SIZE).size() * committee_size
         // script size
         + VarInt::from(script_size).size()
         // control block size

--- a/src/multisig.rs
+++ b/src/multisig.rs
@@ -660,7 +660,7 @@ pub fn finalize_spend_psbt_from_sigs(
     secp: &Secp256k1<All>,
     subnet_id: &SubnetId,
     committee_keys: &[WeightedKey],
-    committee_threshold: u32,
+    committee_threshold: Power,
     psbt: &bitcoin::Psbt,
     signature_sets: &[&[bitcoin::secp256k1::schnorr::Signature]],
 ) -> Result<Transaction, MultisigError> {

--- a/src/provider/rpc.rs
+++ b/src/provider/rpc.rs
@@ -277,6 +277,54 @@ pub async fn get_subnet(
 }
 
 #[derive(Serialize, Deserialize)]
+pub struct GetSubnetBalanceResponse {
+    /// Address of the subnet's current committee multisig. Useful for callers
+    /// that want to top up (refund) the multisig.
+    pub multisig_address: String,
+    pub balance_sats: u64,
+    pub utxo_count: usize,
+}
+
+/// Returns the on-chain balance of the subnet — i.e. the sats held by the
+/// current committee multisig, summed across all unspent outputs the watch-only
+/// wallet tracks for it. The monitor auto-imports the multisig on CREATE /
+/// handover, so no setup needed.
+pub async fn get_subnet_balance(
+    data: Data<Arc<ServerData>>,
+    Params(params): Params<GetSubnetParams>,
+) -> Result<GetSubnetBalanceResponse, JsonRpcError> {
+    info!("getsubnetbalance: {}", params.subnet_id);
+
+    let subnet_state = data
+        .db
+        .get_subnet_state(params.subnet_id)
+        .map_err(|e| {
+            error!("Error getting subnet state from Db: {}", e);
+            RpcError::DbError(e)
+        })?
+        .ok_or_else(|| {
+            error!("Subnet {} not found.", params.subnet_id);
+            RpcError::InvalidParams(format!("Subnet {} not found.", params.subnet_id))
+        })?;
+
+    let multisig_address = subnet_state.multisig_address();
+
+    let unspent = wallet::get_unspent_for_address(&data.btc_watchonly_rpc, &multisig_address)
+        .map_err(|e| {
+            error!("Error listing unspent for multisig {}: {}", multisig_address, e);
+            RpcError::InternalError(e.to_string())
+        })?;
+
+    let balance_sats: u64 = unspent.iter().map(|u| u.amount.to_sat()).sum();
+
+    Ok(GetSubnetBalanceResponse {
+        multisig_address: multisig_address.to_string(),
+        balance_sats,
+        utxo_count: unspent.len(),
+    })
+}
+
+#[derive(Serialize, Deserialize)]
 pub struct PrefundSubnetResponse {
     prefund_txid: bitcoin::Txid,
 }
@@ -2091,6 +2139,7 @@ pub fn make_rpc_server(server_data: Arc<ServerData>) -> RpcServer {
         .with_method("createsubnet", create_subnet)
         .with_method("joinsubnet", join_subnet)
         .with_method("getsubnet", get_subnet)
+        .with_method("getsubnetbalance", get_subnet_balance)
         .with_method("getgenesisinfo", get_genesis_info)
         .with_method("prefundsubnet", prefund_subnet)
         .with_method("fundsubnet", fund_subnet)


### PR DESCRIPTION
## Monitor resilience, checkpoint sizing fix, a new balance RPC, and the BSL client image build pipeline.

**Changes**
- **Monitor resilience** — retry after Bitcoin RPC errors instead of dying; stop surfacing all errors in `process_side_effects` (swallow retryable transient errors with a clearer warn); don't panic when bitcoind reports the wallet as still loading — panic only if it genuinely fails to load (`monitor.rs`, `bitcoin_utils.rs`).
- **Faster cold sync** — IMP25: batch block fetching to speed up monitor sync.
- **Checkpoint tx-size fix** — correct the size estimation bug that inflated estimated weight by an additive `2/3 * 100000` term (threshold was weight-expressed); declare `committee_threshold` as `Power` instead of `u32`.
- **New RPC** — add `get_subnet_balance` endpoint (`provider/rpc.rs`).
- **BSL client image** — GitHub Action + `docker-build-client/` (Dockerfile, entrypoint, README) to build the BSL client image.
- **Logging** — quieter ethapi container; wipe previous relayer logs on start; `.env.example` additions.