### PR TITLE
Fix error in bsl-client image: Use the "bitcoin" branch of the ipc repo.

### DIFF
--- a/.github/workflows/bsl-client-image.yml
+++ b/.github/workflows/bsl-client-image.yml
@@ -1,8 +1,9 @@
 # Builds the public BSL client image and pushes it to GHCR.
 #
-# ipc-cli's Rust bindings are generated from the compiled Solidity ABIs, so the
-# `contracts` job compiles them once (Foundry + pnpm) and shares contracts/out as
-# an artifact. The `build` matrix then builds docker-build-client/Dockerfile on
+# ipc-cli is built from the ipc repo's `bitcoin` branch. Its Rust bindings are generated from
+# the compiled Solidity ABIs, so the `contracts` job compiles them once (Foundry +
+# pnpm) and shares contracts/out as an artifact. The `build` matrix then builds
+# docker-build-client/Dockerfile on
 # native runners (amd64 on ubuntu-latest, arm64 on ubuntu-24.04-arm), each pushing
 # its arch by digest; the `merge` job assembles the :testnet manifest list.
 name: bsl-client image
@@ -27,11 +28,11 @@ jobs:
   contracts:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout ipc (with submodules)
+      - name: Checkout ipc (BSL bitcoin branch, with submodules)
         uses: actions/checkout@v4
         with:
           repository: bitcoinscalinglabs/ipc
-          ref: main
+          ref: bitcoin
           path: ipc
           submodules: recursive
 
@@ -85,11 +86,11 @@ jobs:
         with:
           path: bitcoin-ipc
 
-      - name: Checkout ipc (public, main)
+      - name: Checkout ipc (BSL bitcoin branch)
         uses: actions/checkout@v4
         with:
           repository: bitcoinscalinglabs/ipc
-          ref: main
+          ref: bitcoin
           path: ipc
 
       - name: Restore contract ABIs

--- a/docker-build-client/entrypoint.sh
+++ b/docker-build-client/entrypoint.sh
@@ -20,7 +20,8 @@ fi
 : "${DATABASE_URL:=/var/lib/bsl/db}"
 : "${MONITOR_SYNC_BATCH_SIZE:=1000}"
 : "${SUBNET_ID:=/b4}"
-: "${RUST_LOG:=bitcoin_ipc=info,monitor=info,provider=info,bitcoincore_rpc=error}"
+
+: "${RUST_LOG:=error,bitcoin_ipc=info,monitor=info,provider=info}"
 TUNNEL_KEY="${TUNNEL_KEY:-/run/tunnel_key}"
 LOCAL_RPC_PORT=18443
 RPC_URL="http://127.0.0.1:${LOCAL_RPC_PORT}"


### PR DESCRIPTION
Fix bsl-client image build workflow. Previous version was compiling the wrong branch of the ipc repo.