### PR TITLE
Fixes from testnet experiments

### DIFF
--- a/src/bin/monitor.rs
+++ b/src/bin/monitor.rs
@@ -416,11 +416,37 @@ where
             .collect();
 
         if !import_addresses.is_empty() {
-            // Import all addresses in a batch, each with its own timestamp
-            match bitcoin_ipc::wallet::import_address_batch(&self.watchonly_rpc, &import_addresses)
-            {
+            // Drop addresses whose descriptor is already registered in the watch-only wallet.
+            //
+            // `importdescriptors` adds the descriptor immediately (the address becomes `ismine`
+            // and carries its label) and only then rescans historical blocks for its UTXOs in the
+            // background. That rescan is slow and its RPC call routinely times out or returns
+            // "wallet is rescanning" (handled below). Without this filter we would re-issue
+            // `importdescriptors` on every poll cycle until we observe an `Ok` — but each call
+            // contends the wallet lock and starves the running rescan, so the rescan never
+            // finishes, the `Ok` never comes, and we loop forever (fleet-wide, one bitcoind).
+            // Recognizing "already registered" lets us stop after the first attempt and let the
+            // background rescan complete undisturbed.
+            let pending: Vec<(bitcoin::Address, String, u32)> = import_addresses
+                .into_iter()
+                .filter(|(address, _, _)| {
+                    // On a query error, assume not-imported and let the import below run — it is
+                    // idempotent and its errors are swallowed, so this never gets stuck.
+                    !bitcoin_ipc::wallet::is_address_imported(&self.watchonly_rpc, address)
+                        .unwrap_or(false)
+                })
+                .collect();
+
+            if pending.is_empty() {
+                // Every queued address is registered (its background rescan finishes on its own).
+                self.side_effects.clear();
+                return Ok(());
+            }
+
+            // Import the not-yet-registered addresses in a batch, each with its own timestamp.
+            match bitcoin_ipc::wallet::import_address_batch(&self.watchonly_rpc, &pending) {
                 Ok(_) => {
-                    debug!("Imported {} addresses in batch.", import_addresses.len());
+                    debug!("Imported {} addresses in batch.", pending.len());
                     // Clear processed side effects
                     self.side_effects.clear();
                     return Ok(());
@@ -431,8 +457,9 @@ where
                     // https://bitcoincore.org/en/doc/27.0.0/rpc/wallet/importdescriptors/)
                     // (2) Return error "Wallet is currently rescanning", if the import of
                     // another address is still in progress.
-                    // For such not-fatal errors, we swallow the error here, log a warning, but do not
-                    // remove the address from side_effects and retry in the next cycle.
+                    // In both cases the descriptor is (or will be) registered, so we swallow the
+                    // error, keep the side effects, and re-check next cycle — where the filter
+                    // above sees it registered and clears it, WITHOUT re-issuing importdescriptors.
 
                     // Case (1)
                     if matches!(
@@ -441,14 +468,14 @@ where
                             bitcoincore_rpc::jsonrpc::Error::Transport(_)
                         )
                     ) {
-                        warn!("Watch-only import RPC transport error (timeout or connection); will retry.");
+                        warn!("Watch-only import RPC transport error (timeout or connection); descriptor added, rescan continues in background.");
                         return Ok(());
                     }
                     // Case (2)
                     if matches!(&e, bitcoincore_rpc::Error::JsonRpc(_))
                         && e.to_string().to_lowercase().contains("rescanning")
                     {
-                        warn!("Watch-only wallet is rescanning; will retry.");
+                        warn!("Watch-only wallet is rescanning; descriptor added, will confirm next cycle.");
                         return Ok(());
                     }
                     return Err(e.into());

--- a/src/ipc_lib.rs
+++ b/src/ipc_lib.rs
@@ -2087,6 +2087,7 @@ impl IpcCheckpointSubnetMsg {
             exhaust_unspent,
             &tx_outs,
             &fee_rate,
+            multisig::CHECKPOINT_CONSOLIDATION_LIMIT,
         )?;
 
         // dbg!(&checkpoint_tx);
@@ -2156,6 +2157,7 @@ impl IpcCheckpointSubnetMsg {
                     exhaust_unspent,
                     &tx_outs,
                     &fee_rate,
+                    multisig::CHECKPOINT_CONSOLIDATION_LIMIT,
                 )?;
             }
         }
@@ -2171,6 +2173,7 @@ impl IpcCheckpointSubnetMsg {
             exhaust_unspent,
             &tx_outs,
             &fee_rate,
+            multisig::CHECKPOINT_CONSOLIDATION_LIMIT,
         )?;
 
         debug!("Checkpoint TX: {checkpoint_tx:?}");

--- a/src/multisig.rs
+++ b/src/multisig.rs
@@ -127,6 +127,15 @@ pub fn multisig_threshold(total_power: Power) -> Power {
 pub const POWER_SCALE_FACTOR: u64 = 10_000;
 pub const MAX_POWER: u64 = u32::MAX as u64;
 
+/// How many extra (smallest) committee UTXOs a checkpoint folds in beyond what
+/// coin-selection needs. Data-carrying checkpoints leak a small commit-reveal
+/// "reveal" UTXO each time; greedy largest-first selection never spends them, so
+/// they accumulate until a committee rotation must sweep them all at once (which
+/// then produces an oversized, unbroadcastable transaction). Sweeping a bounded
+/// number per checkpoint keeps the committee UTXO set small and drains any backlog
+/// gradually. The cap keeps a single checkpoint from growing too large.
+pub const CHECKPOINT_CONSOLIDATION_LIMIT: usize = 50;
+
 /// Converts a Bitcoin Amount to a power/weight value (u32) using a fixed scale factor.
 /// Discards small satoshi values based on the provided minimum amount.
 //
@@ -199,6 +208,9 @@ pub fn select_coins(
     base_tx_weight: Weight,
     satisfaction_weight_per_input: Weight,
     change_address: &Address,
+    // Fold in up to this many of the smallest leftover UTXOs beyond what is needed to
+    // cover the target, to drain accumulated dust. Pass 0 for plain coin-selection.
+    consolidation_limit: usize,
 ) -> Result<
     (
         // The list of selected UTXOs
@@ -209,7 +221,7 @@ pub fn select_coins(
     MultisigError,
 > {
     let mut utxos = utxos.to_vec();
-    // Sort UTXOs deterministically by amount, txid and vout
+    // Sort UTXOs deterministically by amount, txid and vout — largest first.
     utxos.sort_by(|a, b| {
         b.amount
             .cmp(&a.amount)
@@ -229,10 +241,10 @@ pub fn select_coins(
     let mut total_amount = Amount::ZERO;
     let mut total_weight = base_tx_weight;
 
-    for utxo in utxos {
-        // Append the utxo
+    // Phase 1: greedily take the largest UTXOs until the target plus fee is covered.
+    let mut covered_index = None;
+    for (index, utxo) in utxos.iter().enumerate() {
         selected.push(utxo.clone());
-
         total_amount += utxo.amount;
         total_weight += satisfaction_weight_per_input;
 
@@ -241,33 +253,75 @@ pub fn select_coins(
             .expect("fee rate shouldn't overflow");
 
         if total_amount >= target + total_fee {
-            let change = total_amount - target - total_fee;
-            trace!(
-                "Selected coins for target amount {}. Total amount: {}, total fee: {}, change: {}",
-                target,
-                total_amount,
-                total_fee,
-                change
-            );
-
-            // if change is non-dust, return it
-            if change > non_dust_change_tx_out.value {
-                let change_tx_out = bitcoin::TxOut {
-                    value: change,
-                    script_pubkey: change_address.script_pubkey(),
-                };
-                return Ok((selected, Some(change_tx_out)));
-            } else {
-                return Ok((selected, None));
-            }
+            covered_index = Some(index);
+            break;
         }
     }
 
-    Err(MultisigError::CoinSelectionFailed(
+    let covered_index = covered_index.ok_or(MultisigError::CoinSelectionFailed(
         "Insufficient funds".to_string(),
-    ))
+    ))?;
+
+    // Phase 2: consolidation. Fold in up to `consolidation_limit` of the smallest
+    // remaining UTXOs (the tail of the largest-first order), so leaked commit-reveal
+    // dust does not accumulate. Their value flows into the change output. This is
+    // best-effort: an input is only swept while the change stays above dust, so
+    // consolidation can never turn a spendable set into an unbuildable transaction.
+    // `consolidation_limit == 0` makes this a no-op and leaves behaviour unchanged.
+    for utxo in utxos[covered_index + 1..]
+        .iter()
+        .rev()
+        .take(consolidation_limit)
+    {
+        let next_weight = total_weight + satisfaction_weight_per_input;
+        let next_amount = total_amount + utxo.amount;
+        let next_fee = fee_rate
+            .fee_wu(next_weight)
+            .expect("fee rate shouldn't overflow");
+        // Only sweep if change would still cover the dust threshold afterwards.
+        if next_amount < target + next_fee + non_dust_change_tx_out.value {
+            break;
+        }
+        selected.push(utxo.clone());
+        total_amount = next_amount;
+        total_weight = next_weight;
+    }
+
+    // Phase 3: compute the final fee and change over the full selected set.
+    let total_fee = fee_rate
+        .fee_wu(total_weight)
+        .expect("fee rate shouldn't overflow");
+    let change = total_amount
+        .checked_sub(target)
+        .and_then(|remainder| remainder.checked_sub(total_fee))
+        .ok_or(MultisigError::CoinSelectionFailed(
+            "Insufficient funds to cover outputs and fees".to_string(),
+        ))?;
+
+    trace!(
+        "Selected {} coins for target {}. Total: {}, fee: {}, change: {}",
+        selected.len(),
+        target,
+        total_amount,
+        total_fee,
+        change
+    );
+
+    // If change is non-dust, include it; otherwise it becomes extra fee.
+    if change > non_dust_change_tx_out.value {
+        Ok((
+            selected,
+            Some(TxOut {
+                value: change,
+                script_pubkey: change_address.script_pubkey(),
+            }),
+        ))
+    } else {
+        Ok((selected, None))
+    }
 }
 
+#[allow(clippy::too_many_arguments)]
 pub fn construct_spend_unsigned_transaction(
     committee_keys: &[WeightedKey],
     threshold: Power,
@@ -276,6 +330,8 @@ pub fn construct_spend_unsigned_transaction(
     exhaust_unspent: bool,
     tx_outs: &[TxOut],
     fee_rate: &FeeRate,
+    // Extra small UTXOs to sweep in the coin-selection path (ignored when exhausting).
+    consolidation_limit: usize,
 ) -> Result<Transaction, MultisigError> {
     trace!("Creating multisig spend tx for tx_outs={:?}", &tx_outs);
 
@@ -417,6 +473,7 @@ pub fn construct_spend_unsigned_transaction(
             base_tx_weight,
             spending_weight_per_input,
             committee_change_address,
+            consolidation_limit,
         )?;
 
         let inputs = selected_utxos
@@ -458,6 +515,8 @@ pub fn construct_spend_psbt(
     exhaust_unspent: bool,
     tx_outs: &[TxOut],
     fee_rate: &FeeRate,
+    // Extra small UTXOs to sweep in the coin-selection path (ignored when exhausting).
+    consolidation_limit: usize,
 ) -> Result<bitcoin::Psbt, MultisigError> {
     trace!("Creating multisig spend PSBT for tx_outs={:?}", &tx_outs);
 
@@ -470,6 +529,7 @@ pub fn construct_spend_psbt(
         exhaust_unspent,
         tx_outs,
         fee_rate,
+        consolidation_limit,
     )?;
 
     // Create the PSBT from the unsigned transaction
@@ -1304,12 +1364,78 @@ mod coin_selection_tests {
             base_weight,
             input_weight,
             &change_address,
+            0,
         )
         .unwrap();
 
         assert_eq!(selected.len(), 2);
         assert!(change.is_some());
         assert_eq!(change.unwrap().value, Amount::from_sat(450));
+    }
+
+    #[test]
+    fn test_consolidation_sweeps_dust() {
+        // One large UTXO that alone covers the target, plus dust UTXOs that greedy
+        // largest-first selection would never touch (distinct by vout).
+        let target = Amount::from_sat(1000);
+        let large_txid = "d7f3553b9631f48a2842a2cb6e0f2b6e344bf82d3ee78295a5361adc17b838b1";
+        let dust_txid = "7224e1f11ddc838100abd123d23af0d02493001fdd746685dc539fe062b45e3e";
+        let mut utxos = vec![create_test_utxo(100_000, large_txid, 0)];
+        for vout in 0..5u32 {
+            utxos.push(create_test_utxo(330, dust_txid, vout));
+        }
+
+        let fee_rate = FeeRate::from_sat_per_vb(1).expect("works");
+        let base_weight = Weight::from_wu(100);
+        let input_weight = Weight::from_wu(50);
+        let change_address = Address::from_str("bcrt1qw508d6qejxtdg4y5r3zarvary0c5xw7kygt080")
+            .unwrap()
+            .assume_checked();
+
+        // Limit 0: unchanged behaviour — greedy selection takes only the large UTXO.
+        let (selected, _) = select_coins(
+            target,
+            &utxos,
+            fee_rate,
+            base_weight,
+            input_weight,
+            &change_address,
+            0,
+        )
+        .unwrap();
+        assert_eq!(selected.len(), 1);
+        assert_eq!(selected[0].amount, Amount::from_sat(100_000));
+
+        // Limit 3: additionally folds in the 3 smallest dust UTXOs, value into change.
+        let (selected, change) = select_coins(
+            target,
+            &utxos,
+            fee_rate,
+            base_weight,
+            input_weight,
+            &change_address,
+            3,
+        )
+        .unwrap();
+        assert_eq!(selected.len(), 4);
+        assert_eq!(selected[0].amount, Amount::from_sat(100_000));
+        assert!(selected[1..]
+            .iter()
+            .all(|u| u.amount == Amount::from_sat(330)));
+        assert!(change.is_some());
+
+        // Limit exceeding the available dust sweeps them all without overshooting.
+        let (selected, _) = select_coins(
+            target,
+            &utxos,
+            fee_rate,
+            base_weight,
+            input_weight,
+            &change_address,
+            100,
+        )
+        .unwrap();
+        assert_eq!(selected.len(), 6); // large + all 5 dust
     }
 
     #[test]
@@ -1334,6 +1460,7 @@ mod coin_selection_tests {
             base_weight,
             input_weight,
             &change_address,
+            0,
         )
         .unwrap();
 
@@ -1370,6 +1497,7 @@ mod coin_selection_tests {
             base_weight,
             input_weight,
             &change_address,
+            0,
         );
 
         assert!(result.is_err());
@@ -1413,6 +1541,7 @@ mod coin_selection_tests {
             base_weight,
             input_weight,
             &change_address,
+            0,
         )
         .unwrap();
 
@@ -1444,6 +1573,7 @@ mod coin_selection_tests {
             base_weight,
             input_weight,
             &change_address,
+            0,
         );
 
         assert!(result.is_err());
@@ -1487,6 +1617,7 @@ mod coin_selection_tests {
             base_weight,
             input_weight,
             &change_address,
+            0,
         )
         .unwrap();
 
@@ -1591,6 +1722,7 @@ mod psbt_tests {
                 script_pubkey: destination.script_pubkey(),
             }],
             &fee_rate,
+            0,
         )
         .unwrap();
 
@@ -1746,6 +1878,7 @@ mod psbt_tests {
             false,
             &[tx_out],
             &fee_rate,
+            0,
         )
         .unwrap();
 
@@ -1937,6 +2070,7 @@ mod psbt_tests {
             false,
             &[tx_out],
             &fee_rate,
+            0,
         )
         .unwrap();
 
@@ -2415,6 +2549,7 @@ mod exhaust_unspent_tests {
             false, // don't exhaust
             &[tx_out.clone()],
             &fee_rate,
+            0,
         )
         .unwrap();
 
@@ -2435,6 +2570,7 @@ mod exhaust_unspent_tests {
             true, // exhaust all UTXOs
             &[tx_out.clone()],
             &fee_rate,
+            0,
         )
         .unwrap();
 
@@ -2503,6 +2639,7 @@ mod exhaust_unspent_tests {
             true, // exhaust all UTXOs
             &[tx_out, tx_out2],
             &fee_rate,
+            0,
         )
         .unwrap();
 

--- a/src/provider/rpc.rs
+++ b/src/provider/rpc.rs
@@ -604,6 +604,7 @@ pub async fn gen_multisig_spend_psbt(
             script_pubkey: recipient.script_pubkey(),
         }],
         &fee_rate,
+        0,
     )
     .map_err(|e| {
         error!(
@@ -782,6 +783,7 @@ pub async fn gen_bootstrap_handover(
         true,
         &[],
         &fee_rate,
+        0,
     )
     .map_err(|e| {
         error!(

--- a/src/wallet.rs
+++ b/src/wallet.rs
@@ -190,6 +190,25 @@ pub fn import_address_batch(
     rpc.call("importdescriptors", &args)
 }
 
+/// Returns true if the address's descriptor is already registered in the (watch-only) wallet,
+/// regardless of whether its follow-up rescan has finished.
+///
+/// `importdescriptors` adds the descriptor immediately — the address becomes `ismine` and carries
+/// its label — and only then rescans historical blocks for its UTXOs in the background. That rescan
+/// can be slow (its RPC call may time out or report "wallet is rescanning"), but the registration
+/// itself is already done, so `getaddressinfo` returns the label/`ismine` even while the rescan is
+/// still in progress. Callers use this to avoid re-issuing `importdescriptors` for an address that
+/// is already registered (which would only contend the wallet lock and starve the running rescan).
+pub fn is_address_imported(
+    rpc: &Client,
+    address: &bitcoin::Address,
+) -> Result<bool, bitcoincore_rpc::Error> {
+    let info = rpc.get_address_info(address)?;
+    Ok(info.is_mine.unwrap_or(false)
+        || info.is_watchonly.unwrap_or(false)
+        || !info.labels.is_empty())
+}
+
 #[derive(Error, Debug)]
 pub enum WalletError {
     #[error(transparent)]


### PR DESCRIPTION
- BUG15: Too many small UTXOs & Consolidatation: after IPC-BTC become bridgeable, we realized  that checkpoints that carry data create 1 new UTXO each time, which over time accumulates.
- Do not re-import wallet descriptors on every loop. This complements a previous commit: 94cbde10 "Do not surface all errors in process_side_effect"